### PR TITLE
Unskip l1-builtin-to-json

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -135,7 +135,6 @@ var expectedFailures = map[string]string{
 		" - not compatible with block syntax",
 	"l2-logical-name": "unsupported in HCL: __logicalName support not yet implemented" +
 		" - requires mapping between lexical names (code references) and logical names (resource names)",
-	"l1-builtin-to-json":                         "no function named toJSON",
 	"l2-resource-optional":                        "optional properties return Computed instead of null",
 	"l2-resource-option-ignore-changes":            "unknown node tags.env - map-key ignore_changes not supported",
 	"l3-component-config-objects":                  "expected resource named plain not found",

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-to-json/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-to-json/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-to-json
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-to-json/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-to-json/main.pp
@@ -1,0 +1,47 @@
+config "aString" "string" {
+}
+
+config "aNumber" "number" {
+}
+
+config "aList" "list(string)" {
+}
+
+config "aSecret" "string" {
+}
+
+output "stringOutput" {
+  value = toJSON(aString)
+}
+
+output "numberOutput" {
+  value = toJSON(aNumber)
+}
+
+output "boolOutput" {
+  value = toJSON(true)
+}
+
+output "arrayOutput" {
+  value = toJSON(["x", "y", "z"])
+}
+
+output "objectOutput" {
+  value = toJSON({
+    "key"   = "value"
+    "count" = 1
+  })
+}
+
+nestedObject = {
+  "anObject" = {
+    "name"  = aString
+    "items" = aList
+  }
+  "a_secret" = aSecret
+}
+
+output "nestedOutput" {
+  value = toJSON(nestedObject)
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-to-json/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-to-json/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-to-json
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-to-json/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-to-json/main.hcl
@@ -1,0 +1,42 @@
+variable "aString" {
+  type = string
+}
+variable "aNumber" {
+  type = number
+}
+variable "aList" {
+  type = list(string)
+}
+variable "aSecret" {
+  type = string
+}
+output "stringOutput" {
+  value = jsonencode(var.aString)
+}
+output "numberOutput" {
+  value = jsonencode(var.aNumber)
+}
+output "boolOutput" {
+  value = jsonencode(true)
+}
+output "arrayOutput" {
+  value = jsonencode(["x", "y", "z"])
+}
+output "objectOutput" {
+  value = jsonencode({
+    "key"   = "value"
+    "count" = 1
+  })
+}
+locals {
+  nestedObject = {
+    "anObject" = {
+      "name"  = var.aString
+      "items" = var.aList
+    }
+    "a_secret" = var.aSecret
+  }
+}
+output "nestedOutput" {
+  value = jsonencode(local.nestedObject)
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-to-json/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-to-json/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-to-json
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-to-json/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-to-json/main.hcl
@@ -1,0 +1,42 @@
+variable "aString" {
+  type = string
+}
+variable "aNumber" {
+  type = number
+}
+variable "aList" {
+  type = list(string)
+}
+variable "aSecret" {
+  type = string
+}
+output "stringOutput" {
+  value = jsonencode(var.aString)
+}
+output "numberOutput" {
+  value = jsonencode(var.aNumber)
+}
+output "boolOutput" {
+  value = jsonencode(true)
+}
+output "arrayOutput" {
+  value = jsonencode(["x", "y", "z"])
+}
+output "objectOutput" {
+  value = jsonencode({
+    "key"   = "value"
+    "count" = 1
+  })
+}
+locals {
+  nestedObject = {
+    "anObject" = {
+      "name"  = var.aString
+      "items" = var.aList
+    }
+    "a_secret" = var.aSecret
+  }
+}
+output "nestedOutput" {
+  value = jsonencode(local.nestedObject)
+}

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1333,6 +1333,8 @@ func (g *generator) funcCallTokens(expr *model.FunctionCallExpression) (hclwrite
 		return g.passthroughFuncCallTokens("base64encode", expr.Args)
 	case "fromBase64":
 		return g.passthroughFuncCallTokens("base64decode", expr.Args)
+	case "toJSON":
+		return g.passthroughFuncCallTokens("jsonencode", expr.Args)
 	case "notImplemented":
 		return g.notImplementedTokens(expr)
 	default:

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -1541,6 +1541,8 @@ func transformFunctionName(name string) string {
 		return "toBase64"
 	case "base64decode":
 		return "fromBase64"
+	case "jsonencode":
+		return "toJSON"
 	case "sensitive":
 		return "secret"
 	case "one":


### PR DESCRIPTION
Map PCL's toJSON to HCL's jsonencode in codegen, and add the reverse jsonencode → toJSON mapping in the converter eject path. This follows the same pattern as the existing toBase64/base64encode mapping.