### PR TITLE
Document Pulumi HCL host compatibility

### DIFF
--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -1,62 +1,112 @@
 # Terraform HCL Compatibility
 
-Pulumi HCL allows you to write infrastructure as code using Terraform-compatible HCL syntax while leveraging the Pulumi engine for state management, secrets, and deployments. This document describes the compatibility between Pulumi HCL and Terraform HCL, including known differences and current limitations.
-
-## Overview
-
-Pulumi HCL parses standard HCL files and translates them to Pulumi resource registrations at runtime. While most Terraform HCL syntax is supported, there are important behavioral differences due to the underlying Pulumi engine.
+Pulumi HCL allows you to write infrastructure as code using Terraform-compatible HCL syntax while leveraging the Pulumi engine for state management, secrets, and deployments.
 
 **Goal**: Maximum compatibility with Terraform HCL syntax with no gratuitous differences.
 
-**Reality**: Some differences are unavoidable due to fundamental architectural differences between Pulumi and Terraform.
+This document focuses on **language and semantic differences**—cases where valid HCL code may behave differently than in Terraform. Platform-level differences (state management, CLI commands, etc.) are expected when adopting any new IaC tool and are summarized briefly at the end.
 
-## Supported Features
+## Supported HCL Syntax
 
-The following Terraform HCL constructs are fully supported:
+The following Terraform HCL constructs are fully supported with identical behavior:
 
 | Feature | Support | Notes |
 |---------|---------|-------|
 | `resource` blocks | Full | Including all meta-arguments |
 | `data` source blocks | Full | Invoked via Pulumi functions |
-| `variable` blocks | Full | Type constraints, defaults, nullable, sensitive, validation |
+| `variable` blocks | Full | Type constraints, defaults, nullable, sensitive |
 | `locals` blocks | Full | Expression interpolation supported |
-| `output` blocks | Full | value, description, sensitive, depends_on, preconditions |
+| `output` blocks | Full | value, description, sensitive, depends_on |
 | `provider` blocks | Full | Including alias support |
 | `terraform.required_providers` | Full | Provider version constraints |
 | `count` meta-argument | Full | Index expansion with `count.index` |
 | `for_each` meta-argument | Full | Key expansion with `each.key`, `each.value` |
 | `depends_on` | Full | Explicit dependencies |
