### PR TITLE
Re-parse unimplemented functions & emit them if HCL supports them

### DIFF
--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -276,6 +276,64 @@ func TestConvertedPCLRange(t *testing.T) {
 	})
 }
 
+func TestNotImplemented(t *testing.T) {
+	t.Parallel()
+
+	generateHCL := func(t *testing.T, pclSource string) string {
+		t.Helper()
+
+		loader := testutil.NewMockReferenceLoader(t)
+
+		p := syntax.NewParser()
+		err := p.ParseFile(strings.NewReader(pclSource), "main.pp")
+		require.NoError(t, err)
+		require.False(t, p.Diagnostics.HasErrors(), p.Diagnostics.Error())
+
+		program, bindDiags, err := pcl.BindProgram(p.Files, pcl.Loader(loader))
+		require.NoError(t, err)
+		require.False(t, bindDiags.HasErrors(), bindDiags.Error())
+
+		files, genDiags, err := codegen.GenerateProgram(program)
+		require.NoError(t, err)
+		require.False(t, genDiags.HasErrors(), genDiags.Error())
+
+		generatedHCL := string(files["main.hcl"])
+		require.NotEmpty(t, generatedHCL)
+
+		hclParser := parser.NewParser()
+		_, hclDiags := hclParser.ParseSource("main.hcl", files["main.hcl"])
+		require.False(t, hclDiags.HasErrors(), hclDiags.Error())
+
+		return generatedHCL
+	}
+
+	t.Run("known_function", func(t *testing.T) {
+		t.Parallel()
+
+		hcl := generateHCL(t, `output result {
+    value = notImplemented("upper(\"hello\")")
+}
+`)
+		assert.Equal(t, `output "result" {
+  value = upper("hello")
+}
+`, hcl)
+	})
+
+	t.Run("unknown_function", func(t *testing.T) {
+		t.Parallel()
+
+		hcl := generateHCL(t, `output result {
+    value = notImplemented("mystery_func(\"hello\")")
+}
+`)
+		assert.Equal(t, `output "result" {
+  value = notImplemented("mystery_func(\"hello\")")
+}
+`, hcl)
+	})
+}
+
 func testConvertedPCL(t *testing.T, pclSource string, schemas ...schema.PackageSpec) *testutil.MockResourceMonitor {
 	t.Helper()
 

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/pulumi/pulumi-language-hcl/pkg/hcl/eval"
 	"github.com/pulumi/pulumi-language-hcl/pkg/hcl/packages"
 	"github.com/pulumi/pulumi-language-hcl/pkg/hcl/transform"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
@@ -1336,9 +1337,58 @@ func (g *generator) funcCallTokens(expr *model.FunctionCallExpression) (hclwrite
 		return g.passthroughFuncCallTokens("base64encode", expr.Args)
 	case "fromBase64":
 		return g.passthroughFuncCallTokens("base64decode", expr.Args)
+	case "notImplemented":
+		return g.notImplementedTokens(expr)
 	default:
 		return g.passthroughFuncCallTokens(expr.Name, expr.Args)
 	}
+}
+
+// notImplementedTokens handles PCL's notImplemented("expression") by extracting the original
+// expression text and emitting it as HCL when the expression uses a function that HCL supports.
+// If the expression doesn't parse, isn't a function call, or uses an unknown function,
+// it falls through to emit notImplemented(...) verbatim.
+func (g *generator) notImplementedTokens(expr *model.FunctionCallExpression) (hclwrite.Tokens, hcl.Diagnostics) {
+	if len(expr.Args) != 1 {
+		return g.passthroughFuncCallTokens(expr.Name, expr.Args)
+	}
+
+	exprText, ok := extractStringLiteral(expr.Args[0])
+	if !ok {
+		return g.passthroughFuncCallTokens(expr.Name, expr.Args)
+	}
+
+	parsed, diags := hclsyntax.ParseExpression([]byte(exprText), "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return g.passthroughFuncCallTokens(expr.Name, expr.Args)
+	}
+
+	funcCall, ok := parsed.(*hclsyntax.FunctionCallExpr)
+	if !ok {
+		return g.passthroughFuncCallTokens(expr.Name, expr.Args)
+	}
+
+	knownFunctions := eval.Functions("")
+	if _, known := knownFunctions[funcCall.Name]; !known {
+		return g.passthroughFuncCallTokens(expr.Name, expr.Args)
+	}
+
+	syntaxTokens, diags := hclsyntax.LexExpression([]byte(exprText), "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return g.passthroughFuncCallTokens(expr.Name, expr.Args)
+	}
+
+	var tokens hclwrite.Tokens
+	for _, t := range syntaxTokens {
+		if t.Type == hclsyntax.TokenEOF {
+			continue
+		}
+		tokens = append(tokens, &hclwrite.Token{
+			Type:  t.Type,
+			Bytes: t.Bytes,
+		})
+	}
+	return tokens, nil
 }
 
 // getOutputTokens generates tokens for getOutput(resource, "outputName").


### PR DESCRIPTION
This allows us to use TF HCL intrinsics that PCL doesn't support.