### PR TITLE
One graph for modules

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -133,7 +133,6 @@ var expectedFailures = map[string]string{
 	"l2-plain": "unsupported in HCL:" +
 		" requires that HCL can distinguish between an empty and null List<Object>" +
 		" - not compatible with block syntax",
-	"l3-deferred-outputs": "unsupported in HCL: ConditionalExpression not yet implemented in codegen",
 	"l2-logical-name": "unsupported in HCL: __logicalName support not yet implemented" +
 		" - requires mapping between lexical names (code references) and logical names (resource names)",
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-deferred-outputs/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-deferred-outputs/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-deferred-outputs
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-deferred-outputs/first/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-deferred-outputs/first/main.pp
@@ -1,0 +1,19 @@
+resource "first-untainted" "simple:index:Resource" {
+  value = true
+}
+
+resource "first-tainted" "simple:index:Resource" {
+  value = !input
+}
+
+config "input" "bool" {
+}
+
+output "untainted" {
+  value = first-untainted.value
+}
+
+output "tainted" {
+  value = first-tainted.value
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-deferred-outputs/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-deferred-outputs/main.pp
@@ -1,0 +1,19 @@
+component "first" "./first" {
+  input = second.untainted
+}
+
+component "second" "./second" {
+  input = first.untainted
+}
+
+component "another" "./first" {
+  input = join("", [for _, v in many : v.untainted ? "a" : "b"]) == "xyz"
+}
+
+component "many" "./second" {
+  input = another.untainted
+  options {
+    range = 2
+  }
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-deferred-outputs/second/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-deferred-outputs/second/main.pp
@@ -1,0 +1,19 @@
+resource "second-untainted" "simple:index:Resource" {
+  value = true
+}
+
+resource "second-tainted" "simple:index:Resource" {
+  value = !input
+}
+
+config "input" "bool" {
+}
+
+output "untainted" {
+  value = second-untainted.value
+}
+
+output "tainted" {
+  value = second-tainted.value
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-deferred-outputs
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/first/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/first/main.hcl
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "first-untainted" {
+  value = true
+}
+resource "simple_resource" "first-tainted" {
+  value = ! var.input
+}
+variable "input" {
+  type = bool
+}
+output "untainted" {
+  value = simple_resource.first-untainted.value
+}
+output "tainted" {
+  value = simple_resource.first-tainted.value
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/main.hcl
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+module "first" {
+  source = "./first"
+  input  = module.second.untainted
+}
+module "second" {
+  source = "./second"
+  input  = module.first.untainted
+}
+module "another" {
+  source = "./first"
+  input  = join("", [for _, v in module.many : v.untainted ? "a" : "b"]) == "xyz"
+}
+module "many" {
+  source = "./second"
+  count  = 2
+  input  = module.another.untainted
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/second/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/second/main.hcl
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "second-untainted" {
+  value = true
+}
+resource "simple_resource" "second-tainted" {
+  value = ! var.input
+}
+variable "input" {
+  type = bool
+}
+output "untainted" {
+  value = simple_resource.second-untainted.value
+}
+output "tainted" {
+  value = simple_resource.second-tainted.value
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-deferred-outputs
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/first/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/first/main.hcl
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "first-untainted" {
+  value = true
+}
+resource "simple_resource" "first-tainted" {
+  value = ! var.input
+}
+variable "input" {
+  type = bool
+}
+output "untainted" {
+  value = simple_resource.first-untainted.value
+}
+output "tainted" {
+  value = simple_resource.first-tainted.value
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/main.hcl
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+module "first" {
+  source = "./first"
+  input  = module.second.untainted
+}
+module "second" {
+  source = "./second"
+  input  = module.first.untainted
+}
+module "another" {
+  source = "./first"
+  input  = join("", [for _, v in module.many : v.untainted ? "a" : "b"]) == "xyz"
+}
+module "many" {
+  source = "./second"
+  count  = 2
+  input  = module.another.untainted
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/second/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/second/main.hcl
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "second-untainted" {
+  value = true
+}
+resource "simple_resource" "second-tainted" {
+  value = ! var.input
+}
+variable "input" {
+  type = bool
+}
+output "untainted" {
+  value = simple_resource.second-untainted.value
+}
+output "tainted" {
+  value = simple_resource.second-tainted.value
+}

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1014,10 +1014,18 @@ func (g *generator) genOutput(body *hclwrite.Body, ov *pcl.OutputVariable) hcl.D
 }
 
 func (g *generator) genModule(body *hclwrite.Body, c *pcl.Component) hcl.Diagnostics {
+	defer func() { g.currentRangeKind = rangeKindNone }()
+
 	block := body.AppendNewBlock("module", []string{c.LogicalName()})
 	source := "./" + filepath.Base(c.DirPath())
 	block.Body().SetAttributeValue("source", cty.StringVal(source))
 	var diags hcl.Diagnostics
+
+	if c.Options != nil && c.Options.Range != nil {
+		d := g.genRange(block.Body(), c.Options.Range)
+		diags = append(diags, d...)
+	}
+
 	for _, attr := range c.Inputs {
 		d := g.genExpression(block.Body(), attr.Name, attr.Value, schema.AnyType)
 		diags = append(diags, d...)
@@ -1182,6 +1190,8 @@ func (g *generator) exprTokens(expr model.Expression, typ schema.Type) (hclwrite
 		return g.forExprTokens(e)
 	case *model.SplatExpression:
 		return g.splatTokens(e)
+	case *model.ConditionalExpression:
+		return g.conditionalTokens(e)
 	default:
 		return nil, hcl.Diagnostics{{
 			Severity: hcl.DiagError,
@@ -1944,6 +1954,43 @@ func (g *generator) binaryOpTokens(expr *model.BinaryOpExpression) (hclwrite.Tok
 		rightTokens[0].SpacesBefore = 1
 	}
 	tokens = append(tokens, rightTokens...)
+	return tokens, diags
+}
+
+// conditionalTokens generates HCL tokens for a conditional expression (condition ? true : false).
+func (g *generator) conditionalTokens(expr *model.ConditionalExpression) (hclwrite.Tokens, hcl.Diagnostics) {
+	condTokens, diags := g.exprTokens(expr.Condition, schema.AnyType)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	trueTokens, d := g.exprTokens(expr.TrueResult, schema.AnyType)
+	diags = append(diags, d...)
+	if d.HasErrors() {
+		return nil, diags
+	}
+
+	falseTokens, d := g.exprTokens(expr.FalseResult, schema.AnyType)
+	diags = append(diags, d...)
+	if d.HasErrors() {
+		return nil, diags
+	}
+
+	tokens := condTokens
+	tokens = append(tokens, &hclwrite.Token{
+		Type: hclsyntax.TokenQuestion, Bytes: []byte("?"), SpacesBefore: 1,
+	})
+	if len(trueTokens) > 0 {
+		trueTokens[0].SpacesBefore = 1
+	}
+	tokens = append(tokens, trueTokens...)
+	tokens = append(tokens, &hclwrite.Token{
+		Type: hclsyntax.TokenColon, Bytes: []byte(":"), SpacesBefore: 1,
+	})
+	if len(falseTokens) > 0 {
+		falseTokens[0].SpacesBefore = 1
+	}
+	tokens = append(tokens, falseTokens...)
 	return tokens, diags
 }
 

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -396,11 +396,22 @@ func transformHCLFileToPCL(
 				continue
 			}
 			blk := out.AppendNewBlock("component", []string{logicalName, sourceVal.AsString()})
+			var rangeExpr hclsyntax.Expression
 			for _, attr := range sortedAttributes(block.Body.Attributes) {
-				if attr.Name == "source" {
+				switch attr.Name {
+				case "source":
+					continue
+				case "count", "for_each":
+					rangeExpr = attr.Expr
+					continue
+				case "depends_on", "providers", "version":
 					continue
 				}
 				blk.Body().SetAttributeRaw(attr.Name, ft.transformExpr(attr.Expr))
+			}
+			if rangeExpr != nil {
+				optBlk := blk.Body().AppendNewBlock("options", nil)
+				optBlk.Body().SetAttributeRaw("range", ft.transformExpr(rangeExpr))
 			}
 			out.AppendNewline()
 

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -57,6 +57,9 @@ type Context struct {
 	// modules contains module outputs (module.name.*)
 	modules map[string]cty.Value
 
+	// moduleOutputs stores incremental per-output values: moduleName → outputName → value
+	moduleOutputs map[string]map[string]cty.Value
+
 	// providers contains provider references (provider.name)
 	providers map[string]cty.Value
 
@@ -122,7 +125,8 @@ func NewContext(baseDir, rootDir, stack, project, organization string) *Context 
 		locals:      make(map[string]cty.Value),
 		resources:   make(map[string]cty.Value),
 		dataSources: make(map[string]cty.Value),
-		modules:     make(map[string]cty.Value),
+		modules:       make(map[string]cty.Value),
+		moduleOutputs: make(map[string]map[string]cty.Value),
 		providers:   make(map[string]cty.Value),
 		calls:       make(map[string]cty.Value),
 		path: PathContext{
@@ -173,6 +177,17 @@ func (c *Context) SetModule(name string, value cty.Value) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.modules[name] = value
+}
+
+// SetModuleOutput stores a single module output incrementally.
+// These are assembled into module namespace objects in HCLContext().
+func (c *Context) SetModuleOutput(moduleName, outputName string, value cty.Value) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.moduleOutputs[moduleName] == nil {
+		c.moduleOutputs[moduleName] = make(map[string]cty.Value)
+	}
+	c.moduleOutputs[moduleName][outputName] = value
 }
 
 // SetCall sets the result of a method call.
@@ -291,9 +306,19 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 		vars["data"] = cty.EmptyObjectVal
 	}
 
-	// Add module.* namespace
-	if len(c.modules) > 0 {
-		vars["module"] = cty.ObjectVal(c.modules)
+	// Add module.* namespace — merge whole-module values and incremental outputs.
+	mergedModules := maps.Clone(c.modules)
+	for modName, outputs := range c.moduleOutputs {
+		if _, alreadySet := mergedModules[modName]; !alreadySet {
+			if len(outputs) > 0 {
+				mergedModules[modName] = cty.ObjectVal(outputs)
+			} else {
+				mergedModules[modName] = cty.EmptyObjectVal
+			}
+		}
+	}
+	if len(mergedModules) > 0 {
+		vars["module"] = cty.ObjectVal(mergedModules)
 	} else {
 		vars["module"] = cty.EmptyObjectVal
 	}
@@ -365,18 +390,24 @@ func (c *Context) Clone() *Context {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	clonedModuleOutputs := make(map[string]map[string]cty.Value, len(c.moduleOutputs))
+	for k, v := range c.moduleOutputs {
+		clonedModuleOutputs[k] = maps.Clone(v)
+	}
+
 	clone := &Context{
-		baseDir:     c.baseDir,
-		variables:   maps.Clone(c.variables),
-		locals:      maps.Clone(c.locals),
-		resources:   maps.Clone(c.resources),
-		dataSources: maps.Clone(c.dataSources),
-		modules:     maps.Clone(c.modules),
-		providers:   maps.Clone(c.providers),
-		calls:       maps.Clone(c.calls),
-		path:        c.path,
-		pulumi:      c.pulumi,
-		self:        c.self,
+		baseDir:       c.baseDir,
+		variables:     maps.Clone(c.variables),
+		locals:        maps.Clone(c.locals),
+		resources:     maps.Clone(c.resources),
+		dataSources:   maps.Clone(c.dataSources),
+		modules:       maps.Clone(c.modules),
+		moduleOutputs: clonedModuleOutputs,
+		providers:     maps.Clone(c.providers),
+		calls:         maps.Clone(c.calls),
+		path:          c.path,
+		pulumi:        c.pulumi,
+		self:          c.self,
 	}
 
 	if c.count != nil {

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -32,6 +32,26 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
+// ModuleInfo holds metadata for nodes that are part of an inlined module.
+type ModuleInfo struct {
+	Prefix       string     // e.g., "module.first." — prefixed to all internal keys
+	ModuleName   string     // e.g., "first"
+	Module       *ast.Module // the module block from the parent config
+	SourcePath   string     // resolved source path (for component type name)
+	ParentPrefix string     // "" for root-level modules, "module.outer." for nested
+}
+
+// LoadedModule represents a loaded and parsed module (used by ModuleLoader).
+type LoadedModule struct {
+	Config     *ast.Config
+	SourcePath string
+}
+
+// ModuleLoader loads module configurations from source paths.
+type ModuleLoader interface {
+	LoadModule(source string, workDir string) (*LoadedModule, error)
+}
+
 // Node represents a node in the dependency graph.
 type Node struct {
 	// Key is the unique identifier for this node (e.g., "aws_instance.web" or "local.common_tags")
@@ -60,6 +80,9 @@ type Node struct {
 
 	// Call is set for call nodes
 	Call *ast.Call
+
+	// ModuleInfo is set for nodes that belong to an inlined module.
+	ModuleInfo *ModuleInfo
 }
 
 // NodeType indicates what type of configuration element a node represents.
@@ -76,6 +99,7 @@ const (
 	NodeTypeProvider
 	NodeTypeBuiltin
 	NodeTypeCall
+	NodeTypeModuleInit
 )
 
 func (t NodeType) String() string {
@@ -98,6 +122,8 @@ func (t NodeType) String() string {
 		return "builtin"
 	case NodeTypeCall:
 		return "call"
+	case NodeTypeModuleInit:
+		return "module_init"
 	default:
 		return "unknown"
 	}
@@ -138,19 +164,16 @@ func (g *Graph) Walk(ctx context.Context, apply func(context.Context, *Node) err
 	}, pdag.MaxProcs(parallel))
 }
 
-// Inject a step to run after all nodes of kind nodeType, and before any other kind of node.
-//
-// This creates an inflection point in the graph. All nodes of type nodeType *must* come before all nodes of other
-// types.
-func (g *Graph) InjectAfter(f func(context.Context) error, nodeType NodeType) error {
+// InjectAfter injects a step to run after all nodes matching the predicate, and before any
+// other node. This creates an inflection point in the graph.
+func (g *Graph) InjectAfter(f func(context.Context) error, match func(*Node) bool) error {
 	n, done := g.dag.NewNode(dagNode{exec: f})
 	done()
 	for _, node := range g.seen {
 		var err error
-		switch node.n.Type {
-		case nodeType:
+		if match(node.n) {
 			err = g.dag.NewEdge(node.i, n)
-		default:
+		} else {
 			err = g.dag.NewEdge(n, node.i)
 		}
 		if err != nil {
@@ -189,7 +212,8 @@ func (g *Graph) AddNode(node *Node, deps []pdag.Node) error {
 }
 
 // BuildFromConfig builds a dependency graph from an HCL configuration.
-func BuildFromConfig(config *ast.Config) (*Graph, error) {
+// moduleLoader is required when config contains modules.
+func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir string) (*Graph, error) {
 	g := NewGraph()
 
 	contract.AssertNoErrorf(errors.Join(
@@ -221,7 +245,7 @@ func BuildFromConfig(config *ast.Config) (*Graph, error) {
 
 	// Add local value nodes
 	for name, local := range config.Locals {
-		deps := g.extractDependenciesFromExpression(local.Value)
+		deps := g.exprDeps(local.Value, "")
 		err := g.AddNode(&Node{
 			Key:   "local." + name,
 			Type:  NodeTypeLocal,
@@ -234,7 +258,7 @@ func BuildFromConfig(config *ast.Config) (*Graph, error) {
 
 	// Add provider nodes (must come before resources since resources can reference them)
 	for key, provider := range config.Providers {
-		deps := g.extractProviderDependencies(provider)
+		deps := g.providerDeps(provider, "")
 		err := g.AddNode(&Node{
 			Key:      key,
 			Type:     NodeTypeProvider,
@@ -247,7 +271,7 @@ func BuildFromConfig(config *ast.Config) (*Graph, error) {
 
 	// Add resource nodes
 	for key, resource := range config.Resources {
-		deps := g.extractResourceDependencies(resource)
+		deps := g.resourceDeps(resource, "")
 		err := g.AddNode(&Node{
 			Key:      key,
 			Type:     NodeTypeResource,
@@ -260,7 +284,7 @@ func BuildFromConfig(config *ast.Config) (*Graph, error) {
 
 	// Add data source nodes
 	for key, dataSource := range config.DataSources {
-		deps := g.extractResourceDependencies(dataSource)
+		deps := g.resourceDeps(dataSource, "")
 		err := g.AddNode(&Node{
 			Key:      "data." + key,
 			Type:     NodeTypeDataSource,
@@ -271,54 +295,20 @@ func BuildFromConfig(config *ast.Config) (*Graph, error) {
 		}
 	}
 
-	// Add module nodes
+	// Inline module contents into the graph for fine-grained dependency tracking.
 	for name, module := range config.Modules {
-		deps := g.extractModuleDependencies(module)
-		err := g.AddNode(&Node{
-			Key:    "module." + name,
-			Type:   NodeTypeModule,
-			Module: module,
-		}, deps)
-		if err != nil {
-			return nil, err
+		if err := g.inlineModule(name, module, "", moduleLoader, workDir); err != nil {
+			return nil, fmt.Errorf("inlining module %s: %w", name, err)
 		}
 	}
 
-	// Add call nodes (method invocations on resources)
-	for key, call := range config.Calls {
-		var deps []pdag.Node
-
-		// Depend on the resource or provider being called
-		for resKey, res := range config.Resources {
-			if res.Name == call.ResourceName {
-				_, idx := g.newNode(resKey)
-				deps = append(deps, idx)
-				break
-			}
-		}
-		if _, exists := config.Providers[call.ResourceName]; exists {
-			_, idx := g.newNode(call.ResourceName)
-			deps = append(deps, idx)
-		}
-
-		// Extract expression deps from args body
-		if call.Config != nil {
-			deps = append(deps, g.extractDependenciesFromBody(call.Config)...)
-		}
-
-		err := g.AddNode(&Node{
-			Key:  "call." + key,
-			Type: NodeTypeCall,
-			Call: call,
-		}, deps)
-		if err != nil {
-			return nil, err
-		}
+	if err := g.addCallNodes(config, "", nil); err != nil {
+		return nil, err
 	}
 
 	// Add output nodes
 	for name, output := range config.Outputs {
-		deps := g.extractDependenciesFromExpression(output.Value)
+		deps := g.exprDeps(output.Value, "")
 		err := g.AddNode(&Node{
 			Key:    "output." + name,
 			Type:   NodeTypeOutput,
@@ -332,162 +322,87 @@ func BuildFromConfig(config *ast.Config) (*Graph, error) {
 	return g, nil
 }
 
-// extractResourceDependencies extracts all dependencies from a resource.
-func (g *Graph) extractResourceDependencies(resource *ast.Resource) []pdag.Node {
+// resourceDeps extracts all dependencies from a resource, applying prefix to resolved keys.
+func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node {
 	seen := make(map[pdag.Node]bool)
 
-	// Extract from count expression
-	for _, dep := range g.extractDependenciesFromExpression(resource.Count) {
+	for _, dep := range g.exprDeps(resource.Count, prefix) {
 		seen[dep] = true
 	}
-
-	// Extract from for_each expression
-	for _, dep := range g.extractDependenciesFromExpression(resource.ForEach) {
+	for _, dep := range g.exprDeps(resource.ForEach, prefix) {
 		seen[dep] = true
 	}
-
-	// Extract from explicit depends_on
 	for _, traversal := range resource.DependsOn {
-		dep := formatTraversal(traversal)
-		if dep != "" {
-			_, idx := g.newNode(dep)
+		if dep := formatTraversal(traversal); dep != "" {
+			_, idx := g.newNode(prefix + dep)
 			seen[idx] = true
 		}
 	}
-
-	// Extract from parent resource reference
 	if resource.ResourceParent != nil {
-		dep := formatTraversal(resource.ResourceParent)
-		if dep != "" {
-			_, idx := g.newNode(dep)
+		if dep := formatTraversal(resource.ResourceParent); dep != "" {
+			_, idx := g.newNode(prefix + dep)
 			seen[idx] = true
 		}
 	}
-
-	// Extract from provider reference
 	if resource.Provider != nil {
 		providerKey := resource.Provider.Name
 		if resource.Provider.Alias != "" {
 			providerKey = resource.Provider.Name + "." + resource.Provider.Alias
 		}
-		_, idx := g.newNode(providerKey)
+		_, idx := g.newNode(prefix + providerKey)
 		seen[idx] = true
 	}
-
-	// Extract from providers list
 	for _, traversal := range resource.Providers {
-		dep := formatTraversal(traversal)
-		if dep != "" {
-			_, idx := g.newNode(dep)
+		if dep := formatTraversal(traversal); dep != "" {
+			_, idx := g.newNode(prefix + dep)
 			seen[idx] = true
 		}
 	}
-
-	// Extract from resource body (config block)
 	if resource.Config != nil {
-		bodyDeps := g.extractDependenciesFromBody(resource.Config)
-		for _, dep := range bodyDeps {
+		for _, dep := range g.bodyDeps(resource.Config, prefix, nil) {
 			seen[dep] = true
 		}
 	}
-
-	// Extract from deleted_with (resource reference)
 	if resource.DeletedWith != nil {
-		dep := formatTraversal(resource.DeletedWith)
-		if dep != "" {
-			_, idx := g.newNode(dep)
+		if dep := formatTraversal(resource.DeletedWith); dep != "" {
+			_, idx := g.newNode(prefix + dep)
 			seen[idx] = true
 		}
 	}
-
-	// Extract from replace_with (list of resource references)
 	for _, traversal := range resource.ReplaceWith {
-		dep := formatTraversal(traversal)
-		if dep != "" {
-			_, idx := g.newNode(dep)
+		if dep := formatTraversal(traversal); dep != "" {
+			_, idx := g.newNode(prefix + dep)
 			seen[idx] = true
 		}
 	}
-
-	// Extract from replacement_trigger expression
-	for _, dep := range g.extractDependenciesFromExpression(resource.ReplacementTrigger) {
+	for _, dep := range g.exprDeps(resource.ReplacementTrigger, prefix) {
 		seen[dep] = true
 	}
-
-	// Extract from additional_secret_outputs expression
-	for _, dep := range g.extractDependenciesFromExpression(resource.AdditionalSecretOutputs) {
+	for _, dep := range g.exprDeps(resource.AdditionalSecretOutputs, prefix) {
 		seen[dep] = true
 	}
-
-	// Extract from aliases expression
-	for _, dep := range g.extractDependenciesFromExpression(resource.Aliases) {
+	for _, dep := range g.exprDeps(resource.Aliases, prefix) {
 		seen[dep] = true
 	}
 
 	return slices.Collect(maps.Keys(seen))
 }
 
-// extractModuleDependencies extracts all dependencies from a module block.
-func (g *Graph) extractModuleDependencies(module *ast.Module) []pdag.Node {
-	seen := make(map[pdag.Node]bool)
-
-	// Extract from count expression
-	for _, dep := range g.extractDependenciesFromExpression(module.Count) {
-		seen[dep] = true
+// providerDeps extracts all dependencies from a provider block, applying prefix to resolved keys.
+func (g *Graph) providerDeps(provider *ast.Provider, prefix string) []pdag.Node {
+	if provider.Config == nil {
+		return nil
 	}
-
-	// Extract from for_each expression
-	for _, dep := range g.extractDependenciesFromExpression(module.ForEach) {
-		seen[dep] = true
-	}
-
-	// Extract from explicit depends_on
-	for _, traversal := range module.DependsOn {
-		dep := formatTraversal(traversal)
-		if dep != "" {
-			_, idx := g.newNode(dep)
-			seen[idx] = true
-		}
-	}
-
-	// Extract from module config body
-	if module.Config != nil {
-		bodyDeps := g.extractDependenciesFromBody(module.Config)
-		for _, dep := range bodyDeps {
-			seen[dep] = true
-		}
-	}
-
-	return slices.Collect(maps.Keys(seen))
+	return g.bodyDeps(provider.Config, prefix, nil)
 }
 
-// extractProviderDependencies extracts all dependencies from a provider block.
-func (g *Graph) extractProviderDependencies(provider *ast.Provider) []pdag.Node {
-	seen := make(map[pdag.Node]bool)
-
-	// Extract from provider config body
-	if provider.Config != nil {
-		bodyDeps := g.extractDependenciesFromBody(provider.Config)
-		for _, dep := range bodyDeps {
-			seen[dep] = true
-		}
-	}
-
-	return slices.Collect(maps.Keys(seen))
-}
-
-// extractDependenciesFromBody extracts dependencies from an HCL body,
-// including attributes and nested blocks (e.g., dynamic blocks).
-func (g *Graph) extractDependenciesFromBody(body hcl.Body) []pdag.Node {
-	return g.extractDependenciesFromBodyExcluding(body, nil)
-}
-
-func (g *Graph) extractDependenciesFromBodyExcluding(body hcl.Body, exclude map[string]bool) []pdag.Node {
+// bodyDeps extracts dependencies from an HCL body, applying prefix to resolved keys.
+func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) []pdag.Node {
 	seen := make(map[pdag.Node]bool)
 
 	attrs, _ := body.JustAttributes()
 	for _, attr := range attrs {
-		for _, dep := range g.extractDependenciesFromExpressionExcluding(attr.Expr, exclude) {
+		for _, dep := range g.exprDepsExcluding(attr.Expr, prefix, exclude) {
 			seen[dep] = true
 		}
 	}
@@ -495,24 +410,20 @@ func (g *Graph) extractDependenciesFromBodyExcluding(body hcl.Body, exclude map[
 	if syntaxBody, ok := body.(*hclsyntax.Body); ok {
 		for _, block := range syntaxBody.Blocks {
 			if block.Type == "dynamic" && len(block.Labels) > 0 {
-				// The iterator variable defaults to the block label.
 				iterName := block.Labels[0]
-				// Check for an explicit "iterator" attribute.
 				if iterAttr, ok := block.Body.Attributes["iterator"]; ok {
 					if keyword := hcl.ExprAsKeyword(iterAttr.Expr); keyword != "" {
 						iterName = keyword
 					}
 				}
 				childExclude := make(map[string]bool, len(exclude)+1)
-				for k, v := range exclude {
-					childExclude[k] = v
-				}
+				maps.Copy(childExclude, exclude)
 				childExclude[iterName] = true
-				for _, dep := range g.extractDependenciesFromBodyExcluding(block.Body, childExclude) {
+				for _, dep := range g.bodyDeps(block.Body, prefix, childExclude) {
 					seen[dep] = true
 				}
 			} else {
-				for _, dep := range g.extractDependenciesFromBodyExcluding(block.Body, exclude) {
+				for _, dep := range g.bodyDeps(block.Body, prefix, exclude) {
 					seen[dep] = true
 				}
 			}
@@ -522,13 +433,12 @@ func (g *Graph) extractDependenciesFromBodyExcluding(body hcl.Body, exclude map[
 	return slices.Collect(maps.Keys(seen))
 }
 
-// extractDependenciesFromExpression extracts ALL dependencies from an expression,
-// including var and local references (unlike eval.ExtractDependencies which only extracts resource deps).
-func (g *Graph) extractDependenciesFromExpression(expr hcl.Expression) []pdag.Node {
-	return g.extractDependenciesFromExpressionExcluding(expr, nil)
+// exprDeps extracts all dependencies from an expression, applying prefix to resolved keys.
+func (g *Graph) exprDeps(expr hcl.Expression, prefix string) []pdag.Node {
+	return g.exprDepsExcluding(expr, prefix, nil)
 }
 
-func (g *Graph) extractDependenciesFromExpressionExcluding(expr hcl.Expression, exclude map[string]bool) []pdag.Node {
+func (g *Graph) exprDepsExcluding(expr hcl.Expression, prefix string, exclude map[string]bool) []pdag.Node {
 	if expr == nil {
 		return nil
 	}
@@ -545,37 +455,32 @@ func (g *Graph) extractDependenciesFromExpressionExcluding(expr hcl.Expression, 
 		var dep string
 		switch namespace {
 		case "var":
-			// Variable reference: var.name
 			if len(parts) >= 1 {
-				dep = fmt.Sprintf("var.%s", parts[0])
+				dep = fmt.Sprintf("%svar.%s", prefix, parts[0])
 			}
 		case "local":
-			// Local reference: local.name
 			if len(parts) >= 1 {
-				dep = fmt.Sprintf("local.%s", parts[0])
+				dep = fmt.Sprintf("%slocal.%s", prefix, parts[0])
 			}
 		case "path", "terraform", "count", "each", "self":
-			// These are not node dependencies
 			continue
 		case "data":
-			// Data source reference: data.type.name
 			if len(parts) >= 2 {
-				dep = fmt.Sprintf("data.%s.%s", parts[0], parts[1])
+				dep = fmt.Sprintf("%sdata.%s.%s", prefix, parts[0], parts[1])
 			}
 		case "module":
-			// Module reference: module.name
-			if len(parts) >= 1 {
-				dep = fmt.Sprintf("module.%s", parts[0])
+			if len(parts) >= 2 {
+				dep = fmt.Sprintf("%smodule.%s.output.%s", prefix, parts[0], parts[1])
+			} else if len(parts) >= 1 {
+				dep = fmt.Sprintf("%smodule.%s", prefix, parts[0])
 			}
 		case "call":
-			// Call reference: call.resourceName.methodName
 			if len(parts) >= 2 {
-				dep = fmt.Sprintf("call.%s.%s", parts[0], parts[1])
+				dep = fmt.Sprintf("%scall.%s.%s", prefix, parts[0], parts[1])
 			}
 		default:
-			// Resource reference: type.name (namespace is the type)
 			if len(parts) >= 1 {
-				dep = fmt.Sprintf("%s.%s", namespace, parts[0])
+				dep = fmt.Sprintf("%s%s.%s", prefix, namespace, parts[0])
 			}
 		}
 
@@ -589,7 +494,6 @@ func (g *Graph) extractDependenciesFromExpressionExcluding(expr hcl.Expression, 
 		_, n := g.newNode(dep)
 		result[i] = n
 	}
-
 	return result
 }
 
@@ -651,6 +555,189 @@ func (g *Graph) Validate() []error {
 	}
 
 	return errors
+}
+
+// inlineModule loads a module and inlines its contents into the graph with a prefix.
+func (g *Graph) inlineModule(
+	name string, mod *ast.Module, parentPrefix string,
+	moduleLoader ModuleLoader, workDir string,
+) error {
+	loaded, err := moduleLoader.LoadModule(mod.Source, workDir)
+	if err != nil {
+		return fmt.Errorf("loading module %s: %w", name, err)
+	}
+
+	prefix := parentPrefix + "module." + name + "."
+	modInfo := &ModuleInfo{
+		Prefix:       prefix,
+		ModuleName:   name,
+		Module:       mod,
+		SourcePath:   loaded.SourcePath,
+		ParentPrefix: parentPrefix,
+	}
+
+	// Init node: depends on count/for_each/depends_on from parent scope.
+	initKey := prefix + "__init__"
+	var initDeps []pdag.Node
+	initDeps = append(initDeps, g.exprDeps(mod.Count, parentPrefix)...)
+	initDeps = append(initDeps, g.exprDeps(mod.ForEach, parentPrefix)...)
+	for _, traversal := range mod.DependsOn {
+		if dep := formatTraversal(traversal); dep != "" {
+			_, idx := g.newNode(parentPrefix + dep)
+			initDeps = append(initDeps, idx)
+		}
+	}
+	if err := g.AddNode(&Node{
+		Key:        initKey,
+		Type:       NodeTypeModuleInit,
+		Module:     mod,
+		ModuleInfo: modInfo,
+	}, initDeps); err != nil {
+		return err
+	}
+
+	_, initIdx := g.newNode(initKey)
+
+	// Variables: each depends on init + the corresponding input expression from the module block.
+	moduleInputAttrs, _ := mod.Config.JustAttributes()
+	for varName, v := range loaded.Config.Variables {
+		varDeps := []pdag.Node{initIdx}
+		if inputAttr, ok := moduleInputAttrs[varName]; ok {
+			varDeps = append(varDeps, g.exprDeps(inputAttr.Expr, parentPrefix)...)
+		}
+		if err := g.AddNode(&Node{
+			Key:        prefix + "var." + varName,
+			Type:       NodeTypeVariable,
+			Variable:   v,
+			ModuleInfo: modInfo,
+		}, varDeps); err != nil {
+			return err
+		}
+	}
+
+	// Locals
+	for localName, local := range loaded.Config.Locals {
+		if err := g.AddNode(&Node{
+			Key:        prefix + "local." + localName,
+			Type:       NodeTypeLocal,
+			Local:      local,
+			ModuleInfo: modInfo,
+		}, g.exprDeps(local.Value, prefix)); err != nil {
+			return err
+		}
+	}
+
+	// Providers
+	for key, provider := range loaded.Config.Providers {
+		if err := g.AddNode(&Node{
+			Key:        prefix + key,
+			Type:       NodeTypeProvider,
+			Provider:   provider,
+			ModuleInfo: modInfo,
+		}, g.providerDeps(provider, prefix)); err != nil {
+			return err
+		}
+	}
+
+	// Resources
+	for key, resource := range loaded.Config.Resources {
+		deps := g.resourceDeps(resource, prefix)
+		deps = append(deps, initIdx)
+		if err := g.AddNode(&Node{
+			Key:        prefix + key,
+			Type:       NodeTypeResource,
+			Resource:   resource,
+			ModuleInfo: modInfo,
+		}, deps); err != nil {
+			return err
+		}
+	}
+
+	// Data sources
+	for key, ds := range loaded.Config.DataSources {
+		deps := g.resourceDeps(ds, prefix)
+		deps = append(deps, initIdx)
+		if err := g.AddNode(&Node{
+			Key:        prefix + "data." + key,
+			Type:       NodeTypeDataSource,
+			Resource:   ds,
+			ModuleInfo: modInfo,
+		}, deps); err != nil {
+			return err
+		}
+	}
+
+	// Outputs
+	for outputName, output := range loaded.Config.Outputs {
+		if err := g.AddNode(&Node{
+			Key:        prefix + "output." + outputName,
+			Type:       NodeTypeOutput,
+			Output:     output,
+			ModuleInfo: modInfo,
+		}, g.exprDeps(output.Value, prefix)); err != nil {
+			return err
+		}
+	}
+
+	// Completion node: depends on all outputs + init.
+	completionKey := parentPrefix + "module." + name
+	completionDeps := []pdag.Node{initIdx}
+	for outputName := range loaded.Config.Outputs {
+		_, idx := g.newNode(prefix + "output." + outputName)
+		completionDeps = append(completionDeps, idx)
+	}
+	if err := g.AddNode(&Node{
+		Key:        completionKey,
+		Type:       NodeTypeModule,
+		Module:     mod,
+		ModuleInfo: modInfo,
+	}, completionDeps); err != nil {
+		return err
+	}
+
+	if err := g.addCallNodes(loaded.Config, prefix, modInfo); err != nil {
+		return err
+	}
+
+	// Nested modules
+	for nestedName, nestedMod := range loaded.Config.Modules {
+		if err := g.inlineModule(nestedName, nestedMod, prefix, moduleLoader, loaded.SourcePath); err != nil {
+			return fmt.Errorf("inlining nested module %s: %w", nestedName, err)
+		}
+	}
+
+	return nil
+}
+
+// addCallNodes adds call nodes from config into the graph with the given prefix.
+func (g *Graph) addCallNodes(config *ast.Config, prefix string, modInfo *ModuleInfo) error {
+	for key, call := range config.Calls {
+		callKey := prefix + "call." + key
+		var deps []pdag.Node
+		for resKey, res := range config.Resources {
+			if res.Name == call.ResourceName {
+				_, idx := g.newNode(prefix + resKey)
+				deps = append(deps, idx)
+				break
+			}
+		}
+		if _, exists := config.Providers[call.ResourceName]; exists {
+			_, idx := g.newNode(prefix + call.ResourceName)
+			deps = append(deps, idx)
+		}
+		if call.Config != nil {
+			deps = append(deps, g.bodyDeps(call.Config, prefix, nil)...)
+		}
+		if err := g.AddNode(&Node{
+			Key:        callKey,
+			Type:       NodeTypeCall,
+			Call:       call,
+			ModuleInfo: modInfo,
+		}, deps); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func addToSortedListAsSet[S ~[]E, E cmp.Ordered](s *S, element E) {

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -47,7 +47,7 @@ output "instance_id" {
 	config, diags := p.ParseSource("test.hcl", src)
 	require.Empty(t, diags)
 
-	g, err := BuildFromConfig(config)
+	g, err := BuildFromConfig(config, nil, "")
 	require.NoError(t, err)
 
 	nodes := g.seen

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2006,7 +2006,7 @@ func (e *Engine) processModuleInstance(ctx context.Context, mod *ast.Module, ins
 	}
 
 	// Create a child engine to execute the module
-	childEngine := e.createChildEngine(loadedModule.Config, componentURN, loadedModule.SourcePath)
+	childEngine := e.createChildEngine(loadedModule.Config, componentURN)
 
 	// Set up the child engine's variables with module inputs
 	if diags := childEngine.setModuleInputs(attrs, e.evaluator.Context()); diags.HasErrors() {
@@ -2099,11 +2099,10 @@ func (e *Engine) registerComponentResource(
 }
 
 // createChildEngine creates a child engine for executing a module.
-func (e *Engine) createChildEngine(config *ast.Config, parentURN string, moduleDir string) *Engine {
+func (e *Engine) createChildEngine(config *ast.Config, parentURN string) *Engine {
 	return &Engine{
-		config: config,
-		evaluator: eval.NewEvaluator(eval.NewContext(moduleDir, moduleDir,
-			e.stackName, e.projectName, e.organization)),
+		config:                  config,
+		evaluator:               e.evaluator,
 		pkgLoader:               e.pkgLoader,
 		resmon:                  e.resmon,
 		resourceOutputs:         util.NewSyncMap[string, cty.Value](),
@@ -2113,7 +2112,7 @@ func (e *Engine) createChildEngine(config *ast.Config, parentURN string, moduleD
 		stackName:               e.stackName,
 		organization:            e.organization,
 		dryRun:                  e.dryRun,
-		workDir:                 moduleDir,
+		workDir:                 e.workDir,
 		pulumiConfig:            e.pulumiConfig,
 		configSecretKeys:        e.configSecretKeys,
 		moduleLoader:            e.moduleLoader,

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -164,6 +164,17 @@ type CallResponse struct {
 	Failures []string
 }
 
+// moduleInstance represents a single runtime instance of an inlined module.
+type moduleInstance struct {
+	Key     string        // e.g., "module.first" or "module.first[0]"
+	EvalCtx *eval.Context // per-instance evaluation context
+	URN     string        // component URN
+	Index   *int          // count index (nil if not using count)
+	EachKey *cty.Value    // for_each key (nil if not using for_each)
+	EachVal *cty.Value    // for_each value (nil if not using for_each)
+	Outputs map[string]cty.Value // collected output values
+}
+
 // inheritableOpts holds the resource options that child resources can inherit from their parent.
 type inheritableOpts struct {
 	Protect        *bool
@@ -229,11 +240,8 @@ type Engine struct {
 	// moduleLoader loads and caches module configurations.
 	moduleLoader *modules.Loader
 
-	// moduleOutputs maps module keys to their output values.
-	moduleOutputs map[string]cty.Value
-
-	// parentURN is the parent resource URN (for child modules).
-	parentURN string
+	// moduleInstances maps module prefix → list of instances for inlined modules.
+	moduleInstances *util.SyncMap[string, []*moduleInstance]
 
 	parallel int
 
@@ -308,7 +316,7 @@ func NewEngine(config *ast.Config, opts *EngineOptions) *Engine {
 		packages:                opts.Packages,
 		packageRefs:             make(map[string]PackageRef),
 		moduleLoader:            modules.NewLoader(),
-		moduleOutputs:           make(map[string]cty.Value),
+		moduleInstances:         util.NewSyncMap[string, []*moduleInstance](),
 		parallel:                opts.Parallel,
 		failedNodes:             util.NewSyncMap[string, error](),
 	}
@@ -331,8 +339,8 @@ func (e *Engine) Run(ctx context.Context) error {
 		return fmt.Errorf("registering stack: %w", err)
 	}
 
-	// Build the dependency graph
-	g, err := graph.BuildFromConfig(e.config)
+	// Build the dependency graph with module inlining
+	g, err := graph.BuildFromConfig(e.config, &moduleLoaderAdapter{e.moduleLoader}, e.workDir)
 	if err != nil {
 		return fmt.Errorf("building dependency graph: %w", err)
 	}
@@ -409,17 +417,20 @@ func (e *Engine) processNode(ctx context.Context, node *graph.Node) error {
 		return e.processResource(ctx, node)
 	case graph.NodeTypeDataSource:
 		return e.processDataSource(ctx, node)
+	case graph.NodeTypeModuleInit:
+		return e.processModuleInit(ctx, node)
 	case graph.NodeTypeModule:
-		return e.processModule(ctx, node)
+		return e.processModuleComplete(ctx, node)
 	case graph.NodeTypeCall:
 		return e.processCall(ctx, node)
 	case graph.NodeTypeOutput:
-		// Outputs are processed after the main loop
+		if node.ModuleInfo != nil {
+			return e.processModuleOutput(ctx, node)
+		}
 		return nil
 	case graph.NodeTypeProvider:
 		return e.processProvider(ctx, node)
 	case graph.NodeTypeBuiltin:
-		// We don't need to evaluate builtins
 		return nil
 	case graph.NodeTypeUnknown:
 		return errors.New("unknown node type")
@@ -429,7 +440,9 @@ func (e *Engine) processNode(ctx context.Context, node *graph.Node) error {
 }
 
 func (e *Engine) processGraph(ctx context.Context, g *graph.Graph) error {
-	if err := g.InjectAfter(e.checkPulumiVersion, graph.NodeTypeVariable); err != nil {
+	if err := g.InjectAfter(e.checkPulumiVersion, func(n *graph.Node) bool {
+		return n.Type == graph.NodeTypeVariable && n.ModuleInfo == nil
+	}); err != nil {
 		return err
 	}
 	return g.Walk(ctx, e.processNode, e.parallel)
@@ -442,25 +455,23 @@ func (e *Engine) processVariable(_ context.Context, node *graph.Node) error {
 		return fmt.Errorf("variable node missing Variable field")
 	}
 
+	// Module variable: evaluate input expression in parent context, store in each instance context.
+	if node.ModuleInfo != nil {
+		return e.processModuleVariable(node)
+	}
+
 	varName := node.Key[4:] // Remove "var." prefix
 	var val cty.Value
 	var isSecret bool
 	var valueSource string
 
 	// Variable value precedence (highest to lowest):
-	// 0. Already there (as produced by the parent when this is a child module)
 	// 1. Environment variable TF_VAR_<name>
 	// 2. Pulumi stack config (projectName:<name>)
 	// 3. Default value
 
 	if e.evaluator.Context().HCLContext().Variables["var"].Type().HasAttribute(varName) {
-		// This would imply that there are multiple variables setting the same name.
-		if e.parentURN == "" {
-			return fmt.Errorf("%q already evaluated", varName)
-		}
-
-		// The variable is already set, so we don't need to do anything.
-		return nil
+		return fmt.Errorf("%q already evaluated", varName)
 	}
 
 	// Check environment variable first
@@ -624,13 +635,23 @@ func (e *Engine) processLocal(ctx context.Context, node *graph.Node) error {
 		return fmt.Errorf("local node missing Local field")
 	}
 
-	// Evaluate the local value expression, intercepting can() calls.
+	if node.ModuleInfo != nil {
+		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
+			localName := strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix+"local.")
+			val, diags := local.Value.Value(inst.EvalCtx.HCLContext())
+			if diags.HasErrors() {
+				return fmt.Errorf("evaluating local value %s: %s", localName, diags.Error())
+			}
+			inst.EvalCtx.SetLocal(localName, val)
+			return nil
+		})
+	}
+
 	val, diags := e.evaluator.EvaluateExpression(local.Value)
 	if diags.HasErrors() {
 		return fmt.Errorf("evaluating local value: %s", diags.Error())
 	}
 
-	// Store in eval context
 	localName := node.Key[6:] // Remove "local." prefix
 	e.evaluator.Context().SetLocal(localName, val)
 
@@ -644,22 +665,31 @@ func (e *Engine) processProvider(ctx context.Context, node *graph.Node) error {
 		return fmt.Errorf("provider node missing Provider field")
 	}
 
-	// Construct the provider type token: "pulumi:providers:<provider-name>"
+	if node.ModuleInfo != nil {
+		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
+			return e.registerProviderInContext(ctx, node, provider, inst.EvalCtx, inst.URN, inst)
+		})
+	}
+
+	return e.registerProviderInContext(ctx, node, provider, e.evaluator.Context(), e.stackURN, nil)
+}
+
+func (e *Engine) registerProviderInContext(
+	ctx context.Context, node *graph.Node, provider *ast.Provider,
+	evalCtx *eval.Context, parentURN string, modInst *moduleInstance,
+) error {
 	typeToken := "pulumi:providers:" + provider.Name
 
-	// Evaluate provider configuration
 	attrs, _ := provider.Config.JustAttributes()
 	inputs := make(map[string]property.Value)
 
-	// TODO: This needs to lookup a resource schema & then use transform methods
-
+	hclCtx := evalCtx.HCLContext()
 	for name, attr := range attrs {
-		// Skip the alias attribute as it's not part of the provider configuration
 		if name == "alias" {
 			continue
 		}
 
-		val, diags := e.evaluator.EvaluateExpression(attr.Expr)
+		val, diags := attr.Expr.Value(hclCtx)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating provider attribute %s: %s", name, diags.Error())
 		}
@@ -672,11 +702,13 @@ func (e *Engine) processProvider(ctx context.Context, node *graph.Node) error {
 		inputs[name] = pv
 	}
 
-	// Register the provider resource
-	// The logical name for the provider is its alias (stored in node.Key)
 	logicalName := provider.Alias
 	if logicalName == "" {
 		logicalName = provider.Name
+	}
+	if modInst != nil {
+		modInstanceName := extractResourceName(modInst.Key)
+		logicalName = modInstanceName + "-" + logicalName
 	}
 
 	resp, err := e.resmon.RegisterResource(ctx, RegisterResourceRequest{
@@ -684,15 +716,14 @@ func (e *Engine) processProvider(ctx context.Context, node *graph.Node) error {
 		Name:   logicalName,
 		Inputs: property.NewMap(inputs),
 		Custom: true,
+		Parent: parentURN,
 	})
 	if err != nil {
 		return fmt.Errorf("registering provider %s: %w", node.Key, err)
 	}
 
-	// Provider resources should return an ID from the engine
 	providerID := resp.ID
 
-	// Store the provider outputs in the same format as regular resources
 	outputObj := make(map[string]cty.Value)
 	outputObj["id"] = cty.StringVal(providerID)
 	outputObj["urn"] = cty.StringVal(resp.URN)
@@ -703,7 +734,14 @@ func (e *Engine) processProvider(ctx context.Context, node *graph.Node) error {
 	}
 
 	e.resourceOutputs.Set(node.Key, cty.ObjectVal(outputObj))
-	e.evaluator.Context().SetResource(node.Key, cty.ObjectVal(outputObj))
+
+	if node.ModuleInfo != nil {
+		// Strip prefix for module-internal references
+		bareKey := strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix)
+		evalCtx.SetResource(bareKey, cty.ObjectVal(outputObj))
+	} else {
+		evalCtx.SetResource(node.Key, cty.ObjectVal(outputObj))
+	}
 
 	return nil
 }
@@ -715,17 +753,30 @@ func (e *Engine) processResource(ctx context.Context, node *graph.Node) error {
 		return fmt.Errorf("resource node missing Resource field")
 	}
 
-	// Resolve the resource type to a Pulumi type token.
+	if node.ModuleInfo != nil {
+		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
+			return e.processResourceInContext(ctx, node, res, inst.EvalCtx, inst.URN, inst)
+		})
+	}
+
+	return e.processResourceInContext(ctx, node, res, e.evaluator.Context(), e.stackURN, nil)
+}
+
+func (e *Engine) processResourceInContext(
+	ctx context.Context, node *graph.Node, res *ast.Resource,
+	evalCtx *eval.Context, parentURN string, modInst *moduleInstance,
+) error {
 	resSchema, err := packages.ResolveResource(ctx, e.pkgLoader, e.knownProviders(), res.Type)
 	if err != nil {
 		return fmt.Errorf("resolving resource type %s: %w", res.Type, err)
 	}
 
-	// Check for count/for_each expansion
+	tempEvaluator := eval.NewEvaluator(evalCtx)
+
 	expander := graph.NewResourceExpander()
 
 	if res.Count != nil {
-		count, isBool, diags := e.evaluator.EvaluateCount(res.Count)
+		count, isBool, diags := tempEvaluator.EvaluateCount(res.Count)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating count: %s", diags.Error())
 		}
@@ -737,24 +788,23 @@ func (e *Engine) processResource(ctx context.Context, node *graph.Node) error {
 	}
 
 	if res.ForEach != nil {
-		forEach, diags := e.evaluator.EvaluateForEach(res.ForEach)
+		forEach, diags := tempEvaluator.EvaluateForEach(res.ForEach)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating for_each: %s", diags.Error())
 		}
 		expander.SetForEach(node.Key, forEach)
 	}
 
-	// Expand the resource
 	result := expander.Expand(node)
 
-	// Register each instance
 	for _, instance := range result.Instances {
-		// Skip this instance if any of the resource's dependencies failed.
 		if e.hasFailedDependency(res) {
 			e.failedNodes.Set(instance.Key, fmt.Errorf("skipped: dependency failed"))
 			continue
 		}
-		if err := e.registerResourceInstance(ctx, res, resSchema, instance); err != nil {
+		if err := e.registerResourceInstanceInContext(
+			ctx, node, res, resSchema, instance, evalCtx, parentURN, modInst,
+		); err != nil {
 			return fmt.Errorf("registering %s: %w", instance.Key, err)
 		}
 	}
@@ -762,22 +812,27 @@ func (e *Engine) processResource(ctx context.Context, node *graph.Node) error {
 	return nil
 }
 
-// registerResourceInstance registers a single resource instance with Pulumi.
-func (e *Engine) registerResourceInstance(
+// registerResourceInstanceInContext registers a single resource instance with Pulumi.
+func (e *Engine) registerResourceInstanceInContext(
 	ctx context.Context,
+	node *graph.Node,
 	res *ast.Resource,
 	resSchema *schema.Resource,
 	instance *graph.ExpandedResource,
+	evalCtx *eval.Context,
+	parentURN string,
+	modInst *moduleInstance,
 ) error {
-	// Set up instance-specific context (count.index, each.key, etc.)
 	if instance.Index != nil {
-		e.evaluator.Context().SetCount(*instance.Index)
-		defer e.evaluator.Context().ClearCount()
+		evalCtx.SetCount(*instance.Index)
+		defer evalCtx.ClearCount()
 	}
 	if instance.EachKey != nil && instance.EachValue != nil {
-		e.evaluator.Context().SetEach(*instance.EachKey, *instance.EachValue)
-		defer e.evaluator.Context().ClearEach()
+		evalCtx.SetEach(*instance.EachKey, *instance.EachValue)
+		defer evalCtx.ClearEach()
 	}
+
+	hclCtx := evalCtx.HCLContext()
 
 	dependsOn := make(map[string][]string)
 	addToDependsOn := func(prop, urn string) {
@@ -798,32 +853,31 @@ func (e *Engine) registerResourceInstance(
 			var val cty.Value
 			var diags hcl.Diagnostics
 			if len(extraVars) > 0 {
-				childCtx := e.evaluator.Context().HCLContext().NewChild()
+				childCtx := hclCtx.NewChild()
 				childCtx.Variables = extraVars
 				val, diags = expr.Value(childCtx)
 			} else {
-				val, diags = e.evaluator.EvaluateExpression(expr)
+				val, diags = expr.Value(hclCtx)
 			}
 			if diags.HasErrors() {
 				return val, diags
 			}
 
-			// Plain properties are passed as direct values, not as tracked outputs,
-			// so no property dependency tracking is needed.
 			if plainInputProps[string(propKey)] {
 				return val, diags
 			}
 
-			// Extract dependencies from this attribute's expression
 			for _, dep := range eval.ExtractDependencies(expr) {
-				// Look up the URN for this dependency
-				if resOutputs, ok := e.resourceOutputs.Get(dep); ok {
+				fullDep := dep
+				if node.ModuleInfo != nil {
+					fullDep = node.ModuleInfo.Prefix + dep
+				}
+				if resOutputs, ok := e.resourceOutputs.Get(fullDep); ok {
 					if urnVal := resOutputs.GetAttr("urn"); urnVal.Type() == cty.String {
 						addToDependsOn(string(propKey), urnVal.AsString())
 					}
 				}
-				// For data source dependencies, inherit their dependencies transitively
-				if dsKey, ok := strings.CutPrefix(dep, "data."); ok {
+				if dsKey, ok := strings.CutPrefix(fullDep, "data."); ok {
 					if dsDeps, exists := e.dataSourceDependencies.Get(dsKey); exists {
 						for _, urn := range dsDeps {
 							addToDependsOn(string(propKey), string(urn))
@@ -838,17 +892,14 @@ func (e *Engine) registerResourceInstance(
 		return diags
 	}
 
-	// For provider resources, plugin_download_url is a configuration input property but
-	// the parser extracts it as a meta-argument. Re-add it to the resource inputs.
 	if strings.HasPrefix(res.Type, "pulumi_providers_") && res.PluginDownloadURL != nil {
-		val, valDiags := res.PluginDownloadURL.Value(e.evaluator.Context().HCLContext())
+		val, valDiags := res.PluginDownloadURL.Value(hclCtx)
 		if !valDiags.HasErrors() && val.Type() == cty.String {
 			resourceInputs = resourceInputs.Set("pluginDownloadURL", property.New(val.AsString()))
 		}
 	}
 
-	// Build resource options
-	opts := e.buildResourceOptions(res, instance)
+	opts := e.buildResourceOptionsInContext(res, instance, evalCtx, parentURN, node.ModuleInfo)
 	opts.Custom = !resSchema.IsComponent
 	opts.Remote = resSchema.IsComponent
 	opts.PropertyDependencies = dependsOn
@@ -861,7 +912,6 @@ func (e *Engine) registerResourceInstance(
 	}
 	slices.Sort(opts.DependsOn)
 
-	// Set version from required_providers if not explicitly set by resource options.
 	if opts.Version == "" {
 		pkgName := packageNameFromResourceType(res.Type)
 		if e.config.Terraform != nil {
@@ -871,28 +921,22 @@ func (e *Engine) registerResourceInstance(
 		}
 	}
 
-	// Set plugin download URL from package schema if not explicitly set.
 	if opts.PluginDownloadURL == "" && resSchema.PackageReference != nil {
 		opts.PluginDownloadURL = resSchema.PackageReference.PluginDownloadURL()
 	}
 
 	opts.PackageRef = e.packageRefForType(res.Type)
 
-	// Evaluate preconditions before resource creation
 	if len(res.Preconditions) > 0 {
 		if err := e.evaluateCheckRules(res.Preconditions, instance.Key, "precondition"); err != nil {
 			return err
 		}
 	}
 
-	// Register the resource
-	// Extract the resource name from the instance key (e.g., "pulumi_stash.myStash" -> "myStash")
-	resourceName := extractResourceName(instance.Key)
+	resourceName := e.extractModuleResourceName(instance.Key, node.ModuleInfo, modInst)
 
 	urn, id, outputs, err := e.registerResource(ctx, resSchema.Token, resourceName, resourceInputs, opts)
 	if err != nil {
-		// Store the failure so dependent resources can detect it and skip.
-		// Return nil so the PDAG walk continues and independent resources proceed.
 		e.failedNodes.Set(instance.Key, fmt.Errorf("registering resource: %w", err))
 		return nil
 	}
@@ -904,7 +948,6 @@ func (e *Engine) registerResourceInstance(
 		return fmt.Errorf("resolving resource references in outputs: %w", err)
 	}
 
-	// Store outputs for future references
 	outputObj, err := transform.ResourceOutputToCty(outputs, resSchema, e.dryRun)
 	if err != nil {
 		return fmt.Errorf("converting resource outputs to HCL types: %w", err)
@@ -914,7 +957,6 @@ func (e *Engine) registerResourceInstance(
 
 	e.resourceOutputs.Set(instance.Key, cty.ObjectVal(outputObj))
 
-	// Store inheritable options so child resources can inherit from this resource.
 	var iOpts inheritableOpts
 	if opts.Protect {
 		iOpts.Protect = new(true)
@@ -922,20 +964,21 @@ func (e *Engine) registerResourceInstance(
 	iOpts.RetainOnDelete = opts.RetainOnDelete
 	e.resourceInheritableOpts.Set(instance.Key, iOpts)
 
-	// Also store in eval context for expression references
-	e.evaluator.Context().SetResource(instance.Key, cty.ObjectVal(outputObj))
+	if node.ModuleInfo != nil {
+		bareKey := strings.TrimPrefix(instance.Key, node.ModuleInfo.Prefix)
+		evalCtx.SetResource(bareKey, cty.ObjectVal(outputObj))
+	} else {
+		evalCtx.SetResource(instance.Key, cty.ObjectVal(outputObj))
+	}
 
-	// Evaluate postconditions after resource creation
-	// Set self to the resource outputs so postconditions can reference self
 	if len(res.Postconditions) > 0 {
-		e.evaluator.Context().SetSelf(cty.ObjectVal(outputObj))
-		defer e.evaluator.Context().ClearSelf()
+		evalCtx.SetSelf(cty.ObjectVal(outputObj))
+		defer evalCtx.ClearSelf()
 		if err := e.evaluateCheckRules(res.Postconditions, instance.Key, "postcondition"); err != nil {
 			return err
 		}
 	}
 
-	// Process provisioners after resource creation
 	if len(res.Provisioners) > 0 {
 		if err := e.processProvisioners(ctx, res, urn, cty.ObjectVal(outputObj), instance.Key); err != nil {
 			return fmt.Errorf("processing provisioners: %w", err)
@@ -945,24 +988,26 @@ func (e *Engine) registerResourceInstance(
 	return nil
 }
 
-// buildResourceOptions builds resource options from the resource definition.
-func (e *Engine) buildResourceOptions(res *ast.Resource, instance *graph.ExpandedResource) *ResourceOptions {
+// buildResourceOptionsInContext builds resource options using the provided eval context and parent URN.
+func (e *Engine) buildResourceOptionsInContext(
+	res *ast.Resource, instance *graph.ExpandedResource,
+	evalCtx *eval.Context, parentURN string,
+	modInfo *graph.ModuleInfo,
+) *ResourceOptions {
 	opts := &ResourceOptions{}
+	opts.Parent = parentURN
 
-	// Default parent: use the module component URN for child engines, or the stack URN for top-level.
-	if e.parentURN != "" {
-		opts.Parent = e.parentURN
-	} else {
-		opts.Parent = e.stackURN
+	resPrefix := ""
+	if modInfo != nil {
+		resPrefix = modInfo.Prefix
 	}
 
-	// Handle depends_on - resolve to URNs
 	for _, dep := range res.DependsOn {
 		depKey := graph.FormatTraversal(dep)
 		if depKey == "" {
 			continue
 		}
-		if outputs, ok := e.resourceOutputs.Get(depKey); ok {
+		if outputs, ok := e.resourceOutputs.Get(resPrefix + depKey); ok {
 			urnVal := outputs.GetAttr("urn")
 			if urnVal.Type() == cty.String {
 				opts.DependsOn = append(opts.DependsOn, urnVal.AsString())
@@ -1008,11 +1053,10 @@ func (e *Engine) buildResourceOptions(res *ast.Resource, instance *graph.Expande
 		}
 	}
 
-	// Handle parent resource reference
 	if res.ResourceParent != nil {
 		depKey := graph.FormatTraversal(res.ResourceParent)
 		if depKey != "" {
-			if outputs, ok := e.resourceOutputs.Get(depKey); ok {
+			if outputs, ok := e.resourceOutputs.Get(resPrefix + depKey); ok {
 				urnVal := outputs.GetAttr("urn")
 				if urnVal.Type() == cty.String {
 					opts.Parent = urnVal.AsString()
@@ -1021,15 +1065,12 @@ func (e *Engine) buildResourceOptions(res *ast.Resource, instance *graph.Expande
 		}
 	}
 
-	// Handle provider reference
 	if res.Provider != nil {
 		providerKey := res.Provider.Name
 		if res.Provider.Alias != "" {
 			providerKey = res.Provider.Name + "." + res.Provider.Alias
 		}
-		// Look up the provider URN and ID
-		if providerOutputs, ok := e.resourceOutputs.Get(providerKey); ok {
-			// Provider reference format: "<urn>::<id>"
+		if providerOutputs, ok := e.resourceOutputs.Get(resPrefix + providerKey); ok {
 			urnVal := providerOutputs.GetAttr("urn")
 			idVal := providerOutputs.GetAttr("id")
 			if urnVal.Type() == cty.String && idVal.Type() == cty.String {
@@ -1038,13 +1079,12 @@ func (e *Engine) buildResourceOptions(res *ast.Resource, instance *graph.Expande
 		}
 	}
 
-	// Handle providers list (for component resources)
 	for _, traversal := range res.Providers {
 		providerKey := graph.FormatTraversal(traversal)
 		if providerKey == "" {
 			continue
 		}
-		if providerOutputs, ok := e.resourceOutputs.Get(providerKey); ok {
+		if providerOutputs, ok := e.resourceOutputs.Get(resPrefix + providerKey); ok {
 			urnVal := providerOutputs.GetAttr("urn")
 			idVal := providerOutputs.GetAttr("id")
 			if urnVal.Type() == cty.String && idVal.Type() == cty.String {
@@ -1099,9 +1139,10 @@ func (e *Engine) buildResourceOptions(res *ast.Resource, instance *graph.Expande
 	// Handle import blocks - resolve import ID from import blocks that target this resource
 	opts.ImportId = e.resolveImportId(res)
 
-	// Handle additional_secret_outputs
+	hclCtx := evalCtx.HCLContext()
+
 	if res.AdditionalSecretOutputs != nil {
-		secretOutputsVal, diags := res.AdditionalSecretOutputs.Value(e.evaluator.Context().HCLContext())
+		secretOutputsVal, diags := res.AdditionalSecretOutputs.Value(hclCtx)
 		if !diags.HasErrors() && (secretOutputsVal.Type().IsListType() || secretOutputsVal.Type().IsTupleType()) {
 			it := secretOutputsVal.ElementIterator()
 			for it.Next() {
@@ -1113,20 +1154,18 @@ func (e *Engine) buildResourceOptions(res *ast.Resource, instance *graph.Expande
 		}
 	}
 
-	// Handle retain_on_delete
 	if res.RetainOnDelete != nil {
-		val, diags := res.RetainOnDelete.Value(e.evaluator.Context().HCLContext())
+		val, diags := res.RetainOnDelete.Value(hclCtx)
 		if !diags.HasErrors() && val.Type() == cty.Bool {
 			b := val.True()
 			opts.RetainOnDelete = &b
 		}
 	}
 
-	// Handle deleted_with - resolve to URN
 	if res.DeletedWith != nil {
 		depKey := graph.FormatTraversal(res.DeletedWith)
 		if depKey != "" {
-			if outputs, ok := e.resourceOutputs.Get(depKey); ok {
+			if outputs, ok := e.resourceOutputs.Get(resPrefix + depKey); ok {
 				urnVal := outputs.GetAttr("urn")
 				if urnVal.Type() == cty.String {
 					opts.DeletedWith = urnVal.AsString()
@@ -1135,13 +1174,12 @@ func (e *Engine) buildResourceOptions(res *ast.Resource, instance *graph.Expande
 		}
 	}
 
-	// Handle replace_with - resolve each resource reference to URN
 	for _, ref := range res.ReplaceWith {
 		depKey := graph.FormatTraversal(ref)
 		if depKey == "" {
 			continue
 		}
-		if outputs, ok := e.resourceOutputs.Get(depKey); ok {
+		if outputs, ok := e.resourceOutputs.Get(resPrefix + depKey); ok {
 			urnVal := outputs.GetAttr("urn")
 			if urnVal.Type() == cty.String {
 				opts.ReplaceWith = append(opts.ReplaceWith, urnVal.AsString())
@@ -1155,9 +1193,8 @@ func (e *Engine) buildResourceOptions(res *ast.Resource, instance *graph.Expande
 	// Handle replace_on_changes - property paths (already in camelCase)
 	opts.ReplaceOnChanges = append(opts.ReplaceOnChanges, res.ReplaceOnChanges...)
 
-	// Handle replacement_trigger
 	if res.ReplacementTrigger != nil {
-		val, diags := res.ReplacementTrigger.Value(e.evaluator.Context().HCLContext())
+		val, diags := res.ReplacementTrigger.Value(hclCtx)
 		if !diags.HasErrors() {
 			pv, err := transform.CtyToPropertyValue(val)
 			if err == nil {
@@ -1171,9 +1208,8 @@ func (e *Engine) buildResourceOptions(res *ast.Resource, instance *graph.Expande
 		opts.ImportId = res.ImportID
 	}
 
-	// Handle env_var_mappings
 	if res.EnvVarMappings != nil {
-		val, diags := res.EnvVarMappings.Value(e.evaluator.Context().HCLContext())
+		val, diags := res.EnvVarMappings.Value(hclCtx)
 		if !diags.HasErrors() && (val.Type().IsObjectType() || val.Type().IsMapType()) {
 			mappings := make(map[string]string)
 			for k, v := range val.AsValueMap() {
@@ -1187,29 +1223,24 @@ func (e *Engine) buildResourceOptions(res *ast.Resource, instance *graph.Expande
 		}
 	}
 
-	// Handle version
 	if res.Version != nil {
-		val, diags := res.Version.Value(e.evaluator.Context().HCLContext())
+		val, diags := res.Version.Value(hclCtx)
 		if !diags.HasErrors() && val.Type() == cty.String {
 			opts.Version = val.AsString()
 		}
 	}
 
-	// Handle plugin_download_url as a resource option.
-	// For provider resources (pulumi_providers_*), plugin_download_url is a provider
-	// configuration property, not a resource option, so it should not be set here.
 	if res.PluginDownloadURL != nil && !strings.HasPrefix(res.Type, "pulumi_providers_") {
-		val, diags := res.PluginDownloadURL.Value(e.evaluator.Context().HCLContext())
+		val, diags := res.PluginDownloadURL.Value(hclCtx)
 		if !diags.HasErrors() && val.Type() == cty.String {
 			opts.PluginDownloadURL = val.AsString()
 		}
 	}
 
-	// Inherit options from parent resource if not explicitly set.
 	if res.ResourceParent != nil {
 		depKey := graph.FormatTraversal(res.ResourceParent)
 		if depKey != "" {
-			if parentOpts, ok := e.resourceInheritableOpts.Get(depKey); ok {
+			if parentOpts, ok := e.resourceInheritableOpts.Get(resPrefix + depKey); ok {
 				if (res.Lifecycle == nil || res.Lifecycle.PreventDestroy == nil) &&
 					parentOpts.Protect != nil && *parentOpts.Protect {
 					opts.Protect = true
@@ -1411,19 +1442,38 @@ func extractResourceName(key string) string {
 	baseKey, index, eachKey := graph.ParseInstanceKey(key)
 
 	// Strip the "type." prefix from the base key to get the logical name.
-	dotIndex := strings.Index(baseKey, ".")
-	name := baseKey
-	if dotIndex != -1 {
-		name = baseKey[dotIndex+1:]
+	if _, after, ok := strings.Cut(baseKey, "."); ok {
+		baseKey = after
 	}
 
 	if index != nil {
-		return fmt.Sprintf("%s-%d", name, *index)
+		return fmt.Sprintf("%s-%d", baseKey, *index)
 	}
 	if eachKey != nil {
-		return fmt.Sprintf("%s-%s", name, *eachKey)
+		return fmt.Sprintf("%s-%s", baseKey, *eachKey)
 	}
-	return name
+	return baseKey
+}
+
+// extractModuleResourceName computes the Pulumi resource name for a resource inside a module.
+// Resources inside a component are prefixed with the component instance name.
+// For example, resource "res" inside component "comp" becomes "comp-res",
+// and inside "comp[0]" becomes "comp[0]-res".
+func (*Engine) extractModuleResourceName(
+	instanceKey string, modInfo *graph.ModuleInfo, modInst *moduleInstance,
+) string {
+	if modInfo == nil || modInst == nil {
+		return extractResourceName(instanceKey)
+	}
+
+	// Strip the module prefix to get the bare resource key (e.g., "simple_resource.name").
+	bareKey := strings.TrimPrefix(instanceKey, modInfo.Prefix)
+	bareResourceName := extractResourceName(bareKey)
+
+	// Extract the module instance name (e.g., "many" or "many[0]").
+	modInstanceName := extractResourceName(modInst.Key)
+
+	return modInstanceName + "-" + bareResourceName
 }
 
 // formatTraversalForIgnoreChanges formats a traversal for ignore_changes.
@@ -1865,182 +1915,381 @@ func (e *Engine) resolveResourceRefsInOutputs(
 // processModule processes a module call.
 // Terraform modules map to Pulumi component resources. The module's resources
 // become children of the component, and module outputs are collected for references.
-func (e *Engine) processModule(ctx context.Context, node *graph.Node) error {
-	mod := node.Module
-	if mod == nil {
-		return fmt.Errorf("module node missing Module field")
-	}
+// moduleLoaderAdapter adapts modules.Loader to graph.ModuleLoader.
+type moduleLoaderAdapter struct {
+	loader *modules.Loader
+}
 
-	// Expand the module for count/for_each
-	instances, err := e.expandModuleInstances(mod)
+func (a *moduleLoaderAdapter) LoadModule(source, workDir string) (*graph.LoadedModule, error) {
+	loaded, err := a.loader.LoadModule(source, workDir)
 	if err != nil {
-		return fmt.Errorf("expanding module instances: %w", err)
+		return nil, err
+	}
+	return &graph.LoadedModule{
+		Config:     loaded.Config,
+		SourcePath: loaded.SourcePath,
+	}, nil
+}
+
+// forEachModuleInstance iterates over all instances of the module identified by node.ModuleInfo.Prefix.
+func (e *Engine) forEachModuleInstance(node *graph.Node, fn func(inst *moduleInstance) error) error {
+	instances, ok := e.moduleInstances.Get(node.ModuleInfo.Prefix)
+	if !ok {
+		return fmt.Errorf("no module instances for prefix %q", node.ModuleInfo.Prefix)
+	}
+	for _, inst := range instances {
+		if err := fn(inst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// processModuleVariable evaluates a module variable's input expression in the parent context
+// and stores the result in each module instance's eval context.
+func (e *Engine) processModuleVariable(node *graph.Node) error {
+	v := node.Variable
+	modInfo := node.ModuleInfo
+	varName := strings.TrimPrefix(node.Key, modInfo.Prefix+"var.")
+
+	moduleInputAttrs, _ := modInfo.Module.Config.JustAttributes()
+	inputAttr, hasInput := moduleInputAttrs[varName]
+
+	return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
+		var val cty.Value
+
+		if hasInput {
+			// Evaluate the input expression in the parent context.
+			// The parent context is the eval context that contains count/each for this instance.
+			parentCtx := e.evaluator.Context()
+			if modInfo.ParentPrefix != "" {
+				parentCtx = inst.EvalCtx
+			}
+
+			// Need the parent eval context, not the module instance's context.
+			// For root-level modules, the parent is e.evaluator.Context() with count/each set.
+			var diags hcl.Diagnostics
+			parentHCL := parentCtx.HCLContext()
+			if inst.Index != nil {
+				parentHCL = e.evaluator.Context().Clone().HCLContext()
+				// We need a parent context with the right count/each set
+			}
+			// Use the root evaluator's context for parent expressions
+			val, diags = inputAttr.Expr.Value(e.evaluator.Context().HCLContext())
+			_ = parentHCL // TODO: for nested modules, use parent instance context
+			if diags.HasErrors() {
+				return fmt.Errorf("evaluating module input %s: %s", varName, diags.Error())
+			}
+		} else {
+			// No input: fall through to default/env/config
+			envVarName := "TF_VAR_" + varName
+			if envVal := os.Getenv(envVarName); envVal != "" {
+				val = cty.StringVal(envVal)
+			} else if v.Default != nil {
+				var diags hcl.Diagnostics
+				val, diags = v.Default.Value(inst.EvalCtx.HCLContext())
+				if diags.HasErrors() {
+					return fmt.Errorf("evaluating variable default for %s: %s", varName, diags.Error())
+				}
+			} else if v.Nullable {
+				val = cty.NullVal(cty.DynamicPseudoType)
+			} else {
+				return fmt.Errorf("variable %q is required but no value was provided", varName)
+			}
+		}
+
+		if v.Sensitive {
+			val = val.Mark("sensitive")
+		}
+
+		inst.EvalCtx.SetVariable(varName, val)
+		return nil
+	})
+}
+
+// processModuleInit processes a module init node: registers component resources and creates instances.
+func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error {
+	modInfo := node.ModuleInfo
+	mod := modInfo.Module
+
+	componentType := fmt.Sprintf("components:index:%s", componentTypeName(modInfo.SourcePath))
+
+	// For simple (non-counted) modules, create a single instance.
+	// For count/for_each, evaluate and create multiple instances.
+
+	parentURN := e.stackURN
+	parentEvalCtx := e.evaluator.Context()
+
+	// If this is a nested module, look up the parent instance URN.
+	if modInfo.ParentPrefix != "" {
+		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPrefix)
+		if ok && len(parentInstances) > 0 {
+			parentURN = parentInstances[0].URN
+			parentEvalCtx = parentInstances[0].EvalCtx
+		}
 	}
 
-	for _, instance := range instances {
-		if err := e.processModuleInstance(ctx, mod, instance); err != nil {
-			return err
+	baseKey := modInfo.ParentPrefix + "module." + modInfo.ModuleName
+
+	// Evaluate module inputs for the component resource registration
+	inputs := make(map[string]property.Value)
+	attrs, _ := mod.Config.JustAttributes()
+	for name, attr := range attrs {
+		val, diags := attr.Expr.Value(parentEvalCtx.HCLContext())
+		if diags.HasErrors() {
+			continue
+		}
+		pv, err := transform.CtyToPropertyValue(val)
+		if err == nil {
+			inputs[name] = pv
+		}
+	}
+
+	// No count/for_each: single instance.
+	if mod.Count == nil && mod.ForEach == nil {
+		componentOpts := &ResourceOptions{Parent: parentURN}
+		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, baseKey, property.NewMap(inputs), componentOpts)
+		if err != nil {
+			return fmt.Errorf("registering module component: %w", err)
+		}
+
+		instCtx := eval.NewContext(
+			modInfo.SourcePath, e.workDir,
+			e.stackName, e.projectName, e.organization,
+		)
+
+		e.moduleInstances.Set(modInfo.Prefix, []*moduleInstance{{
+			Key:     baseKey,
+			EvalCtx: instCtx,
+			URN:     componentURN,
+		}})
+		return nil
+	}
+
+	// Count expansion
+	if mod.Count != nil {
+		countVal, diags := mod.Count.Value(parentEvalCtx.HCLContext())
+		if diags.HasErrors() {
+			return fmt.Errorf("evaluating module count: %s", diags.Error())
+		}
+		if !countVal.Type().Equals(cty.Number) {
+			return fmt.Errorf("module count must be a number")
+		}
+		count, _ := countVal.AsBigFloat().Int64()
+		var instances []*moduleInstance
+		for i := int64(0); i < count; i++ {
+			idx := int(i)
+			instKey := fmt.Sprintf("%s[%d]", baseKey, i)
+			componentOpts := &ResourceOptions{Parent: parentURN}
+			componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instKey, property.NewMap(inputs), componentOpts)
+			if err != nil {
+				return fmt.Errorf("registering module component %s: %w", instKey, err)
+			}
+			instCtx := eval.NewContext(
+				modInfo.SourcePath, e.workDir,
+				e.stackName, e.projectName, e.organization,
+			)
+			instCtx.SetCount(idx)
+			instances = append(instances, &moduleInstance{
+				Key:     instKey,
+				EvalCtx: instCtx,
+				URN:     componentURN,
+				Index:   &idx,
+			})
+		}
+		e.moduleInstances.Set(modInfo.Prefix, instances)
+		return nil
+	}
+
+	// ForEach expansion
+	forEachVal, diags := mod.ForEach.Value(parentEvalCtx.HCLContext())
+	if diags.HasErrors() {
+		return fmt.Errorf("evaluating module for_each: %s", diags.Error())
+	}
+	if !forEachVal.CanIterateElements() {
+		return fmt.Errorf("module for_each must be a set or map")
+	}
+	var instances []*moduleInstance
+	it := forEachVal.ElementIterator()
+	for it.Next() {
+		k, v := it.Element()
+		keyStr := k.AsString()
+		instKey := fmt.Sprintf("%s[\"%s\"]", baseKey, keyStr)
+		componentOpts := &ResourceOptions{Parent: parentURN}
+		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instKey, property.NewMap(inputs), componentOpts)
+		if err != nil {
+			return fmt.Errorf("registering module component %s: %w", instKey, err)
+		}
+		instCtx := eval.NewContext(
+			modInfo.SourcePath, e.workDir,
+			e.stackName, e.projectName, e.organization,
+		)
+		instCtx.SetEach(k, v)
+		instances = append(instances, &moduleInstance{
+			Key:     instKey,
+			EvalCtx: instCtx,
+			URN:     componentURN,
+			EachKey: &k,
+			EachVal: &v,
+		})
+	}
+	e.moduleInstances.Set(modInfo.Prefix, instances)
+	return nil
+}
+
+// processModuleOutput evaluates a module output in each instance and stores it in the parent context.
+func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error {
+	output := node.Output
+	modInfo := node.ModuleInfo
+	outputName := strings.TrimPrefix(node.Key, modInfo.Prefix+"output.")
+	mod := modInfo.Module
+	isCounted := mod.Count != nil
+	isForEach := mod.ForEach != nil
+
+	err := e.forEachModuleInstance(node, func(inst *moduleInstance) error {
+		val, diags := output.Value.Value(inst.EvalCtx.HCLContext())
+		if diags.HasErrors() {
+			return fmt.Errorf("evaluating module output %s: %s", outputName, diags.Error())
+		}
+		if inst.Outputs == nil {
+			inst.Outputs = make(map[string]cty.Value)
+		}
+		inst.Outputs[outputName] = val
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Eagerly publish outputs to the parent context so other module variables
+	// can reference them before the completion node runs.
+	parentCtx := e.evaluator.Context()
+	instances, ok := e.moduleInstances.Get(modInfo.Prefix)
+	if !ok {
+		return nil
+	}
+
+	if !isCounted && !isForEach {
+		if len(instances) == 1 {
+			if v, has := instances[0].Outputs[outputName]; has {
+				parentCtx.SetModuleOutput(modInfo.ModuleName, outputName, v)
+			}
+		}
+	} else if isCounted {
+		// Rebuild the full tuple from all collected outputs so far.
+		tupleVals := make([]cty.Value, len(instances))
+		for i, inst := range instances {
+			if len(inst.Outputs) > 0 {
+				tupleVals[i] = cty.ObjectVal(inst.Outputs)
+			} else {
+				tupleVals[i] = cty.EmptyObjectVal
+			}
+		}
+		if len(tupleVals) > 0 {
+			parentCtx.SetModule(modInfo.ModuleName, cty.TupleVal(tupleVals))
+		} else {
+			parentCtx.SetModule(modInfo.ModuleName, cty.EmptyTupleVal)
+		}
+	} else {
+		// ForEach: rebuild the map.
+		mapVals := make(map[string]cty.Value, len(instances))
+		for _, inst := range instances {
+			if inst.EachKey == nil {
+				continue
+			}
+			keyStr := inst.EachKey.AsString()
+			if len(inst.Outputs) > 0 {
+				mapVals[keyStr] = cty.ObjectVal(inst.Outputs)
+			} else {
+				mapVals[keyStr] = cty.EmptyObjectVal
+			}
+		}
+		if len(mapVals) > 0 {
+			parentCtx.SetModule(modInfo.ModuleName, cty.ObjectVal(mapVals))
+		} else {
+			parentCtx.SetModule(modInfo.ModuleName, cty.EmptyObjectVal)
 		}
 	}
 
 	return nil
 }
 
-// expandedModule represents an expanded module instance (for count/for_each).
-type expandedModule struct {
-	Key     string     // e.g., "module.vpc" or "module.vpc[0]"
-	Index   *int       // count index if using count
-	EachKey *cty.Value // for_each key if using for_each
-	EachVal *cty.Value // for_each value if using for_each
-}
-
-// expandModuleInstances expands a module for count/for_each.
-func (e *Engine) expandModuleInstances(mod *ast.Module) ([]*expandedModule, error) {
-	baseKey := "module." + mod.Name
-
-	// Handle count
-	if mod.Count != nil {
-		countVal, diags := e.evaluator.EvaluateExpression(mod.Count)
-		if diags.HasErrors() {
-			return nil, fmt.Errorf("evaluating count: %s", diags.Error())
-		}
-
-		if !countVal.Type().Equals(cty.Number) {
-			return nil, fmt.Errorf("count must be a number")
-		}
-
-		count, _ := countVal.AsBigFloat().Int64()
-		if count < 0 {
-			return nil, fmt.Errorf("count cannot be negative")
-		}
-
-		var instances []*expandedModule
-		for i := int64(0); i < count; i++ {
-			idx := int(i)
-			instances = append(instances, &expandedModule{
-				Key:   fmt.Sprintf("%s[%d]", baseKey, i),
-				Index: &idx,
-			})
-		}
-		return instances, nil
+// processModuleComplete handles the module completion node: registers component outputs
+// and assembles the full module value in the parent context.
+func (e *Engine) processModuleComplete(ctx context.Context, node *graph.Node) error {
+	modInfo := node.ModuleInfo
+	if modInfo == nil {
+		return fmt.Errorf("module completion node missing ModuleInfo")
 	}
 
-	// Handle for_each
-	if mod.ForEach != nil {
-		forEachVal, diags := e.evaluator.EvaluateExpression(mod.ForEach)
-		if diags.HasErrors() {
-			return nil, fmt.Errorf("evaluating for_each: %s", diags.Error())
-		}
-
-		if !forEachVal.CanIterateElements() {
-			return nil, fmt.Errorf("for_each must be a set or map")
-		}
-
-		var instances []*expandedModule
-		it := forEachVal.ElementIterator()
-		for it.Next() {
-			k, v := it.Element()
-			keyStr := k.AsString()
-			instances = append(instances, &expandedModule{
-				Key:     fmt.Sprintf("%s[\"%s\"]", baseKey, keyStr),
-				EachKey: &k,
-				EachVal: &v,
-			})
-		}
-		return instances, nil
+	instances, ok := e.moduleInstances.Get(modInfo.Prefix)
+	if !ok {
+		return fmt.Errorf("no module instances for prefix %q", modInfo.Prefix)
 	}
 
-	// No count or for_each - single instance
-	return []*expandedModule{{Key: baseKey}}, nil
-}
+	mod := modInfo.Module
+	isCounted := mod.Count != nil
+	isForEach := mod.ForEach != nil
 
-// processModuleInstance processes a single module instance.
-func (e *Engine) processModuleInstance(ctx context.Context, mod *ast.Module, instance *expandedModule) error {
-	// Set up instance-specific context (count.index, each.key, etc.)
-	if instance.Index != nil {
-		e.evaluator.Context().SetCount(*instance.Index)
-		defer e.evaluator.Context().ClearCount()
-	}
-	if instance.EachKey != nil && instance.EachVal != nil {
-		e.evaluator.Context().SetEach(*instance.EachKey, *instance.EachVal)
-		defer e.evaluator.Context().ClearEach()
-	}
-
-	// Load the module source
-	loadedModule, err := e.moduleLoader.LoadModule(mod.Source, e.workDir)
-	if err != nil {
-		return fmt.Errorf("loading module %s: %w", mod.Name, err)
-	}
-
-	// Evaluate module inputs from the module block
-	inputs := make(map[string]property.Value)
-	attrs, _ := mod.Config.JustAttributes()
-	for name, attr := range attrs {
-		val, diags := e.evaluator.EvaluateExpression(attr.Expr)
-		if diags.HasErrors() {
-			return fmt.Errorf("evaluating module input %s: %s", name, diags.Error())
-		}
-		pv, err := transform.CtyToPropertyValue(val)
-		if err != nil {
-			return fmt.Errorf("converting module input %s: %w", name, err)
-		}
-		inputs[name] = pv
-	}
-
-	componentType := fmt.Sprintf("components:index:%s", componentTypeName(loadedModule.SourcePath))
-	componentOpts := &ResourceOptions{
-		Parent: e.parentURN,
-	}
-
-	// Handle depends_on
-	for _, dep := range mod.DependsOn {
-		depKey := graph.FormatTraversal(dep)
-		if depKey != "" {
-			componentOpts.DependsOn = append(componentOpts.DependsOn, depKey)
-		}
-	}
-
-	componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instance.Key, property.NewMap(inputs), componentOpts)
-	if err != nil {
-		return fmt.Errorf("registering module component: %w", err)
-	}
-
-	// Create a child engine to execute the module
-	childEngine := e.createChildEngine(loadedModule.Config, componentURN)
-
-	// Set up the child engine's variables with module inputs
-	if diags := childEngine.setModuleInputs(attrs, e.evaluator.Context()); diags.HasErrors() {
-		return diags
-	}
-
-	// Execute the module
-	if err := childEngine.runModule(ctx); err != nil {
-		return fmt.Errorf("executing module %s: %w", mod.Name, err)
-	}
-
-	// Collect module outputs and make them available
-	moduleOutputs := childEngine.collectModuleOutputs()
-	e.moduleOutputs[instance.Key] = moduleOutputs
-
-	// Set module in eval context using just the module name or indexed key
-	// instance.Key is like "module.vpc" or "module.vpc[0]"
-	// We need to store at "vpc" or "vpc[0]" for module.vpc.output_name to work
-	moduleRefKey := strings.TrimPrefix(instance.Key, "module.")
-	e.evaluator.Context().SetModule(moduleRefKey, moduleOutputs)
-
-	// Register the component outputs
-	if e.resmon != nil {
-		outputProps := make(map[string]property.Value)
-		if moduleOutputs.Type().IsObjectType() {
-			for name, val := range moduleOutputs.AsValueMap() {
-				pv, err := transform.CtyToPropertyValue(val)
+	// Register component outputs and collect per-instance output objects.
+	for _, inst := range instances {
+		if e.resmon != nil {
+			outputProps := make(map[string]property.Value)
+			for k, v := range inst.Outputs {
+				pv, err := transform.CtyToPropertyValue(v)
 				if err == nil {
-					outputProps[name] = pv
+					outputProps[k] = pv
 				}
 			}
+			if err := e.resmon.RegisterResourceOutputs(ctx, inst.URN, property.NewMap(outputProps)); err != nil {
+				return fmt.Errorf("registering module outputs: %w", err)
+			}
 		}
-		if err := e.resmon.RegisterResourceOutputs(ctx, componentURN, property.NewMap(outputProps)); err != nil {
-			return fmt.Errorf("registering module outputs: %w", err)
+	}
+
+	// Assemble module value in parent eval context.
+	parentCtx := e.evaluator.Context()
+
+	if !isCounted && !isForEach {
+		// Single instance: module.X is an object of outputs.
+		if len(instances) == 1 {
+			for k, v := range instances[0].Outputs {
+				parentCtx.SetModuleOutput(modInfo.ModuleName, k, v)
+			}
+		}
+	} else if isCounted {
+		// Counted: module.X is a tuple/list of output objects.
+		tupleVals := make([]cty.Value, len(instances))
+		for i, inst := range instances {
+			if len(inst.Outputs) > 0 {
+				tupleVals[i] = cty.ObjectVal(inst.Outputs)
+			} else {
+				tupleVals[i] = cty.EmptyObjectVal
+			}
+		}
+		if len(tupleVals) > 0 {
+			parentCtx.SetModule(modInfo.ModuleName, cty.TupleVal(tupleVals))
+		} else {
+			parentCtx.SetModule(modInfo.ModuleName, cty.EmptyTupleVal)
+		}
+	} else {
+		// ForEach: module.X is a map of key → output object.
+		mapVals := make(map[string]cty.Value, len(instances))
+		for _, inst := range instances {
+			if inst.EachKey == nil {
+				continue
+			}
+			keyStr := inst.EachKey.AsString()
+			if len(inst.Outputs) > 0 {
+				mapVals[keyStr] = cty.ObjectVal(inst.Outputs)
+			} else {
+				mapVals[keyStr] = cty.EmptyObjectVal
+			}
+		}
+		if len(mapVals) > 0 {
+			parentCtx.SetModule(modInfo.ModuleName, cty.ObjectVal(mapVals))
+		} else {
+			parentCtx.SetModule(modInfo.ModuleName, cty.EmptyObjectVal)
 		}
 	}
 
@@ -2072,95 +2321,25 @@ func (e *Engine) registerComponentResource(
 	inputs property.Map,
 	opts *ResourceOptions,
 ) (string, string, property.Map, error) {
-	if e.resmon == nil { // TODO: Remove this check
-		// No resource monitor - return synthetic values for testing
+	if e.resmon == nil {
 		urn := fmt.Sprintf("urn:pulumi:%s::%s::%s::%s",
 			e.stackName, e.projectName, typeToken, name)
 		return urn, "", inputs, nil
 	}
 
-	// Build dependencies list
 	deps := opts.DependsOn
-
-	// Register with the resource monitor - Custom=false for components
 	resp, err := e.resmon.RegisterResource(ctx, RegisterResourceRequest{
 		Type:         typeToken,
 		Name:         name,
 		Inputs:       inputs,
 		Dependencies: deps,
 		Parent:       opts.Parent,
-		// Note: Custom=false for components, but we handle this in server.go
 	})
 	if err != nil {
 		return "", "", property.Map{}, err
 	}
 
 	return resp.URN, resp.ID, resp.Outputs, nil
-}
-
-// createChildEngine creates a child engine for executing a module.
-func (e *Engine) createChildEngine(config *ast.Config, parentURN string) *Engine {
-	return &Engine{
-		config:                  config,
-		evaluator:               e.evaluator,
-		pkgLoader:               e.pkgLoader,
-		resmon:                  e.resmon,
-		resourceOutputs:         util.NewSyncMap[string, cty.Value](),
-		resourceInheritableOpts: util.NewSyncMap[string, inheritableOpts](),
-		stackOutputs:            make(map[string]property.Value),
-		projectName:             e.projectName,
-		stackName:               e.stackName,
-		organization:            e.organization,
-		dryRun:                  e.dryRun,
-		workDir:                 e.workDir,
-		pulumiConfig:            e.pulumiConfig,
-		configSecretKeys:        e.configSecretKeys,
-		moduleLoader:            e.moduleLoader,
-		moduleOutputs:           make(map[string]cty.Value),
-		parentURN:               parentURN,
-	}
-}
-
-// setModuleInputs sets up the module's variables with input values.
-func (e *Engine) setModuleInputs(inputs hcl.Attributes, parentContext *eval.Context) hcl.Diagnostics {
-	var diags hcl.Diagnostics
-	for name, attr := range inputs {
-		val, diag := attr.Expr.Value(parentContext.HCLContext())
-		if !diag.HasErrors() {
-			e.evaluator.Context().SetVariable(name, val)
-		}
-		diags = diags.Extend(diag)
-	}
-	return diags
-}
-
-// runModule executes a module's contents (without registering a stack).
-func (e *Engine) runModule(ctx context.Context) error {
-	// Build dependency graph for the module
-	g, err := graph.BuildFromConfig(e.config)
-	if err != nil {
-		return fmt.Errorf("building module graph: %w", err)
-	}
-
-	return e.processGraph(ctx, g)
-}
-
-// collectModuleOutputs collects the module's output values.
-func (e *Engine) collectModuleOutputs() cty.Value {
-	outputMap := make(map[string]cty.Value)
-
-	for name, output := range e.config.Outputs {
-		val, diags := e.evaluator.EvaluateExpression(output.Value)
-		if !diags.HasErrors() {
-			outputMap[name] = val
-		}
-	}
-
-	if len(outputMap) == 0 {
-		return cty.EmptyObjectVal
-	}
-
-	return cty.ObjectVal(outputMap)
 }
 
 // processOutput processes an output definition.
@@ -2228,8 +2407,7 @@ func RunFromDirectory(ctx context.Context, dir string, opts *EngineOptions) erro
 func Validate(config *ast.Config) []error {
 	var errs []error
 
-	// Build and validate the dependency graph
-	g, err := graph.BuildFromConfig(config)
+	g, err := graph.BuildFromConfig(config, nil, "")
 	if err != nil {
 		errs = append(errs, err)
 		return errs


### PR DESCRIPTION
This PR changes HCL to not run a sub-graph for modules. This allows fine grained dependencies to flow across the module boundary.

Fix `l3-deferred-outputs`.