-| `lifecycle` block | Partial | See [Lifecycle Differences](#lifecycle-block-differences) |
 | Built-in functions | 80+ | Most Terraform functions supported |
 | Splat expressions | Full | `resource.name[*].attr` |
 | String interpolation | Full | `"${var.name}-suffix"` |
 | Complex types | Full | Lists, maps, sets, objects, tuples |
+| Resource references | Full | `aws_instance.web.id`, `data.aws_ami.ubuntu.id` |
 
-## Fundamental Differences
+## Language and Semantic Differences
 
-These differences arise from architectural distinctions between Pulumi and Terraform and represent permanent behavioral variations.
+These are cases where valid HCL syntax is interpreted differently by Pulumi HCL. Understanding these differences is important when migrating existing configurations.
 
-### State Management
+### Lifecycle Block Behavior
 
-| Aspect | Terraform | Pulumi HCL |
-|--------|-----------|------------|
-| State storage | Local files, S3, Terraform Cloud, etc. | Pulumi Cloud or self-managed backends |
-| State format | Terraform state JSON | Pulumi checkpoint format |
-| State migration | `terraform state` commands | `pulumi state` commands |
+The `lifecycle` block is parsed, but some options have different semantics:
 
-**Impact**: Existing Terraform state files cannot be directly imported. Resources must be imported using `pulumi import` or recreated.
+| Lifecycle Option | Terraform Behavior | Pulumi HCL Behavior |
+|------------------|-------------------|---------------------|
+| `prevent_destroy` | Prevents `terraform destroy` from removing the resource | Maps to Pulumi's `protect` option (similar effect) |
+| `create_before_destroy` | Creates replacement before destroying original | Parsed but not enforced; Pulumi determines replacement ordering |
+| `ignore_changes` | Ignores specified attribute changes during updates | Supported via Pulumi's `ignoreChanges` resource option |
+| `replace_triggered_by` | Forces replacement when referenced resources change | Parsed but has no effect |
+| `precondition` / `postcondition` | Validates conditions before/after apply | Parsed but not enforced |
 
-The following Terraform blocks are parsed but have no effect:
+**Example**:
+```hcl
+resource "aws_instance" "web" {
+  # ...
+
+  lifecycle {
+    prevent_destroy = true        # Works - maps to Pulumi protect
+    ignore_changes  = [tags]      # Works - maps to ignoreChanges
+    create_before_destroy = true  # Parsed but Pulumi controls ordering
+  }
+}
+```
+
+### Provider Source Names
+
+Provider sources use the `pulumi/` namespace rather than `hashicorp/`:
 
 ```hcl
 terraform {
-  # Ignored - Pulumi manages state
+  required_providers {
+    aws = {
+      source  = "pulumi/aws"  # Not "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+```
+
+Terraform-style resource type names (e.g., `aws_instance`) are automatically mapped to Pulumi tokens for bridged providers. For native Pulumi providers without a Terraform bridge, use Pulumi-style type names directly:
+
+```hcl
+# Bridged provider - Terraform-style works
+resource "aws_instance" "web" { }
+
+# Native Pulumi provider - use Pulumi-style
+resource "kubernetes:apps/v1:Deployment" "app" { }
+```
+
+### Secrets and Sensitive Values
+
+Pulumi has a richer secrets model than Terraform. Values marked `sensitive` are automatically wrapped as Pulumi secrets, which provides encryption at rest in state:
+
+```hcl
+variable "database_password" {
+  type      = string
+  sensitive = true  # Becomes a Pulumi secret (encrypted in state)
+}
+```
+
+This is generally an improvement, but be aware that secret values propagate differently—any output derived from a secret is also marked secret.
+
+### Ignored Terraform Blocks
+
+The following blocks are parsed for compatibility but have no effect, since Pulumi handles these concerns differently:
+
+```hcl
+terraform {
+  # Ignored - Pulumi manages state via Pulumi Cloud or self-managed backends
   backend "s3" {
     bucket = "my-terraform-state"
-    key    = "state.tfstate"
   }
 
-  # Ignored - Pulumi has its own cloud service
+  # Ignored - use Pulumi Cloud instead
   cloud {
     organization = "my-org"
   }
@@ -66,137 +116,46 @@ terraform {
 }
 ```
 
-### Execution Model
+No warning is emitted for these blocks, so existing configurations with backend definitions will work without modification.
 
-| Aspect | Terraform | Pulumi HCL |
-|--------|-----------|------------|
-| Planning | Separate plan phase (`terraform plan`) | Integrated preview (`pulumi preview`) |
-| Execution | Apply from saved plan | Direct execution |
-| Parallelism | Configurable via `-parallelism` | Automatic based on dependencies |
+## Not Yet Implemented
 
-**Impact**: Pulumi HCL executes resource operations in parallel based on the dependency graph. The execution model is designed for the Pulumi engine's approach to infrastructure management.
+These features are planned but not yet available. They represent temporary gaps rather than fundamental incompatibilities.
 
-### Provider Configuration
+### Modules
 
-Pulumi HCL uses Pulumi providers (including Terraform-bridged providers) rather than native Terraform providers.
+Module blocks are parsed but produce an error at runtime:
 
 ```hcl
-terraform {
-  required_providers {
-    aws = {
-      source  = "pulumi/aws"  # Use pulumi/ prefix
-      version = ">= 6.0"
-    }
-  }
-}
-```
-
-**Type name resolution**:
-- Terraform-style names (e.g., `aws_instance`) are automatically mapped to Pulumi tokens for bridged providers
-- For non-bridged providers, use Pulumi-style type names directly (e.g., `aws:ec2/instance:Instance`)
-
-### Attribute Name Conversion
-
-Terraform uses `snake_case` for attribute names, while Pulumi uses `camelCase`. Automatic conversion is applied:
-
-```hcl
-resource "aws_instance" "web" {
-  instance_type = "t3.micro"  # Sent to Pulumi as "instanceType"
-}
-
-output "ip" {
-  value = aws_instance.web.public_ip  # Received from Pulumi as "publicIp"
-}
-```
-
-This conversion is transparent in your HCL code—always use `snake_case` as you would in Terraform.
-
-### Lifecycle Block Differences
-
-The `lifecycle` block is supported with the following behavioral differences:
-
-| Lifecycle Option | Terraform Behavior | Pulumi HCL Behavior |
-|------------------|-------------------|---------------------|
-| `prevent_destroy` | Prevents destruction | Maps to Pulumi's `protect` option |
-| `create_before_destroy` | Creates replacement before destroying original | Parsed but not enforced (Pulumi handles replacement ordering) |
-| `ignore_changes` | Ignores changes to specified attributes | Supported via `ignoreChanges` resource option |
-| `replace_triggered_by` | Forces replacement when referenced resources change | Parsed but no special handling |
-| `precondition` / `postcondition` | Validates conditions | Parsed but not enforced |
-
-### Secrets Handling
-
-Pulumi automatically wraps values marked as `sensitive` as Pulumi secrets:
-
-```hcl
-variable "database_password" {
-  type      = string
-  sensitive = true  # Automatically becomes a Pulumi secret
-}
-
-output "connection_string" {
-  value     = "postgres://user:${var.database_password}@host/db"
-  sensitive = true  # Output is marked as secret
-}
-```
-
-### Resource Addressing
-
-Resources are addressed differently in the underlying system:
-
-| Aspect | Terraform | Pulumi HCL |
-|--------|-----------|------------|
-| Basic resource | `aws_instance.web` | `aws_instance.web` (URN: `urn:pulumi:stack::project::aws:ec2/instance:Instance::aws_instance.web`) |
-| With count | `aws_instance.web[0]` | `aws_instance.web[0]` |
-| With for_each | `aws_instance.web["key"]` | `aws_instance.web["key"]` |
-
-HCL references work identically in your code, but the underlying Pulumi URNs differ from Terraform resource addresses.
-
-## Current Limitations
-
-These are features that are not yet implemented but may be added in future releases. They do not represent fundamental incompatibilities.
-
-### Module Support
-
-Module blocks are parsed but not executed:
-
-```hcl
-# NOT YET SUPPORTED
+# NOT YET SUPPORTED - will error
 module "vpc" {
   source = "./modules/vpc"
-
   cidr_block = "10.0.0.0/16"
 }
-
-# Will result in error: "module support not yet implemented"
 ```
 
-**Workaround**: Inline the module resources directly, or refactor to use Pulumi components in a different Pulumi language (TypeScript, Python, etc.).
+**Workaround**: Inline the module's resources directly into your configuration.
 
 ### Provisioners
 
-Provisioner blocks are parsed but not executed at runtime:
+Provisioner blocks (`local-exec`, `remote-exec`, `file`) are parsed but silently ignored at runtime:
 
 ```hcl
 resource "aws_instance" "web" {
   ami           = "ami-12345678"
   instance_type = "t3.micro"
 
-  # PARSED BUT NOT EXECUTED
+  # SILENTLY IGNORED
   provisioner "remote-exec" {
     inline = ["sudo apt-get update"]
-  }
-
-  # PARSED BUT NOT EXECUTED
-  provisioner "local-exec" {
-    command = "echo ${self.private_ip}"
   }
 }
 ```
 
-**Workaround**: Use the [Pulumi Command provider](https://www.pulumi.com/registry/packages/command/) for executing commands:
+**Workaround**: Use the [Pulumi Command provider](https://www.pulumi.com/registry/packages/command/):
 
 ```hcl
-resource "command_remote_Command" "install" {
+resource "command:remote:Command" "setup" {
   connection {
     host = aws_instance.web.public_ip
   }
@@ -204,9 +163,9 @@ resource "command_remote_Command" "install" {
 }
 ```
 
-### Variable Configuration Integration
+### Variable Configuration
 
-Variables currently only use default values from HCL. Pulumi stack configuration values are not yet integrated:
+Variables currently only use default values defined in HCL. Pulumi stack configuration (`pulumi config set`) is not yet integrated:
 
 ```hcl
 variable "region" {
@@ -215,11 +174,11 @@ variable "region" {
 }
 ```
 
-**Workaround**: Ensure all variables have appropriate defaults, or set values using environment variables (`TF_VAR_region`).
+**Workaround**: Set values via environment variables (`TF_VAR_region=us-east-1`) or ensure all variables have appropriate defaults.
 
 ### Variable Validation
 
-Variable validation blocks are parsed but not enforced:
+Validation blocks are parsed but not enforced:
 
 ```hcl
 variable "instance_type" {
@@ -234,9 +193,9 @@ variable "instance_type" {
 }
 ```
 
-### State Migration Blocks
+### `moved` and `import` Blocks
 
-The following blocks are not supported:
+These Terraform 1.x features for state manipulation are not supported:
 
 ```hcl
 # NOT SUPPORTED
@@ -252,66 +211,51 @@ import {
 }
 ```
 
-**Workaround**: Use `pulumi state rename` for moves, and `pulumi import` for importing existing resources.
+**Workaround**: Use `pulumi state rename` and `pulumi import` commands.
 
-### Functions Not Implemented
+### Missing Function
 
-The following function is not yet available:
+| Function | Status |
+|----------|--------|
+| `rsadecrypt()` | Not implemented |
 
-| Function | Status | Workaround |
-|----------|--------|------------|
-| `rsadecrypt()` | Not implemented | Use external tooling to decrypt values before passing to Pulumi |
+## Platform Differences
 
-## Migration Guide
+These are expected differences when using any new IaC platform. They affect how you operate the tool, not how your HCL code behaves.
 
-When migrating from Terraform to Pulumi HCL:
+| Concern | Terraform | Pulumi HCL |
+|---------|-----------|------------|
+| **State storage** | Local files, S3, Terraform Cloud | Pulumi Cloud or self-managed backends |
+| **State commands** | `terraform state list/show/rm` | `pulumi state` |
+| **Import resources** | `terraform import` or `import` blocks | `pulumi import` |
+| **Workspaces** | `terraform workspace` | Pulumi stacks |
+| **Preview changes** | `terraform plan` | `pulumi preview` |
+| **Apply changes** | `terraform apply` | `pulumi up` |
+| **Destroy** | `terraform destroy` | `pulumi destroy` |
 
-1. **State**: Existing Terraform state is not compatible. Either:
-   - Import existing resources using `pulumi import`
-   - Start fresh and recreate resources
+Existing Terraform state files are not compatible with Pulumi. When migrating, either import existing resources with `pulumi import` or recreate them.
 
-2. **Modules**: Inline module resources or convert to Pulumi components
+## Quick Reference
 
-3. **Provisioners**: Replace with Pulumi Command provider resources
-
-4. **Backend configuration**: Remove or comment out `backend` and `cloud` blocks
-
-5. **Provider sources**: Update to use `pulumi/` prefixed provider sources:
-   ```hcl
-   # Before (Terraform)
-   source = "hashicorp/aws"
-
-   # After (Pulumi HCL)
-   source = "pulumi/aws"
-   ```
-
-6. **Variables**: Ensure all variables have defaults until stack configuration integration is complete
-
-## Feature Comparison Summary
-
-| Feature | Terraform | Pulumi HCL | Notes |
-|---------|:---------:|:----------:|-------|
-| Resources | Yes | Yes | Full support |
-| Data sources | Yes | Yes | Full support |
-| Variables | Yes | Yes | Defaults only (config integration pending) |
-| Locals | Yes | Yes | Full support |
-| Outputs | Yes | Yes | Full support |
-| Providers | Yes | Yes | Pulumi providers |
-| Modules | Yes | No | Not yet implemented |
-| Provisioners | Yes | No | Use Command provider |
-| Workspaces | Yes | N/A | Use Pulumi stacks |
-| State backends | Yes | N/A | Use Pulumi state management |
-| `moved` blocks | Yes | No | Use `pulumi state` |
-| `import` blocks | Yes | No | Use `pulumi import` |
-| `count` | Yes | Yes | Full support |
-| `for_each` | Yes | Yes | Full support |
-| `depends_on` | Yes | Yes | Full support |
-| `lifecycle` | Yes | Partial | Some options mapped differently |
-| Functions | Yes | Mostly | 80+ functions, `rsadecrypt` pending |
+| Feature | Status | Notes |
+|---------|:------:|-------|
+| Resources | Yes | Full support |
+| Data sources | Yes | Full support |
+| Variables | Partial | Defaults only; stack config pending |
+| Locals | Yes | Full support |
+| Outputs | Yes | Full support |
+| Providers | Yes | Use `pulumi/` source prefix |
+| `count` / `for_each` | Yes | Full support |
+| `depends_on` | Yes | Full support |
+| `lifecycle` | Partial | Some options differ; see above |
+| Modules | No | Not yet implemented |
+| Provisioners | No | Silently ignored; use Command provider |
+| `moved` / `import` blocks | No | Use CLI commands |
+| Functions | Mostly | 80+ supported; `rsadecrypt` pending |
 
 ## Getting Help
 
-If you encounter compatibility issues not covered in this document:
+If you encounter compatibility issues not covered here:
 
 1. Check the [Pulumi HCL GitHub repository](https://github.com/pulumi/pulumi-language-hcl) for known issues
 2. File an issue with a minimal reproduction case

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -1,0 +1,318 @@
+# Terraform HCL Compatibility
+
+Pulumi HCL allows you to write infrastructure as code using Terraform-compatible HCL syntax while leveraging the Pulumi engine for state management, secrets, and deployments. This document describes the compatibility between Pulumi HCL and Terraform HCL, including known differences and current limitations.
+
+## Overview
+
+Pulumi HCL parses standard HCL files and translates them to Pulumi resource registrations at runtime. While most Terraform HCL syntax is supported, there are important behavioral differences due to the underlying Pulumi engine.
+
+**Goal**: Maximum compatibility with Terraform HCL syntax with no gratuitous differences.
+
+**Reality**: Some differences are unavoidable due to fundamental architectural differences between Pulumi and Terraform.
+
+## Supported Features
+
+The following Terraform HCL constructs are fully supported:
+
+| Feature | Support | Notes |
+|---------|---------|-------|
+| `resource` blocks | Full | Including all meta-arguments |
+| `data` source blocks | Full | Invoked via Pulumi functions |
+| `variable` blocks | Full | Type constraints, defaults, nullable, sensitive, validation |
+| `locals` blocks | Full | Expression interpolation supported |
+| `output` blocks | Full | value, description, sensitive, depends_on, preconditions |
+| `provider` blocks | Full | Including alias support |
+| `terraform.required_providers` | Full | Provider version constraints |
+| `count` meta-argument | Full | Index expansion with `count.index` |
+| `for_each` meta-argument | Full | Key expansion with `each.key`, `each.value` |
+| `depends_on` | Full | Explicit dependencies |
+| `lifecycle` block | Partial | See [Lifecycle Differences](#lifecycle-block-differences) |
+| Built-in functions | 80+ | Most Terraform functions supported |
+| Splat expressions | Full | `resource.name[*].attr` |
+| String interpolation | Full | `"${var.name}-suffix"` |
+| Complex types | Full | Lists, maps, sets, objects, tuples |
+
+## Fundamental Differences
+
+These differences arise from architectural distinctions between Pulumi and Terraform and represent permanent behavioral variations.
+
+### State Management
+
+| Aspect | Terraform | Pulumi HCL |
+|--------|-----------|------------|
+| State storage | Local files, S3, Terraform Cloud, etc. | Pulumi Cloud or self-managed backends |
+| State format | Terraform state JSON | Pulumi checkpoint format |
+| State migration | `terraform state` commands | `pulumi state` commands |
+
+**Impact**: Existing Terraform state files cannot be directly imported. Resources must be imported using `pulumi import` or recreated.
+
+The following Terraform blocks are parsed but have no effect:
+
+```hcl
+terraform {
+  # Ignored - Pulumi manages state
+  backend "s3" {
+    bucket = "my-terraform-state"
+    key    = "state.tfstate"
+  }
+
+  # Ignored - Pulumi has its own cloud service
+  cloud {
+    organization = "my-org"
+  }
+
+  # Ignored - Pulumi has its own versioning
+  required_version = ">= 1.0"
+}
+```
+
+### Execution Model
+
+| Aspect | Terraform | Pulumi HCL |
+|--------|-----------|------------|
+| Planning | Separate plan phase (`terraform plan`) | Integrated preview (`pulumi preview`) |
+| Execution | Apply from saved plan | Direct execution |
+| Parallelism | Configurable via `-parallelism` | Automatic based on dependencies |
+
+**Impact**: Pulumi HCL executes resource operations in parallel based on the dependency graph. The execution model is designed for the Pulumi engine's approach to infrastructure management.
+
+### Provider Configuration
+
+Pulumi HCL uses Pulumi providers (including Terraform-bridged providers) rather than native Terraform providers.
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "pulumi/aws"  # Use pulumi/ prefix
+      version = ">= 6.0"
+    }
+  }
+}
+```
+
+**Type name resolution**:
+- Terraform-style names (e.g., `aws_instance`) are automatically mapped to Pulumi tokens for bridged providers
+- For non-bridged providers, use Pulumi-style type names directly (e.g., `aws:ec2/instance:Instance`)
+
+### Attribute Name Conversion
+
+Terraform uses `snake_case` for attribute names, while Pulumi uses `camelCase`. Automatic conversion is applied:
+
+```hcl
+resource "aws_instance" "web" {
+  instance_type = "t3.micro"  # Sent to Pulumi as "instanceType"
+}
+
+output "ip" {
+  value = aws_instance.web.public_ip  # Received from Pulumi as "publicIp"
+}
+```
+
+This conversion is transparent in your HCL code—always use `snake_case` as you would in Terraform.
+
+### Lifecycle Block Differences
+
+The `lifecycle` block is supported with the following behavioral differences:
+
+| Lifecycle Option | Terraform Behavior | Pulumi HCL Behavior |
+|------------------|-------------------|---------------------|
+| `prevent_destroy` | Prevents destruction | Maps to Pulumi's `protect` option |
+| `create_before_destroy` | Creates replacement before destroying original | Parsed but not enforced (Pulumi handles replacement ordering) |
+| `ignore_changes` | Ignores changes to specified attributes | Supported via `ignoreChanges` resource option |
+| `replace_triggered_by` | Forces replacement when referenced resources change | Parsed but no special handling |
+| `precondition` / `postcondition` | Validates conditions | Parsed but not enforced |
+
+### Secrets Handling
+
+Pulumi automatically wraps values marked as `sensitive` as Pulumi secrets:
+
+```hcl
+variable "database_password" {
+  type      = string
+  sensitive = true  # Automatically becomes a Pulumi secret
+}
+
+output "connection_string" {
+  value     = "postgres://user:${var.database_password}@host/db"
+  sensitive = true  # Output is marked as secret
+}
+```
+
+### Resource Addressing
+
+Resources are addressed differently in the underlying system:
+
+| Aspect | Terraform | Pulumi HCL |
+|--------|-----------|------------|
+| Basic resource | `aws_instance.web` | `aws_instance.web` (URN: `urn:pulumi:stack::project::aws:ec2/instance:Instance::aws_instance.web`) |
+| With count | `aws_instance.web[0]` | `aws_instance.web[0]` |
+| With for_each | `aws_instance.web["key"]` | `aws_instance.web["key"]` |
+
+HCL references work identically in your code, but the underlying Pulumi URNs differ from Terraform resource addresses.
+
+## Current Limitations
+
+These are features that are not yet implemented but may be added in future releases. They do not represent fundamental incompatibilities.
+
+### Module Support
+
+Module blocks are parsed but not executed:
+
+```hcl
+# NOT YET SUPPORTED
+module "vpc" {
+  source = "./modules/vpc"
+
+  cidr_block = "10.0.0.0/16"
+}
+
+# Will result in error: "module support not yet implemented"
+```
+
+**Workaround**: Inline the module resources directly, or refactor to use Pulumi components in a different Pulumi language (TypeScript, Python, etc.).
+
+### Provisioners
+
+Provisioner blocks are parsed but not executed at runtime:
+
+```hcl
+resource "aws_instance" "web" {
+  ami           = "ami-12345678"
+  instance_type = "t3.micro"
+
+  # PARSED BUT NOT EXECUTED
+  provisioner "remote-exec" {
+    inline = ["sudo apt-get update"]
+  }
+
+  # PARSED BUT NOT EXECUTED
+  provisioner "local-exec" {
+    command = "echo ${self.private_ip}"
+  }
+}
+```
+
+**Workaround**: Use the [Pulumi Command provider](https://www.pulumi.com/registry/packages/command/) for executing commands:
+
+```hcl
+resource "command_remote_Command" "install" {
+  connection {
+    host = aws_instance.web.public_ip
+  }
+  create = "sudo apt-get update"
+}
+```
+
+### Variable Configuration Integration
+
+Variables currently only use default values from HCL. Pulumi stack configuration values are not yet integrated:
+
+```hcl
+variable "region" {
+  type    = string
+  default = "us-west-2"  # Only this default is used
+}
+```
+
+**Workaround**: Ensure all variables have appropriate defaults, or set values using environment variables (`TF_VAR_region`).
+
+### Variable Validation
+
+Variable validation blocks are parsed but not enforced:
+
+```hcl
+variable "instance_type" {
+  type    = string
+  default = "t3.micro"
+
+  # PARSED BUT NOT ENFORCED
+  validation {
+    condition     = can(regex("^t3\\.", var.instance_type))
+    error_message = "Must be a t3 instance type."
+  }
+}
+```
+
+### State Migration Blocks
+
+The following blocks are not supported:
+
+```hcl
+# NOT SUPPORTED
+moved {
+  from = aws_instance.old_name
+  to   = aws_instance.new_name
+}
+
+# NOT SUPPORTED
+import {
+  to = aws_instance.web
+  id = "i-1234567890abcdef0"
+}
+```
+
+**Workaround**: Use `pulumi state rename` for moves, and `pulumi import` for importing existing resources.
+
+### Functions Not Implemented
+
+The following function is not yet available:
+
+| Function | Status | Workaround |
+|----------|--------|------------|
+| `rsadecrypt()` | Not implemented | Use external tooling to decrypt values before passing to Pulumi |
+
+## Migration Guide
+
+When migrating from Terraform to Pulumi HCL:
+
+1. **State**: Existing Terraform state is not compatible. Either:
+   - Import existing resources using `pulumi import`
+   - Start fresh and recreate resources
+
+2. **Modules**: Inline module resources or convert to Pulumi components
+
+3. **Provisioners**: Replace with Pulumi Command provider resources
+
+4. **Backend configuration**: Remove or comment out `backend` and `cloud` blocks
+
+5. **Provider sources**: Update to use `pulumi/` prefixed provider sources:
+   ```hcl
+   # Before (Terraform)
+   source = "hashicorp/aws"
+
+   # After (Pulumi HCL)
+   source = "pulumi/aws"
+   ```
+
+6. **Variables**: Ensure all variables have defaults until stack configuration integration is complete
+
+## Feature Comparison Summary
+
+| Feature | Terraform | Pulumi HCL | Notes |
+|---------|:---------:|:----------:|-------|
+| Resources | Yes | Yes | Full support |
+| Data sources | Yes | Yes | Full support |
+| Variables | Yes | Yes | Defaults only (config integration pending) |
+| Locals | Yes | Yes | Full support |
+| Outputs | Yes | Yes | Full support |
+| Providers | Yes | Yes | Pulumi providers |
+| Modules | Yes | No | Not yet implemented |
+| Provisioners | Yes | No | Use Command provider |
+| Workspaces | Yes | N/A | Use Pulumi stacks |
+| State backends | Yes | N/A | Use Pulumi state management |
+| `moved` blocks | Yes | No | Use `pulumi state` |
+| `import` blocks | Yes | No | Use `pulumi import` |
+| `count` | Yes | Yes | Full support |
+| `for_each` | Yes | Yes | Full support |
+| `depends_on` | Yes | Yes | Full support |
+| `lifecycle` | Yes | Partial | Some options mapped differently |
+| Functions | Yes | Mostly | 80+ functions, `rsadecrypt` pending |
+
+## Getting Help
+
+If you encounter compatibility issues not covered in this document:
+
+1. Check the [Pulumi HCL GitHub repository](https://github.com/pulumi/pulumi-language-hcl) for known issues
+2. File an issue with a minimal reproduction case
+3. Join the [Pulumi Community Slack](https://slack.pulumi.com/) for community support

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -67,9 +67,11 @@ These features are parsed for compatibility but not yet functional. They represe
 
 | Option | Status |
 |--------|--------|
-| `create_before_destroy` | Parsed but not yet wired to Pulumi's `deleteBeforeReplace` |
-| `replace_triggered_by` | Parsed but ignored |
+| `create_before_destroy` | Parsed but not yet wired to Pulumi's [`deleteBeforeReplace`](https://www.pulumi.com/docs/iac/concepts/resources/options/deletebeforereplace/) |
+| `replace_triggered_by` | Parsed but not yet wired to Pulumi's [`replaceOnChanges`](https://www.pulumi.com/docs/iac/concepts/resources/options/replaceonchanges/) (partial support possible—see note) |
 | `precondition` / `postcondition` | Parsed but validations do not run |
+
+**Note on `replace_triggered_by`**: Pulumi's `replaceOnChanges` watches properties on the *current* resource, while Terraform's `replace_triggered_by` watches *other* resources. When the referenced resource's output is also an input to this resource, the behavior can be equivalent. Cases where `replace_triggered_by` references a resource not used as an input cannot be directly mapped.
 
 ### Modules
 
@@ -215,7 +217,7 @@ Existing Terraform state files are not compatible. When migrating, import resour
 | `prevent_destroy` | Yes | Maps to `protect` |
 | `ignore_changes` | Yes | Maps to `ignoreChanges` |
 | `create_before_destroy` | Pending | Parsed but not yet functional |
-| `replace_triggered_by` | Pending | Parsed but ignored |
+| `replace_triggered_by` | Pending | Partial support possible via `replaceOnChanges` |
 | `precondition` / `postcondition` | Pending | Parsed but not enforced |
 | Modules | No | Not yet implemented |
 | Provisioners | No | Silently ignored |

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -1,31 +1,27 @@
 # Terraform HCL Compatibility
 
-Pulumi HCL allows you to write infrastructure as code using Terraform-compatible HCL syntax while leveraging the Pulumi engine for state management, secrets, and deployments.
+Pulumi HCL lets you write infrastructure using Terraform-compatible HCL syntax while running on the Pulumi engine. This document covers what works, what's different, and what's not yet implemented.
 
-**Goal**: Maximum compatibility with Terraform HCL syntax with no gratuitous differences.
+## Supported Features
 
-This document describes what's supported, what's not yet implemented, and what platform-level differences to expect when using Pulumi instead of Terraform.
+The following HCL constructs work with identical behavior to Terraform:
 
-## Fully Supported
+### Core Blocks
 
-The following Terraform HCL constructs work with identical behavior:
-
-### Core Constructs
-
-| Feature | Notes |
-|---------|-------|
-| `resource` blocks | Full support including nested blocks |
-| `data` source blocks | Invoked via Pulumi provider functions |
-| `variable` blocks | Type constraints, defaults, nullable, sensitive |
-| `locals` blocks | Full expression interpolation |
-| `output` blocks | value, description, sensitive, depends_on |
-| `provider` blocks | Including alias support |
+| Block | Notes |
+|-------|-------|
+| `resource` | Full support including nested blocks |
+| `data` | Data sources invoked via Pulumi provider functions |
+| `variable` | Type constraints, defaults, nullable, sensitive |
+| `locals` | Full expression interpolation |
+| `output` | value, description, sensitive, depends_on |
+| `provider` | Including alias support |
 | `terraform.required_providers` | Provider version constraints |
 
 ### Meta-Arguments
 
-| Feature | Notes |
-|---------|-------|
+| Argument | Notes |
+|----------|-------|
 | `count` | Index expansion with `count.index` |
 | `for_each` | Key expansion with `each.key`, `each.value` |
 | `depends_on` | Explicit dependency declarations |
@@ -33,12 +29,12 @@ The following Terraform HCL constructs work with identical behavior:
 
 ### Lifecycle Options
 
-| Option | Notes |
-|--------|-------|
-| `prevent_destroy` | Maps to Pulumi's `protect` resource option |
-| `ignore_changes` | Maps to Pulumi's `ignoreChanges` resource option |
+| Option | Pulumi Equivalent |
+|--------|-------------------|
+| `prevent_destroy` | [`protect`](https://www.pulumi.com/docs/iac/concepts/resources/options/protect/) |
+| `ignore_changes` | [`ignoreChanges`](https://www.pulumi.com/docs/iac/concepts/resources/options/ignorechanges/) |
 
-### Expressions and Functions
+### Expressions
 
 | Feature | Notes |
 |---------|-------|
@@ -46,11 +42,11 @@ The following Terraform HCL constructs work with identical behavior:
 | Splat expressions | `resource.name[*].attr` |
 | Resource references | `aws_instance.web.id`, `data.aws_ami.ubuntu.id` |
 | Complex types | Lists, maps, sets, objects, tuples |
-| Built-in functions | 80+ Terraform functions supported |
+| Built-in functions | 80+ Terraform functions |
 
 ### Sensitive Values
 
-Values marked `sensitive` are automatically wrapped as Pulumi secrets, providing encryption at rest:
+Values marked `sensitive` become Pulumi secrets, providing encryption at rest:
 
 ```hcl
 variable "database_password" {
@@ -59,107 +55,13 @@ variable "database_password" {
 }
 ```
 
-## Not Yet Implemented
-
-These features are parsed for compatibility but not yet functional. They represent temporary implementation gaps.
-
-### Lifecycle Options
-
-| Option | Status |
-|--------|--------|
-| `create_before_destroy` | Parsed but not yet wired to Pulumi's [`deleteBeforeReplace`](https://www.pulumi.com/docs/iac/concepts/resources/options/deletebeforereplace/) |
-| `replace_triggered_by` | Not supported (no direct Pulumi equivalent) |
-| `precondition` / `postcondition` | Parsed but validations do not run |
-
-**Note on `replace_triggered_by`**: Terraform's `replace_triggered_by` cascades replacement when *other* resources change. Pulumi's [`replaceOnChanges`](https://www.pulumi.com/docs/iac/concepts/resources/options/replaceonchanges/) triggers replacement when properties on *this* resource change—different semantics that don't directly map.
-
-### Modules
-
-Module blocks produce an error at runtime:
-
-```hcl
-# NOT YET SUPPORTED - will error
-module "vpc" {
-  source = "./modules/vpc"
-  cidr_block = "10.0.0.0/16"
-}
-```
-
-**Workaround**: Inline the module's resources directly into your configuration.
-
-### Provisioners
-
-Provisioner blocks (`local-exec`, `remote-exec`, `file`) are parsed but not yet executed. They will map to the [Pulumi Command provider](https://www.pulumi.com/registry/packages/command/) once implemented:
-
-```hcl
-resource "aws_instance" "web" {
-  ami           = "ami-12345678"
-  instance_type = "t3.micro"
-
-  # PARSED BUT NOT YET EXECUTED
-  provisioner "remote-exec" {
-    inline = ["sudo apt-get update"]
-  }
-}
-```
-
-### Variable Configuration
-
-Variables currently only use default values from HCL. Pulumi stack configuration (`pulumi config set`) is not yet integrated:
-
-```hcl
-variable "region" {
-  type    = string
-  default = "us-west-2"  # Only this default is used
-}
-```
-
-**Workaround**: Set values via environment variables (`TF_VAR_region=us-east-1`) or ensure all variables have defaults.
-
-### Variable Validation
-
-Validation blocks are not yet enforced (will produce a warning):
-
-```hcl
-variable "instance_type" {
-  type    = string
-  default = "t3.micro"
-
-  # NOT YET ENFORCED
-  validation {
-    condition     = can(regex("^t3\\.", var.instance_type))
-    error_message = "Must be a t3 instance type."
-  }
-}
-```
-
-### State Migration Blocks
-
-`moved` and `import` blocks are not supported:
-
-```hcl
-# NOT SUPPORTED
-moved {
-  from = aws_instance.old_name
-  to   = aws_instance.new_name
-}
-```
-
-**Workaround**: Use `pulumi state rename` and `pulumi import` CLI commands.
-
-### Missing Functions
-
-| Function | Status |
-|----------|--------|
-| `rsadecrypt()` | Not yet implemented |
-
 ## Platform Differences
 
-These are expected differences when using Pulumi instead of Terraform. They don't affect HCL syntax or behavior—just how you operate the tool.
+These are expected differences when using Pulumi instead of Terraform. They affect tooling, not HCL behavior.
 
-### Provider Configuration
+### Provider Sources
 
-Provider sources use Pulumi's namespace:
+Use the `pulumi/` namespace for providers:
 
 ```hcl
 terraform {
@@ -176,56 +78,139 @@ Terraform-style resource type names (e.g., `aws_instance`) are automatically map
 
 ### Ignored Blocks
 
-The following blocks are parsed but have no effect (Pulumi handles these concerns differently):
+These blocks are parsed but have no effect:
 
 ```hcl
 terraform {
-  backend "s3" { }        # Ignored - use Pulumi state backends
-  cloud { }               # Ignored - use Pulumi Cloud
-  required_version = ""   # Ignored - Pulumi has its own versioning
+  backend "s3" { }        # Use Pulumi state backends instead
+  cloud { }               # Use Pulumi Cloud instead
+  required_version = ""   # Pulumi has its own versioning
 }
 ```
 
-### CLI and State
+### CLI Commands
 
-| Concern | Terraform | Pulumi HCL |
-|---------|-----------|------------|
-| **State storage** | Local files, S3, Terraform Cloud | Pulumi Cloud or self-managed backends |
-| **State commands** | `terraform state` | `pulumi state` |
-| **Import resources** | `terraform import` | `pulumi import` |
-| **Workspaces** | `terraform workspace` | Pulumi stacks |
-| **Preview changes** | `terraform plan` | `pulumi preview` |
-| **Apply changes** | `terraform apply` | `pulumi up` |
-| **Destroy** | `terraform destroy` | `pulumi destroy` |
+| Operation | Terraform | Pulumi |
+|-----------|-----------|--------|
+| Preview changes | `terraform plan` | `pulumi preview` |
+| Apply changes | `terraform apply` | `pulumi up` |
+| Destroy | `terraform destroy` | `pulumi destroy` |
+| State operations | `terraform state` | `pulumi state` |
+| Import resources | `terraform import` | `pulumi import` |
+| Environments | `terraform workspace` | Pulumi stacks |
 
-Existing Terraform state files are not compatible. When migrating, import resources with `pulumi import` or recreate them.
+Existing Terraform state files are not compatible. Import resources with `pulumi import` or recreate them.
+
+## Unsupported Features
+
+These features cannot be supported due to fundamental differences between Pulumi and Terraform.
+
+### `replace_triggered_by`
+
+Terraform's `replace_triggered_by` cascades replacement when *other* resources change. Pulumi's [`replaceOnChanges`](https://www.pulumi.com/docs/iac/concepts/resources/options/replaceonchanges/) triggers replacement when properties on *this* resource change—different semantics that don't map directly.
+
+### `moved` and `import` Blocks
+
+Use `pulumi state rename` and `pulumi import` CLI commands instead.
+
+## Not Yet Implemented
+
+These features are parsed for compatibility but not yet functional. They represent temporary gaps.
+
+### Lifecycle Options
+
+| Option | Status |
+|--------|--------|
+| `create_before_destroy` | Will map to [`deleteBeforeReplace`](https://www.pulumi.com/docs/iac/concepts/resources/options/deletebeforereplace/) |
+| `precondition` / `postcondition` | Validations do not run yet |
+
+### Modules
+
+Module blocks produce an error at runtime:
+
+```hcl
+module "vpc" {
+  source     = "./modules/vpc"
+  cidr_block = "10.0.0.0/16"
+}
+# Error: module support not yet implemented
+```
+
+**Workaround**: Inline the module's resources directly.
+
+### Provisioners
+
+Provisioner blocks (`local-exec`, `remote-exec`, `file`) are parsed but not executed. They will map to the [Pulumi Command provider](https://www.pulumi.com/registry/packages/command/):
+
+```hcl
+provisioner "remote-exec" {
+  inline = ["sudo apt-get update"]
+}
+# Parsed but not yet executed
+```
+
+### Variable Configuration
+
+Variables use default values only. Pulumi stack configuration (`pulumi config set`) is not yet integrated:
+
+```hcl
+variable "region" {
+  type    = string
+  default = "us-west-2"  # Only this default is used
+}
+```
+
+**Workaround**: Use environment variables (`TF_VAR_region=us-east-1`) or ensure all variables have defaults.
+
+### Variable Validation
+
+Validation blocks are parsed but not enforced:
+
+```hcl
+variable "instance_type" {
+  type    = string
+  default = "t3.micro"
+
+  validation {
+    condition     = can(regex("^t3\\.", var.instance_type))
+    error_message = "Must be a t3 instance type."
+  }
+}
+# Validation is not enforced
+```
+
+### Missing Functions
+
+| Function | Status |
+|----------|--------|
+| `rsadecrypt()` | Not yet implemented |
 
 ## Quick Reference
 
 | Feature | Status | Notes |
 |---------|:------:|-------|
-| Resources | Yes | Full support |
-| Data sources | Yes | Full support |
+| Resources | Yes | |
+| Data sources | Yes | |
 | Variables | Partial | Defaults only; stack config pending |
-| Locals | Yes | Full support |
-| Outputs | Yes | Full support |
+| Locals | Yes | |
+| Outputs | Yes | |
 | Providers | Yes | Use `pulumi/` source prefix |
-| `count` / `for_each` | Yes | Full support |
-| `depends_on` | Yes | Full support |
+| `count` / `for_each` | Yes | |
+| `depends_on` | Yes | |
 | `prevent_destroy` | Yes | Maps to `protect` |
 | `ignore_changes` | Yes | Maps to `ignoreChanges` |
-| `create_before_destroy` | Pending | Parsed but not yet functional |
+| `create_before_destroy` | Pending | Will map to `deleteBeforeReplace` |
 | `replace_triggered_by` | No | No direct Pulumi equivalent |
-| `precondition` / `postcondition` | Pending | Parsed but not enforced |
-| Modules | No | Not yet implemented |
+| `precondition` / `postcondition` | Pending | |
+| Modules | Pending | Not yet implemented |
 | Provisioners | Pending | Will map to Command provider |
 | `moved` / `import` blocks | No | Use CLI commands |
 | Functions | Mostly | 80+ supported; `rsadecrypt` pending |
 
 ## Getting Help
 
-If you encounter compatibility issues not covered here:
+If you encounter compatibility issues:
 
-1. Check the [Pulumi HCL GitHub repository](https://github.com/pulumi/pulumi-language-hcl) for known issues
-2. File an issue with a minimal reproduction case
-3. Join the [Pulumi Community Slack](https://slack.pulumi.com/) for community support
+1. Check the [GitHub repository](https://github.com/pulumi/pulumi-language-hcl) for known issues
+2. File an issue with a minimal reproduction
+3. Join the [Pulumi Community Slack](https://slack.pulumi.com/)

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -34,28 +34,19 @@ These are cases where valid HCL syntax is interpreted differently by Pulumi HCL.
 
 ### Lifecycle Block Behavior
 
-The `lifecycle` block is parsed, but some options have different semantics:
+The `lifecycle` block is supported, but not all options have an effect:
 
-| Lifecycle Option | Terraform Behavior | Pulumi HCL Behavior |
-|------------------|-------------------|---------------------|
-| `prevent_destroy` | Prevents `terraform destroy` from removing the resource | Maps to Pulumi's `protect` option (similar effect) |
-| `create_before_destroy` | Creates replacement before destroying original | Parsed but not enforced; Pulumi determines replacement ordering |
-| `ignore_changes` | Ignores specified attribute changes during updates | Supported via Pulumi's `ignoreChanges` resource option |
-| `replace_triggered_by` | Forces replacement when referenced resources change | Parsed but has no effect |
-| `precondition` / `postcondition` | Validates conditions before/after apply | Parsed but not enforced |
+| Lifecycle Option | Status | Behavior |
+|------------------|--------|----------|
+| `prevent_destroy` | Works | Maps to Pulumi's `protect` resource option |
+| `ignore_changes` | Works | Maps to Pulumi's `ignoreChanges` resource option |
+| `create_before_destroy` | No effect | Pulumi uses its own replacement ordering logic |
+| `replace_triggered_by` | No effect | Parsed but ignored |
+| `precondition` / `postcondition` | No effect | Parsed but validations do not run |
 
-**Example**:
-```hcl
-resource "aws_instance" "web" {
-  # ...
+For `create_before_destroy`: Pulumi's engine determines replacement strategy based on resource type and provider behavior. You cannot override this ordering via HCL.
 
-  lifecycle {
-    prevent_destroy = true        # Works - maps to Pulumi protect
-    ignore_changes  = [tags]      # Works - maps to ignoreChanges
-    create_before_destroy = true  # Parsed but Pulumi controls ordering
-  }
-}
-```
+For `replace_triggered_by`: If you depend on this to force resource replacement when dependencies change, you'll need to restructure your configuration or trigger replacements manually.
 
 ### Provider Source Names
 
@@ -247,7 +238,7 @@ Existing Terraform state files are not compatible with Pulumi. When migrating, e
 | Providers | Yes | Use `pulumi/` source prefix |
 | `count` / `for_each` | Yes | Full support |
 | `depends_on` | Yes | Full support |
-| `lifecycle` | Partial | Some options differ; see above |
+| `lifecycle` | Partial | `prevent_destroy` and `ignore_changes` work; others ignored |
 | Modules | No | Not yet implemented |
 | Provisioners | No | Silently ignored; use Command provider |
 | `moved` / `import` blocks | No | Use CLI commands |

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -68,10 +68,10 @@ These features are parsed for compatibility but not yet functional. They represe
 | Option | Status |
 |--------|--------|
 | `create_before_destroy` | Parsed but not yet wired to Pulumi's [`deleteBeforeReplace`](https://www.pulumi.com/docs/iac/concepts/resources/options/deletebeforereplace/) |
-| `replace_triggered_by` | Parsed but not yet wired to Pulumi's [`replaceOnChanges`](https://www.pulumi.com/docs/iac/concepts/resources/options/replaceonchanges/) (partial support possible—see note) |
+| `replace_triggered_by` | Not supported (no direct Pulumi equivalent) |
 | `precondition` / `postcondition` | Parsed but validations do not run |
 
-**Note on `replace_triggered_by`**: Pulumi's `replaceOnChanges` watches properties on the *current* resource, while Terraform's `replace_triggered_by` watches *other* resources. When the referenced resource's output is also an input to this resource, the behavior can be equivalent. Cases where `replace_triggered_by` references a resource not used as an input cannot be directly mapped.
+**Note on `replace_triggered_by`**: Terraform's `replace_triggered_by` cascades replacement when *other* resources change. Pulumi's [`replaceOnChanges`](https://www.pulumi.com/docs/iac/concepts/resources/options/replaceonchanges/) triggers replacement when properties on *this* resource change—different semantics that don't directly map.
 
 ### Modules
 
@@ -217,7 +217,7 @@ Existing Terraform state files are not compatible. When migrating, import resour
 | `prevent_destroy` | Yes | Maps to `protect` |
 | `ignore_changes` | Yes | Maps to `ignoreChanges` |
 | `create_before_destroy` | Pending | Parsed but not yet functional |
-| `replace_triggered_by` | Pending | Partial support possible via `replaceOnChanges` |
+| `replace_triggered_by` | No | No direct Pulumi equivalent |
 | `precondition` / `postcondition` | Pending | Parsed but not enforced |
 | Modules | No | Not yet implemented |
 | Provisioners | No | Silently ignored |

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -89,14 +89,14 @@ module "vpc" {
 
 ### Provisioners
 
-Provisioner blocks (`local-exec`, `remote-exec`, `file`) are parsed but silently ignored:
+Provisioner blocks (`local-exec`, `remote-exec`, `file`) are not supported and will produce a warning:
 
 ```hcl
 resource "aws_instance" "web" {
   ami           = "ami-12345678"
   instance_type = "t3.micro"
 
-  # SILENTLY IGNORED
+  # NOT SUPPORTED
   provisioner "remote-exec" {
     inline = ["sudo apt-get update"]
   }
@@ -120,14 +120,14 @@ variable "region" {
 
 ### Variable Validation
 
-Validation blocks are parsed but not enforced:
+Validation blocks are not yet enforced (will produce a warning):
 
 ```hcl
 variable "instance_type" {
   type    = string
   default = "t3.micro"
 
-  # PARSED BUT NOT ENFORCED
+  # NOT YET ENFORCED
   validation {
     condition     = can(regex("^t3\\.", var.instance_type))
     error_message = "Must be a t3 instance type."
@@ -220,7 +220,7 @@ Existing Terraform state files are not compatible. When migrating, import resour
 | `replace_triggered_by` | No | No direct Pulumi equivalent |
 | `precondition` / `postcondition` | Pending | Parsed but not enforced |
 | Modules | No | Not yet implemented |
-| Provisioners | No | Silently ignored |
+| Provisioners | No | Not supported; use Command provider |
 | `moved` / `import` blocks | No | Use CLI commands |
 | Functions | Mostly | 80+ supported; `rsadecrypt` pending |
 

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -89,21 +89,19 @@ module "vpc" {
 
 ### Provisioners
 
-Provisioner blocks (`local-exec`, `remote-exec`, `file`) are not supported and will produce a warning:
+Provisioner blocks (`local-exec`, `remote-exec`, `file`) are parsed but not yet executed. They will map to the [Pulumi Command provider](https://www.pulumi.com/registry/packages/command/) once implemented:
 
 ```hcl
 resource "aws_instance" "web" {
   ami           = "ami-12345678"
   instance_type = "t3.micro"
 
-  # NOT SUPPORTED
+  # PARSED BUT NOT YET EXECUTED
   provisioner "remote-exec" {
     inline = ["sudo apt-get update"]
   }
 }
 ```
-
-**Workaround**: Use the [Pulumi Command provider](https://www.pulumi.com/registry/packages/command/).
 
 ### Variable Configuration
 
@@ -220,7 +218,7 @@ Existing Terraform state files are not compatible. When migrating, import resour
 | `replace_triggered_by` | No | No direct Pulumi equivalent |
 | `precondition` / `postcondition` | Pending | Parsed but not enforced |
 | Modules | No | Not yet implemented |
-| Provisioners | No | Not supported; use Command provider |
+| Provisioners | Pending | Will map to Command provider |
 | `moved` / `import` blocks | No | Use CLI commands |
 | Functions | Mostly | 80+ supported; `rsadecrypt` pending |
 

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -4,118 +4,76 @@ Pulumi HCL allows you to write infrastructure as code using Terraform-compatible
 
 **Goal**: Maximum compatibility with Terraform HCL syntax with no gratuitous differences.
 
-This document focuses on **language and semantic differences**—cases where valid HCL code may behave differently than in Terraform. Platform-level differences (state management, CLI commands, etc.) are expected when adopting any new IaC tool and are summarized briefly at the end.
+This document describes what's supported, what's not yet implemented, and what platform-level differences to expect when using Pulumi instead of Terraform.
 
-## Supported HCL Syntax
+## Fully Supported
 
-The following Terraform HCL constructs are fully supported with identical behavior:
+The following Terraform HCL constructs work with identical behavior:
 
-| Feature | Support | Notes |
-|---------|---------|-------|
-| `resource` blocks | Full | Including all meta-arguments |
-| `data` source blocks | Full | Invoked via Pulumi functions |
-| `variable` blocks | Full | Type constraints, defaults, nullable, sensitive |
-| `locals` blocks | Full | Expression interpolation supported |
-| `output` blocks | Full | value, description, sensitive, depends_on |
-| `provider` blocks | Full | Including alias support |
-| `terraform.required_providers` | Full | Provider version constraints |
-| `count` meta-argument | Full | Index expansion with `count.index` |
-| `for_each` meta-argument | Full | Key expansion with `each.key`, `each.value` |
-| `depends_on` | Full | Explicit dependencies |
-| Built-in functions | 80+ | Most Terraform functions supported |
-| Splat expressions | Full | `resource.name[*].attr` |
-| String interpolation | Full | `"${var.name}-suffix"` |
-| Complex types | Full | Lists, maps, sets, objects, tuples |
-| Resource references | Full | `aws_instance.web.id`, `data.aws_ami.ubuntu.id` |
+### Core Constructs
 
-## Language and Semantic Differences
+| Feature | Notes |
+|---------|-------|
+| `resource` blocks | Full support including nested blocks |
+| `data` source blocks | Invoked via Pulumi provider functions |
+| `variable` blocks | Type constraints, defaults, nullable, sensitive |
+| `locals` blocks | Full expression interpolation |
+| `output` blocks | value, description, sensitive, depends_on |
+| `provider` blocks | Including alias support |
+| `terraform.required_providers` | Provider version constraints |
 
-These are cases where valid HCL syntax is interpreted differently by Pulumi HCL. Understanding these differences is important when migrating existing configurations.
+### Meta-Arguments
 
-### Lifecycle Block Behavior
+| Feature | Notes |
+|---------|-------|
+| `count` | Index expansion with `count.index` |
+| `for_each` | Key expansion with `each.key`, `each.value` |
+| `depends_on` | Explicit dependency declarations |
+| `provider` | Provider selection per resource |
 
-The `lifecycle` block is supported, but not all options have an effect:
+### Lifecycle Options
 
-| Lifecycle Option | Status | Behavior |
-|------------------|--------|----------|
-| `prevent_destroy` | Works | Maps to Pulumi's `protect` resource option |
-| `ignore_changes` | Works | Maps to Pulumi's `ignoreChanges` resource option |
-| `create_before_destroy` | No effect | Pulumi uses its own replacement ordering logic |
-| `replace_triggered_by` | No effect | Parsed but ignored |
-| `precondition` / `postcondition` | No effect | Parsed but validations do not run |
+| Option | Notes |
+|--------|-------|
+| `prevent_destroy` | Maps to Pulumi's `protect` resource option |
+| `ignore_changes` | Maps to Pulumi's `ignoreChanges` resource option |
 
-For `create_before_destroy`: Pulumi's engine determines replacement strategy based on resource type and provider behavior. You cannot override this ordering via HCL.
+### Expressions and Functions
 
-For `replace_triggered_by`: If you depend on this to force resource replacement when dependencies change, you'll need to restructure your configuration or trigger replacements manually.
+| Feature | Notes |
+|---------|-------|
+| String interpolation | `"${var.name}-suffix"` |
+| Splat expressions | `resource.name[*].attr` |
+| Resource references | `aws_instance.web.id`, `data.aws_ami.ubuntu.id` |
+| Complex types | Lists, maps, sets, objects, tuples |
+| Built-in functions | 80+ Terraform functions supported |
 
-### Provider Source Names
+### Sensitive Values
 
-Provider sources use the `pulumi/` namespace rather than `hashicorp/`:
-
-```hcl
-terraform {
-  required_providers {
-    aws = {
-      source  = "pulumi/aws"  # Not "hashicorp/aws"
-      version = ">= 6.0"
-    }
-  }
-}
-```
-
-Terraform-style resource type names (e.g., `aws_instance`) are automatically mapped to Pulumi tokens for bridged providers. For native Pulumi providers without a Terraform bridge, use Pulumi-style type names directly:
-
-```hcl
-# Bridged provider - Terraform-style works
-resource "aws_instance" "web" { }
-
-# Native Pulumi provider - use Pulumi-style
-resource "kubernetes:apps/v1:Deployment" "app" { }
-```
-
-### Secrets and Sensitive Values
-
-Pulumi has a richer secrets model than Terraform. Values marked `sensitive` are automatically wrapped as Pulumi secrets, which provides encryption at rest in state:
+Values marked `sensitive` are automatically wrapped as Pulumi secrets, providing encryption at rest:
 
 ```hcl
 variable "database_password" {
   type      = string
-  sensitive = true  # Becomes a Pulumi secret (encrypted in state)
+  sensitive = true  # Encrypted in Pulumi state
 }
 ```
-
-This is generally an improvement, but be aware that secret values propagate differently—any output derived from a secret is also marked secret.
-
-### Ignored Terraform Blocks
-
-The following blocks are parsed for compatibility but have no effect, since Pulumi handles these concerns differently:
-
-```hcl
-terraform {
-  # Ignored - Pulumi manages state via Pulumi Cloud or self-managed backends
-  backend "s3" {
-    bucket = "my-terraform-state"
-  }
-
-  # Ignored - use Pulumi Cloud instead
-  cloud {
-    organization = "my-org"
-  }
-
-  # Ignored - Pulumi has its own versioning
-  required_version = ">= 1.0"
-}
-```
-
-No warning is emitted for these blocks, so existing configurations with backend definitions will work without modification.
 
 ## Not Yet Implemented
 
-These features are planned but not yet available. They represent temporary gaps rather than fundamental incompatibilities.
+These features are parsed for compatibility but not yet functional. They represent temporary implementation gaps.
+
+### Lifecycle Options
+
+| Option | Status |
+|--------|--------|
+| `create_before_destroy` | Parsed but not yet wired to Pulumi's `deleteBeforeReplace` |
+| `replace_triggered_by` | Parsed but ignored |
+| `precondition` / `postcondition` | Parsed but validations do not run |
 
 ### Modules
 
-Module blocks are parsed but produce an error at runtime:
+Module blocks produce an error at runtime:
 
 ```hcl
 # NOT YET SUPPORTED - will error
@@ -129,7 +87,7 @@ module "vpc" {
 
 ### Provisioners
 
-Provisioner blocks (`local-exec`, `remote-exec`, `file`) are parsed but silently ignored at runtime:
+Provisioner blocks (`local-exec`, `remote-exec`, `file`) are parsed but silently ignored:
 
 ```hcl
 resource "aws_instance" "web" {
@@ -143,20 +101,11 @@ resource "aws_instance" "web" {
 }
 ```
 
-**Workaround**: Use the [Pulumi Command provider](https://www.pulumi.com/registry/packages/command/):
-
-```hcl
-resource "command:remote:Command" "setup" {
-  connection {
-    host = aws_instance.web.public_ip
-  }
-  create = "sudo apt-get update"
-}
-```
+**Workaround**: Use the [Pulumi Command provider](https://www.pulumi.com/registry/packages/command/).
 
 ### Variable Configuration
 
-Variables currently only use default values defined in HCL. Pulumi stack configuration (`pulumi config set`) is not yet integrated:
+Variables currently only use default values from HCL. Pulumi stack configuration (`pulumi config set`) is not yet integrated:
 
 ```hcl
 variable "region" {
@@ -165,7 +114,7 @@ variable "region" {
 }
 ```
 
-**Workaround**: Set values via environment variables (`TF_VAR_region=us-east-1`) or ensure all variables have appropriate defaults.
+**Workaround**: Set values via environment variables (`TF_VAR_region=us-east-1`) or ensure all variables have defaults.
 
 ### Variable Validation
 
@@ -184,9 +133,9 @@ variable "instance_type" {
 }
 ```
 
-### `moved` and `import` Blocks
+### State Migration Blocks
 
-These Terraform 1.x features for state manipulation are not supported:
+`moved` and `import` blocks are not supported:
 
 ```hcl
 # NOT SUPPORTED
@@ -194,37 +143,62 @@ moved {
   from = aws_instance.old_name
   to   = aws_instance.new_name
 }
-
-# NOT SUPPORTED
-import {
-  to = aws_instance.web
-  id = "i-1234567890abcdef0"
-}
 ```
 
-**Workaround**: Use `pulumi state rename` and `pulumi import` commands.
+**Workaround**: Use `pulumi state rename` and `pulumi import` CLI commands.
 
-### Missing Function
+### Missing Functions
 
 | Function | Status |
 |----------|--------|
-| `rsadecrypt()` | Not implemented |
+| `rsadecrypt()` | Not yet implemented |
 
 ## Platform Differences
 
-These are expected differences when using any new IaC platform. They affect how you operate the tool, not how your HCL code behaves.
+These are expected differences when using Pulumi instead of Terraform. They don't affect HCL syntax or behavior—just how you operate the tool.
+
+### Provider Configuration
+
+Provider sources use Pulumi's namespace:
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "pulumi/aws"  # Not "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+```
+
+Terraform-style resource type names (e.g., `aws_instance`) are automatically mapped to Pulumi tokens for bridged providers.
+
+### Ignored Blocks
+
+The following blocks are parsed but have no effect (Pulumi handles these concerns differently):
+
+```hcl
+terraform {
+  backend "s3" { }        # Ignored - use Pulumi state backends
+  cloud { }               # Ignored - use Pulumi Cloud
+  required_version = ""   # Ignored - Pulumi has its own versioning
+}
+```
+
+### CLI and State
 
 | Concern | Terraform | Pulumi HCL |
 |---------|-----------|------------|
 | **State storage** | Local files, S3, Terraform Cloud | Pulumi Cloud or self-managed backends |
-| **State commands** | `terraform state list/show/rm` | `pulumi state` |
-| **Import resources** | `terraform import` or `import` blocks | `pulumi import` |
+| **State commands** | `terraform state` | `pulumi state` |
+| **Import resources** | `terraform import` | `pulumi import` |
 | **Workspaces** | `terraform workspace` | Pulumi stacks |
 | **Preview changes** | `terraform plan` | `pulumi preview` |
 | **Apply changes** | `terraform apply` | `pulumi up` |
 | **Destroy** | `terraform destroy` | `pulumi destroy` |
 
-Existing Terraform state files are not compatible with Pulumi. When migrating, either import existing resources with `pulumi import` or recreate them.
+Existing Terraform state files are not compatible. When migrating, import resources with `pulumi import` or recreate them.
 
 ## Quick Reference
 
@@ -238,9 +212,13 @@ Existing Terraform state files are not compatible with Pulumi. When migrating, e
 | Providers | Yes | Use `pulumi/` source prefix |
 | `count` / `for_each` | Yes | Full support |
 | `depends_on` | Yes | Full support |
-| `lifecycle` | Partial | `prevent_destroy` and `ignore_changes` work; others ignored |
+| `prevent_destroy` | Yes | Maps to `protect` |
+| `ignore_changes` | Yes | Maps to `ignoreChanges` |
+| `create_before_destroy` | Pending | Parsed but not yet functional |
+| `replace_triggered_by` | Pending | Parsed but ignored |
+| `precondition` / `postcondition` | Pending | Parsed but not enforced |
 | Modules | No | Not yet implemented |
-| Provisioners | No | Silently ignored; use Command provider |
+| Provisioners | No | Silently ignored |
 | `moved` / `import` blocks | No | Use CLI commands |
 | Functions | Mostly | 80+ supported; `rsadecrypt` pending |
 


### PR DESCRIPTION
Document known differences between Pulumi HCL and Terraform HCL, separating fundamental architectural differences from temporary implementation gaps. Covers state management, execution model, provider configuration, lifecycle blocks, and current limitations like modules and provisioners.