### PR TITLE
Fix component name prefix and unskip l3-component-simple

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -138,7 +138,6 @@ var expectedFailures = map[string]string{
 	"l1-builtin-to-json":                         "no function named toJSON",
 	"l2-resource-optional":                        "optional properties return Computed instead of null",
 	"l2-resource-option-ignore-changes":            "unknown node tags.env - map-key ignore_changes not supported",
-	"l3-component-simple":                          "component name prefixed with module.",
 	"l3-component-config-objects":                  "expected resource named plain not found",
 	"l3-component-config-primitives":               "expected resource named plain not found",
 	"l3-rewrite-conversions": "resource direct is invalid",

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2055,7 +2055,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 	// No count/for_each: single instance.
 	if mod.Count == nil && mod.ForEach == nil {
 		componentOpts := &ResourceOptions{Parent: parentURN}
-		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, baseKey, property.NewMap(inputs), componentOpts)
+		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, extractResourceName(baseKey), property.NewMap(inputs), componentOpts)
 		if err != nil {
 			return fmt.Errorf("registering module component: %w", err)
 		}
@@ -2088,7 +2088,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 			idx := int(i)
 			instKey := fmt.Sprintf("%s[%d]", baseKey, i)
 			componentOpts := &ResourceOptions{Parent: parentURN}
-			componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instKey, property.NewMap(inputs), componentOpts)
+			componentURN, _, _, err := e.registerComponentResource(ctx, componentType, extractResourceName(instKey), property.NewMap(inputs), componentOpts)
 			if err != nil {
 				return fmt.Errorf("registering module component %s: %w", instKey, err)
 			}
@@ -2123,7 +2123,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 		keyStr := k.AsString()
 		instKey := fmt.Sprintf("%s[\"%s\"]", baseKey, keyStr)
 		componentOpts := &ResourceOptions{Parent: parentURN}
-		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instKey, property.NewMap(inputs), componentOpts)
+		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, extractResourceName(instKey), property.NewMap(inputs), componentOpts)
 		if err != nil {
 			return fmt.Errorf("registering module component %s: %w", instKey, err)
 		}

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1459,10 +1460,8 @@ output "vpc_id" {
 		t.Errorf("expected module type %q, got %q", expectedType, moduleComponent.Type)
 	}
 
-	// Check that the module name includes the module name
-	if !strings.Contains(moduleComponent.Name, "module.vpc") {
-		t.Errorf("expected module name to contain 'module.vpc', got: %s", moduleComponent.Name)
-	}
+	// Check that the module name is the logical module name (without "module." prefix)
+	assert.Equal(t, "vpc", moduleComponent.Name)
 
 	// Find the VPC resource
 	var vpcResource *RegisterResourceRequest


### PR DESCRIPTION
Component resources registered during module initialization used the internal graph key (e.g. `module.someComponent`) as the Pulumi resource name, causing the `module.` prefix to appear in URNs. This applies `extractResourceName` to strip the type prefix before registration, matching how child resource names are already derived.