### PR TITLE
Unskip l3-component-config-primitives

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -137,7 +137,6 @@ var expectedFailures = map[string]string{
 		" - requires mapping between lexical names (code references) and logical names (resource names)",
 	"l2-resource-option-ignore-changes":            "unknown node tags.env - map-key ignore_changes not supported",
 	"l3-component-config-objects":                  "expected resource named plain not found",
-	"l3-component-config-primitives":               "expected resource named plain not found",
 	"l3-rewrite-conversions": "resource direct is invalid",
 }
 

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-primitives/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-primitives/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-config-primitives
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-primitives/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-primitives/main.pp
@@ -1,0 +1,38 @@
+config "plainBool" "bool" {
+}
+
+config "plainNumber" "number" {
+}
+
+config "plainInteger" "number" {
+}
+
+config "plainString" "string" {
+}
+
+config "secretBool" "bool" {
+}
+
+config "secretNumber" "number" {
+}
+
+config "secretInteger" "number" {
+}
+
+config "secretString" "string" {
+}
+
+component "plain" "./primitiveComponent" {
+  boolean = plainBool
+  float   = plainNumber
+  integer = plainInteger
+  string  = plainString
+}
+
+component "secret" "./primitiveComponent" {
+  boolean = secretBool
+  float   = secretNumber
+  integer = secretInteger
+  string  = secretString
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-primitives/primitiveComponent/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-primitives/primitiveComponent/main.pp
@@ -1,0 +1,24 @@
+resource "res" "primitive:index:Resource" {
+  boolean     = boolean
+  float       = float
+  integer     = integer
+  string      = string
+  numberArray = [-1, 0, 1]
+  booleanMap = {
+    "t" = true
+    "f" = false
+  }
+}
+
+config "boolean" "bool" {
+}
+
+config "float" "number" {
+}
+
+config "integer" "number" {
+}
+
+config "string" "string" {
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-primitives/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-primitives/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-config-primitives
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-primitives/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-primitives/main.hcl
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+variable "plainBool" {
+  type = bool
+}
+variable "plainNumber" {
+  type = number
+}
+variable "plainInteger" {
+  type = number
+}
+variable "plainString" {
+  type = string
+}
+variable "secretBool" {
+  type = bool
+}
+variable "secretNumber" {
+  type = number
+}
+variable "secretInteger" {
+  type = number
+}
+variable "secretString" {
+  type = string
+}
+module "plain" {
+  source  = "./primitiveComponent"
+  boolean = var.plainBool
+  float   = var.plainNumber
+  integer = var.plainInteger
+  string  = var.plainString
+}
+module "secret" {
+  source  = "./primitiveComponent"
+  boolean = var.secretBool
+  float   = var.secretNumber
+  integer = var.secretInteger
+  string  = var.secretString
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-primitives/primitiveComponent/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-primitives/primitiveComponent/main.hcl
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+resource "primitive_resource" "res" {
+  boolean      = var.boolean
+  float        = var.float
+  integer      = var.integer
+  string       = var.string
+  number_array = [-1, 0, 1]
+  boolean_map = {
+    "t" = true
+    "f" = false
+  }
+}
+variable "boolean" {
+  type = bool
+}
+variable "float" {
+  type = number
+}
+variable "integer" {
+  type = number
+}
+variable "string" {
+  type = string
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-primitives/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-primitives/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-config-primitives
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-primitives/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-primitives/main.hcl
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+variable "plainBool" {
+  type = bool
+}
+variable "plainNumber" {
+  type = number
+}
+variable "plainInteger" {
+  type = number
+}
+variable "plainString" {
+  type = string
+}
+variable "secretBool" {
+  type = bool
+}
+variable "secretNumber" {
+  type = number
+}
+variable "secretInteger" {
+  type = number
+}
+variable "secretString" {
+  type = string
+}
+module "plain" {
+  source  = "./primitiveComponent"
+  boolean = var.plainBool
+  float   = var.plainNumber
+  integer = var.plainInteger
+  string  = var.plainString
+}
+module "secret" {
+  source  = "./primitiveComponent"
+  boolean = var.secretBool
+  float   = var.secretNumber
+  integer = var.secretInteger
+  string  = var.secretString
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-primitives/primitiveComponent/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-primitives/primitiveComponent/main.hcl
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+resource "primitive_resource" "res" {
+  boolean      = var.boolean
+  float        = var.float
+  integer      = var.integer
+  string       = var.string
+  number_array = [-1, 0, 1]
+  boolean_map = {
+    "t" = true
+    "f" = false
+  }
+}
+variable "boolean" {
+  type = bool
+}
+variable "float" {
+  type = number
+}
+variable "integer" {
+  type = number
+}
+variable "string" {
+  type = string
+}


### PR DESCRIPTION
The l3-component-config-primitives language test was listed as a known failure but passes without any code changes. This removes it from the skip list and adds the generated snapshot files.