### PR TITLE
Fix optional null properties and conditional eject, unskip l2-resource-optional

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -135,7 +135,6 @@ var expectedFailures = map[string]string{
 		" - not compatible with block syntax",
 	"l2-logical-name": "unsupported in HCL: __logicalName support not yet implemented" +
 		" - requires mapping between lexical names (code references) and logical names (resource names)",
-	"l2-resource-optional":                        "optional properties return Computed instead of null",
 	"l2-resource-option-ignore-changes":            "unknown node tags.env - map-key ignore_changes not supported",
 	"l3-component-config-objects":                  "expected resource named plain not found",
 	"l3-component-config-primitives":               "expected resource named plain not found",

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-optional/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-optional/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-optional
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-optional/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-optional/main.pp
@@ -1,0 +1,102 @@
+resource "unsetA" "optionalprimitive:index:Resource" {
+}
+
+resource "unsetB" "optionalprimitive:index:Resource" {
+  boolean     = unsetA.boolean
+  float       = unsetA.float
+  integer     = unsetA.integer
+  string      = unsetA.string
+  numberArray = unsetA.numberArray
+  booleanMap  = unsetA.booleanMap
+}
+
+resource "setA" "optionalprimitive:index:Resource" {
+  boolean     = true
+  float       = 3.14
+  integer     = 42
+  string      = "hello"
+  numberArray = [-1, 0, 1]
+  booleanMap = {
+    "t" = true
+    "f" = false
+  }
+}
+
+resource "setB" "optionalprimitive:index:Resource" {
+  boolean     = setA.boolean
+  float       = setA.float
+  integer     = setA.integer
+  string      = setA.string
+  numberArray = setA.numberArray
+  booleanMap  = setA.booleanMap
+}
+
+resource "sourcePrimitive" "primitive:index:Resource" {
+  boolean     = true
+  float       = 3.14
+  integer     = 42
+  string      = "hello"
+  numberArray = [-1, 0, 1]
+  booleanMap = {
+    "t" = true
+    "f" = false
+  }
+}
+
+resource "fromPrimitive" "optionalprimitive:index:Resource" {
+  boolean     = sourcePrimitive.boolean
+  float       = sourcePrimitive.float
+  integer     = sourcePrimitive.integer
+  string      = sourcePrimitive.string
+  numberArray = sourcePrimitive.numberArray
+  booleanMap  = sourcePrimitive.booleanMap
+}
+
+output "unsetBoolean" {
+  value = unsetB.boolean == null ? "null" : "not null"
+}
+
+output "unsetFloat" {
+  value = unsetB.float == null ? "null" : "not null"
+}
+
+output "unsetInteger" {
+  value = unsetB.integer == null ? "null" : "not null"
+}
+
+output "unsetString" {
+  value = unsetB.string == null ? "null" : "not null"
+}
+
+output "unsetNumberArray" {
+  value = unsetB.numberArray == null ? "null" : "not null"
+}
+
+output "unsetBooleanMap" {
+  value = unsetB.booleanMap == null ? "null" : "not null"
+}
+
+output "setBoolean" {
+  value = setB.boolean
+}
+
+output "setFloat" {
+  value = setB.float
+}
+
+output "setInteger" {
+  value = setB.integer
+}
+
+output "setString" {
+  value = setB.string
+}
+
+output "setNumberArray" {
+  value = setB.numberArray
+}
+
+output "setBooleanMap" {
+  value = setB.booleanMap
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-optional/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-optional/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-optional
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-optional/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-optional/main.hcl
@@ -1,0 +1,97 @@
+terraform {
+  required_providers {
+    optionalprimitive = {
+      source  = "pulumi/optionalprimitive"
+      version = "34.0.0"
+    }
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+resource "optionalprimitive_resource" "unsetA" {
+}
+resource "optionalprimitive_resource" "unsetB" {
+  boolean      = optionalprimitive_resource.unsetA.boolean
+  float        = optionalprimitive_resource.unsetA.float
+  integer      = optionalprimitive_resource.unsetA.integer
+  string       = optionalprimitive_resource.unsetA.string
+  number_array = optionalprimitive_resource.unsetA.number_array
+  boolean_map  = optionalprimitive_resource.unsetA.boolean_map
+}
+resource "optionalprimitive_resource" "setA" {
+  boolean      = true
+  float        = 3.14
+  integer      = 42
+  string       = "hello"
+  number_array = [-1, 0, 1]
+  boolean_map = {
+    "t" = true
+    "f" = false
+  }
+}
+resource "optionalprimitive_resource" "setB" {
+  boolean      = optionalprimitive_resource.setA.boolean
+  float        = optionalprimitive_resource.setA.float
+  integer      = optionalprimitive_resource.setA.integer
+  string       = optionalprimitive_resource.setA.string
+  number_array = optionalprimitive_resource.setA.number_array
+  boolean_map  = optionalprimitive_resource.setA.boolean_map
+}
+resource "primitive_resource" "sourcePrimitive" {
+  boolean      = true
+  float        = 3.14
+  integer      = 42
+  string       = "hello"
+  number_array = [-1, 0, 1]
+  boolean_map = {
+    "t" = true
+    "f" = false
+  }
+}
+resource "optionalprimitive_resource" "fromPrimitive" {
+  boolean      = primitive_resource.sourcePrimitive.boolean
+  float        = primitive_resource.sourcePrimitive.float
+  integer      = primitive_resource.sourcePrimitive.integer
+  string       = primitive_resource.sourcePrimitive.string
+  number_array = primitive_resource.sourcePrimitive.number_array
+  boolean_map  = primitive_resource.sourcePrimitive.boolean_map
+}
+output "unsetBoolean" {
+  value = optionalprimitive_resource.unsetB.boolean == null ? "null" : "not null"
+}
+output "unsetFloat" {
+  value = optionalprimitive_resource.unsetB.float == null ? "null" : "not null"
+}
+output "unsetInteger" {
+  value = optionalprimitive_resource.unsetB.integer == null ? "null" : "not null"
+}
+output "unsetString" {
+  value = optionalprimitive_resource.unsetB.string == null ? "null" : "not null"
+}
+output "unsetNumberArray" {
+  value = optionalprimitive_resource.unsetB.number_array == null ? "null" : "not null"
+}
+output "unsetBooleanMap" {
+  value = optionalprimitive_resource.unsetB.boolean_map == null ? "null" : "not null"
+}
+output "setBoolean" {
+  value = optionalprimitive_resource.setB.boolean
+}
+output "setFloat" {
+  value = optionalprimitive_resource.setB.float
+}
+output "setInteger" {
+  value = optionalprimitive_resource.setB.integer
+}
+output "setString" {
+  value = optionalprimitive_resource.setB.string
+}
+output "setNumberArray" {
+  value = optionalprimitive_resource.setB.number_array
+}
+output "setBooleanMap" {
+  value = optionalprimitive_resource.setB.boolean_map
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-optional/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-optional/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-optional
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-optional/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-optional/main.hcl
@@ -1,0 +1,97 @@
+terraform {
+  required_providers {
+    optionalprimitive = {
+      source  = "pulumi/optionalprimitive"
+      version = "34.0.0"
+    }
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+resource "optionalprimitive_resource" "unsetA" {
+}
+resource "optionalprimitive_resource" "unsetB" {
+  boolean      = optionalprimitive_resource.unsetA.boolean
+  float        = optionalprimitive_resource.unsetA.float
+  integer      = optionalprimitive_resource.unsetA.integer
+  string       = optionalprimitive_resource.unsetA.string
+  number_array = optionalprimitive_resource.unsetA.number_array
+  boolean_map  = optionalprimitive_resource.unsetA.boolean_map
+}
+resource "optionalprimitive_resource" "setA" {
+  boolean      = true
+  float        = 3.14
+  integer      = 42
+  string       = "hello"
+  number_array = [-1, 0, 1]
+  boolean_map = {
+    "t" = true
+    "f" = false
+  }
+}
+resource "optionalprimitive_resource" "setB" {
+  boolean      = optionalprimitive_resource.setA.boolean
+  float        = optionalprimitive_resource.setA.float
+  integer      = optionalprimitive_resource.setA.integer
+  string       = optionalprimitive_resource.setA.string
+  number_array = optionalprimitive_resource.setA.number_array
+  boolean_map  = optionalprimitive_resource.setA.boolean_map
+}
+resource "primitive_resource" "sourcePrimitive" {
+  boolean      = true
+  float        = 3.14
+  integer      = 42
+  string       = "hello"
+  number_array = [-1, 0, 1]
+  boolean_map = {
+    "t" = true
+    "f" = false
+  }
+}
+resource "optionalprimitive_resource" "fromPrimitive" {
+  boolean      = primitive_resource.sourcePrimitive.boolean
+  float        = primitive_resource.sourcePrimitive.float
+  integer      = primitive_resource.sourcePrimitive.integer
+  string       = primitive_resource.sourcePrimitive.string
+  number_array = primitive_resource.sourcePrimitive.number_array
+  boolean_map  = primitive_resource.sourcePrimitive.boolean_map
+}
+output "unsetBoolean" {
+  value = optionalprimitive_resource.unsetB.boolean == null ? "null" : "not null"
+}
+output "unsetFloat" {
+  value = optionalprimitive_resource.unsetB.float == null ? "null" : "not null"
+}
+output "unsetInteger" {
+  value = optionalprimitive_resource.unsetB.integer == null ? "null" : "not null"
+}
+output "unsetString" {
+  value = optionalprimitive_resource.unsetB.string == null ? "null" : "not null"
+}
+output "unsetNumberArray" {
+  value = optionalprimitive_resource.unsetB.number_array == null ? "null" : "not null"
+}
+output "unsetBooleanMap" {
+  value = optionalprimitive_resource.unsetB.boolean_map == null ? "null" : "not null"
+}
+output "setBoolean" {
+  value = optionalprimitive_resource.setB.boolean
+}
+output "setFloat" {
+  value = optionalprimitive_resource.setB.float
+}
+output "setInteger" {
+  value = optionalprimitive_resource.setB.integer
+}
+output "setString" {
+  value = optionalprimitive_resource.setB.string
+}
+output "setNumberArray" {
+  value = optionalprimitive_resource.setB.number_array
+}
+output "setBooleanMap" {
+  value = optionalprimitive_resource.setB.boolean_map
+}

--- a/cmd/pulumi-language-hcl/testdata/sdks/optionalprimitive-34.0.0/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/sdks/optionalprimitive-34.0.0/hcl.sdk.json
@@ -1,0 +1,8 @@
+{
+  "Name": "optionalprimitive",
+  "Kind": "resource",
+  "Version": "34.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null
+}

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -663,6 +663,26 @@ func (ft *fileTransformer) transformExpr(expr hclsyntax.Expression) hclwrite.Tok
 			val[0].SpacesBefore = 1
 		}
 		return append(hclwrite.Tokens{op}, val...)
+	case *hclsyntax.ConditionalExpr:
+		cond := ft.transformExpr(e.Condition)
+		trueVal := ft.transformExpr(e.TrueResult)
+		falseVal := ft.transformExpr(e.FalseResult)
+		tokens := cond
+		tokens = append(tokens, &hclwrite.Token{
+			Type: hclsyntax.TokenQuestion, Bytes: []byte("?"), SpacesBefore: 1,
+		})
+		if len(trueVal) > 0 {
+			trueVal[0].SpacesBefore = 1
+		}
+		tokens = append(tokens, trueVal...)
+		tokens = append(tokens, &hclwrite.Token{
+			Type: hclsyntax.TokenColon, Bytes: []byte(":"), SpacesBefore: 1,
+		})
+		if len(falseVal) > 0 {
+			falseVal[0].SpacesBefore = 1
+		}
+		tokens = append(tokens, falseVal...)
+		return tokens
 	case *hclsyntax.ForExpr:
 		return ft.transformForExpr(e)
 	case *hclsyntax.SplatExpr:

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -463,9 +463,11 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, already
 	// Strip unneeded signifiers
 	prop = codegen.UnwrapType(prop)
 
-	// Handle primitive types & unknown
+	// Handle null & unknown
 
 	switch {
+	case val.IsNull():
+		return property.Value{}, nil
 	case !val.IsKnown():
 		return property.New(property.Computed), nil
 	case val.Type().Equals(cty.String):
@@ -747,7 +749,11 @@ func propertyObjectToCtyMap(path string, m property.Map, properties []*schema.Pr
 		hclName := snakeCaseFromCamelCase(p.Name)
 		v, ok := m.GetOk(p.Name)
 		if !ok {
-			result[hclName] = cty.UnknownVal(ctyTypeFromType(p.Type))
+			if dryRun {
+				result[hclName] = cty.UnknownVal(ctyTypeFromType(p.Type))
+			} else {
+				result[hclName] = cty.NullVal(ctyTypeFromType(p.Type))
+			}
 			continue
 		}
 		// During preview, required properties that are null are treated as unknown.


### PR DESCRIPTION
Two bugs prevented l2-resource-optional from passing:

1. `propertyObjectToCtyMap` returned `cty.UnknownVal` for absent properties even outside of dry-run. During actual execution, absent optional properties should be null, not unknown. Also added a null check in `ctyToResourceProperty` to avoid panicking on null cty values.

2. The HCL→PCL converter didn't handle `ConditionalExpr` (ternary), so expressions like `resource_type.name.attr == null ? "a" : "b"` were copied verbatim instead of having their traversals transformed.