### PR TITLE
Unskip l2-resource-option-additional-secret-outputs

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -139,7 +139,6 @@ var expectedFailures = map[string]string{
 	"l2-resource-optional":                        "optional properties return Computed instead of null",
 	"l2-resource-primitive-defaults":               "failed to convert default integer property value",
 	"l2-resource-option-ignore-changes":            "unknown node tags.env - map-key ignore_changes not supported",
-	"l2-resource-option-additional-secret-outputs": "additionalSecretOutputs not propagated to resource",
 	"l3-component-simple":                          "component name prefixed with module.",
 	"l3-component-config-objects":                  "expected resource named plain not found",
 	"l3-component-config-primitives":               "expected resource named plain not found",

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-additional-secret-outputs/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-additional-secret-outputs/main.pp
@@ -1,7 +1,7 @@
 resource "withSecret" "simple:index:Resource" {
   value = true
   options {
-    additionalSecretOutputs = ["value"]
+    additionalSecretOutputs = [value]
   }
 }
 

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -545,11 +545,7 @@ func (g *generator) genResourceOptions(body *hclwrite.Body, r *pcl.Resource) hcl
 	}
 
 	if opts.AdditionalSecretOutputs != nil {
-		tokens, d := g.exprTokens(opts.AdditionalSecretOutputs, schema.AnyResourceType)
-		diags = append(diags, d...)
-		if !d.HasErrors() {
-			body.SetAttributeRaw("additional_secret_outputs", tokens)
-		}
+		g.genPropertyPathList(body, "additional_secret_outputs", opts.AdditionalSecretOutputs, &diags)
 	}
 
 	if opts.RetainOnDelete != nil {

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -460,7 +460,7 @@ func transformHCLFileToPCL(
 				if pclName, isOpt := resourceOptionHCLToPCL[attr.Name]; isOpt {
 					var tokens hclwrite.Tokens
 					switch attr.Name {
-					case "hide_diffs", "replace_on_changes":
+					case "additional_secret_outputs", "hide_diffs", "replace_on_changes":
 						tokens = ft.transformPropertyPathList(attr.Expr)
 					case "for_each":
 						tokens = ft.transformForEachExpr(attr.Expr)


### PR DESCRIPTION
Fix the round-trip for `additionalSecretOutputs` by ensuring property references are correctly converted between HCL string literals and PCL identifiers.

The codegen now converts PCL property references (scope traversals like `[value]`) into quoted HCL strings (`["value"]`) via a new `propertyListTokens` helper. The converter now uses `transformPropertyPathList` for `additional_secret_outputs`, unquoting string literals back to bare PCL identifiers — matching the existing handling for `ignore_changes`, `hide_diffs`, and `replace_on_changes`.