### PR TITLE
feat(parser): auto-map hashicorp/ provider sources to pulumi/

### DIFF
--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -4,22 +4,32 @@ Pulumi HCL supports [Terraform's HCL syntax](https://developer.hashicorp.com/ter
 
 This document covers only what's different.
 
-## The One Required Change
+## Provider Sources
 
-Provider sources must use the `pulumi/` namespace instead of `hashicorp/`:
+Pulumi HCL uses the `pulumi/` namespace for providers. If your configuration uses
+`hashicorp/` sources, they are **automatically mapped** to `pulumi/`:
 
 ```hcl
 terraform {
   required_providers {
     aws = {
-      source  = "pulumi/aws"  # not "hashicorp/aws"
+      source  = "hashicorp/aws"  # automatically becomes "pulumi/aws"
       version = ">= 6.0"
     }
   }
 }
 ```
 
-Terraform-style resource type names (like `aws_instance`) work unchanged—they're automatically mapped to their Pulumi equivalents.
+**Mapping behavior:**
+
+- Case-insensitive: `hashicorp/`, `HashiCorp/`, and `HASHICORP/` are all mapped
+- A warning is emitted showing both the original and mapped source
+- Update to `pulumi/` in your configuration to suppress the warning
+- Registry hostnames are not stripped: `registry.terraform.io/hashicorp/aws`
+  is passed through unchanged
+
+Terraform-style resource type names (like `aws_instance`) work unchanged—they're
+automatically mapped to their Pulumi equivalents.
 
 ## Behavioral Differences
 

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -16,6 +16,7 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi-language-hcl/pkg/hcl/ast"
@@ -191,7 +192,24 @@ func (p *Parser) parseRequiredProviders(terraform *ast.Terraform, block *hcl.Blo
 			provider.Version = val.AsString()
 		} else if val.Type().IsObjectType() {
 			if sourceVal := val.GetAttr("source"); !sourceVal.IsNull() {
-				provider.Source = sourceVal.AsString()
+				source := sourceVal.AsString()
+				// Auto-map hashicorp/ namespace to pulumi/ for Terraform compatibility
+				// Case-insensitive comparison for better compatibility with various capitalizations
+				lowerSource := strings.ToLower(source)
+				if providerName, found := strings.CutPrefix(lowerSource, "hashicorp/"); found {
+					normalized := "pulumi/" + providerName
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagWarning,
+						Summary:  "Provider source automatically mapped",
+						Detail: fmt.Sprintf(
+							"Changed %q to %q. Pulumi HCL uses the pulumi/ namespace for providers. "+
+								"To suppress this warning, update the source to %q in your configuration.",
+							source, normalized, normalized),
+						Subject: &attr.Range,
+					})
+					source = normalized
+				}
+				provider.Source = source
 			}
 			if versionVal := val.GetAttr("version"); !versionVal.IsNull() {
 				provider.Version = versionVal.AsString()

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -16,6 +16,8 @@ package parser
 
 import (
 	"testing"
+
+	"github.com/hashicorp/hcl/v2"
 )
 
 func TestParseBasicConfig(t *testing.T) {
@@ -326,5 +328,236 @@ resource "aws_instance" "app" {
 		t.Error("Expected lifecycle block")
 	} else if !r2.Lifecycle.IgnoreAllChanges {
 		t.Error("Expected ignore_changes = all")
+	}
+}
+
+func TestHashicorpToPublumiSourceMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		source         string
+		expectedSource string
+		expectWarning  bool
+	}{
+		{
+			name:           "hashicorp source auto-mapped",
+			source:         "hashicorp/aws",
+			expectedSource: "pulumi/aws",
+			expectWarning:  true,
+		},
+		{
+			name:           "pulumi source unchanged",
+			source:         "pulumi/aws",
+			expectedSource: "pulumi/aws",
+			expectWarning:  false,
+		},
+		{
+			name:           "hashicorp random provider",
+			source:         "hashicorp/random",
+			expectedSource: "pulumi/random",
+			expectWarning:  true,
+		},
+		{
+			name:           "other namespace unchanged",
+			source:         "example/custom",
+			expectedSource: "example/custom",
+			expectWarning:  false,
+		},
+		// Case-insensitive tests
+		{
+			name:           "HashiCorp capitalized",
+			source:         "HashiCorp/aws",
+			expectedSource: "pulumi/aws",
+			expectWarning:  true,
+		},
+		{
+			name:           "HASHICORP uppercase",
+			source:         "HASHICORP/aws",
+			expectedSource: "pulumi/aws",
+			expectWarning:  true,
+		},
+		{
+			name:           "Hashicorp titlecase",
+			source:         "Hashicorp/AWS",
+			expectedSource: "pulumi/aws",
+			expectWarning:  true,
+		},
+		// Edge cases
+		{
+			name:           "empty source",
+			source:         "",
+			expectedSource: "",
+			expectWarning:  false,
+		},
+		{
+			name:           "namespace only no provider",
+			source:         "hashicorp/",
+			expectedSource: "pulumi/",
+			expectWarning:  true,
+		},
+		{
+			name:           "registry hostname prefix unchanged",
+			source:         "registry.terraform.io/hashicorp/aws",
+			expectedSource: "registry.terraform.io/hashicorp/aws",
+			expectWarning:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := []byte(`
+terraform {
+  required_providers {
+    test = {
+      source  = "` + tt.source + `"
+      version = ">= 1.0"
+    }
+  }
+}
+`)
+
+			p := NewParser()
+			config, diags := p.ParseSource("test.hcl", src)
+
+			if diags.HasErrors() {
+				for _, d := range diags {
+					t.Errorf("Unexpected error: %s: %s", d.Summary, d.Detail)
+				}
+				t.FailNow()
+			}
+
+			// Verify source was mapped correctly
+			rp, ok := config.Terraform.RequiredProviders["test"]
+			if !ok {
+				t.Fatal("Expected 'test' in required providers")
+			}
+
+			if rp.Source != tt.expectedSource {
+				t.Errorf("Expected source %q, got %q", tt.expectedSource, rp.Source)
+			}
+
+			// Check for warning diagnostic
+			hasWarning := false
+			for _, d := range diags {
+				if d.Severity == hcl.DiagWarning && d.Summary == "Provider source automatically mapped" {
+					hasWarning = true
+					break
+				}
+			}
+
+			if tt.expectWarning && !hasWarning {
+				t.Error("Expected warning diagnostic for hashicorp/ source mapping")
+			}
+			if !tt.expectWarning && hasWarning {
+				t.Error("Did not expect warning diagnostic")
+			}
+		})
+	}
+}
+
+func TestHashicorpSourceMappingMixedProviders(t *testing.T) {
+	src := []byte(`
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    random = {
+      source  = "pulumi/random"
+      version = ">= 4.0"
+    }
+    gcp = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+`)
+
+	p := NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+
+	if diags.HasErrors() {
+		for _, d := range diags {
+			t.Errorf("Unexpected error: %s: %s", d.Summary, d.Detail)
+		}
+		t.FailNow()
+	}
+
+	// Verify aws was mapped
+	if aws, ok := config.Terraform.RequiredProviders["aws"]; ok {
+		if aws.Source != "pulumi/aws" {
+			t.Errorf("Expected aws source 'pulumi/aws', got %q", aws.Source)
+		}
+	} else {
+		t.Error("Expected 'aws' in required providers")
+	}
+
+	// Verify random was unchanged
+	if random, ok := config.Terraform.RequiredProviders["random"]; ok {
+		if random.Source != "pulumi/random" {
+			t.Errorf("Expected random source 'pulumi/random', got %q", random.Source)
+		}
+	} else {
+		t.Error("Expected 'random' in required providers")
+	}
+
+	// Verify gcp was mapped
+	if gcp, ok := config.Terraform.RequiredProviders["gcp"]; ok {
+		if gcp.Source != "pulumi/google" {
+			t.Errorf("Expected gcp source 'pulumi/google', got %q", gcp.Source)
+		}
+	} else {
+		t.Error("Expected 'gcp' in required providers")
+	}
+
+	// Count warning diagnostics - should have 2 (aws and gcp)
+	warningCount := 0
+	for _, d := range diags {
+		if d.Severity == hcl.DiagWarning && d.Summary == "Provider source automatically mapped" {
+			warningCount++
+		}
+	}
+
+	if warningCount != 2 {
+		t.Errorf("Expected 2 warning diagnostics, got %d", warningCount)
+	}
+}
+
+func TestHashicorpMappingWithVersionOnly(t *testing.T) {
+	// Version-only syntax has no source field, so no mapping should occur
+	src := []byte(`
+terraform {
+  required_providers {
+    aws = ">= 6.0"
+  }
+}
+`)
+	p := NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+
+	if diags.HasErrors() {
+		t.Fatalf("Unexpected error: %v", diags)
+	}
+
+	rp, ok := config.Terraform.RequiredProviders["aws"]
+	if !ok {
+		t.Fatal("Expected 'aws' in required providers")
+	}
+
+	// Version-only declarations have no source
+	if rp.Source != "" {
+		t.Errorf("Expected empty source, got %q", rp.Source)
+	}
+
+	if rp.Version != ">= 6.0" {
+		t.Errorf("Expected version '>= 6.0', got %q", rp.Version)
+	}
+
+	// No warning should be emitted
+	for _, d := range diags {
+		if d.Severity == hcl.DiagWarning && d.Summary == "Provider source automatically mapped" {
+			t.Error("Did not expect warning for version-only declaration")
+		}
 	}
 }


### PR DESCRIPTION
Automatically maps `hashicorp/` provider sources to `pulumi/` during parsing, eliminating the need for manual changes when migrating Terraform configurations.

## Changes

- Add case-insensitive source mapping in `parseRequiredProviders()`
- Emit warning diagnostic when mapping occurs with instructions to suppress
- Update documentation in `terraform-compatibility.md`
- Add comprehensive test coverage for mapping behavior

## Example

```hcl
# This now works without manual changes:
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"  # automatically becomes "pulumi/aws"
      version = ">= 6.0"
    }
  }
}
```