### PR TITLE
Unskip l2-resource-primitive-defaults

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -137,7 +137,6 @@ var expectedFailures = map[string]string{
 		" - requires mapping between lexical names (code references) and logical names (resource names)",
 	"l1-builtin-to-json":                         "no function named toJSON",
 	"l2-resource-optional":                        "optional properties return Computed instead of null",
-	"l2-resource-primitive-defaults":               "failed to convert default integer property value",
 	"l2-resource-option-ignore-changes":            "unknown node tags.env - map-key ignore_changes not supported",
 	"l3-component-simple":                          "component name prefixed with module.",
 	"l3-component-config-objects":                  "expected resource named plain not found",

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-primitive-defaults/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-primitive-defaults/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-primitive-defaults
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-primitive-defaults/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-primitive-defaults/main.pp
@@ -1,0 +1,10 @@
+resource "resExplicit" "primitive-defaults:index:Resource" {
+  boolean = true
+  float   = 3.14
+  integer = 42
+  string  = "hello"
+}
+
+resource "resDefaulted" "primitive-defaults:index:Resource" {
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-primitive-defaults/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-primitive-defaults/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-primitive-defaults
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-primitive-defaults/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-primitive-defaults/main.hcl
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    primitive-defaults = {
+      source  = "pulumi/primitive-defaults"
+      version = "8.0.0"
+    }
+  }
+}
+
+resource "primitive-defaults_resource" "resExplicit" {
+  boolean = true
+  float   = 3.14
+  integer = 42
+  string  = "hello"
+}
+resource "primitive-defaults_resource" "resDefaulted" {
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-primitive-defaults/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-primitive-defaults/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-primitive-defaults
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-primitive-defaults/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-primitive-defaults/main.hcl
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    primitive-defaults = {
+      source  = "pulumi/primitive-defaults"
+      version = "8.0.0"
+    }
+  }
+}
+
+resource "primitive-defaults_resource" "resExplicit" {
+  boolean = true
+  float   = 3.14
+  integer = 42
+  string  = "hello"
+}
+resource "primitive-defaults_resource" "resDefaulted" {
+}

--- a/cmd/pulumi-language-hcl/testdata/sdks/primitive-defaults-8.0.0/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/sdks/primitive-defaults-8.0.0/hcl.sdk.json
@@ -1,0 +1,8 @@
+{
+  "Name": "primitive-defaults",
+  "Kind": "resource",
+  "Version": "8.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null
+}

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -433,7 +433,10 @@ func getDefault(path string, d *schema.DefaultValue, typ schema.Type) (property.
 		}
 	}
 	if v := d.Value; v != nil {
-		if i, ok := d.Value.(int); ok {
+		switch i := d.Value.(type) {
+		case int:
+			v = float64(i)
+		case int32:
 			v = float64(i)
 		}
 		v, err := property.Any(v)


### PR DESCRIPTION
The Pulumi schema package binds integer default values as `int32`, but `getDefault` only handled the `int` type before calling `property.Any` (which only accepts `float64` for numbers). This adds `int32` to the type switch so integer defaults are correctly converted to `float64`.