### PR TITLE
Fix ignore_changes with map keys and index traversals, unskip l2-resource-option-ignore-changes

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -135,7 +135,6 @@ var expectedFailures = map[string]string{
 		" - not compatible with block syntax",
 	"l2-logical-name": "unsupported in HCL: __logicalName support not yet implemented" +
 		" - requires mapping between lexical names (code references) and logical names (resource names)",
-	"l2-resource-option-ignore-changes":            "unknown node tags.env - map-key ignore_changes not supported",
 	"l3-component-config-objects":                  "expected resource named plain not found",
 	"l3-rewrite-conversions": "resource direct is invalid",
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-ignore-changes/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-ignore-changes/main.pp
@@ -1,11 +1,23 @@
-resource "ignoreChanges" "simple:index:Resource" {
-  value = true
+resource "receiverIgnore" "nestedobject:index:Receiver" {
+  details = [{
+    key   = "a"
+    value = "b"
+  }]
   options {
-    ignoreChanges = [value]
+    ignoreChanges = [details[0].key]
   }
 }
 
-resource "notIgnoreChanges" "simple:index:Resource" {
-  value = true
+resource "mapIgnore" "nestedobject:index:MapContainer" {
+  tags = {
+    "env" = "prod"
+  }
+  options {
+    ignoreChanges = [tags["env"], tags["with.dot"], tags["with escaped \""]]
+  }
+}
+
+resource "noIgnore" "nestedobject:index:Target" {
+  name = "nothing"
 }
 

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-ignore-changes/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-ignore-changes/main.hcl
@@ -1,18 +1,29 @@
 terraform {
   required_providers {
-    simple = {
-      source  = "pulumi/simple"
-      version = "2.0.0"
+    nestedobject = {
+      source  = "pulumi/nestedobject"
+      version = "1.42.0"
     }
   }
 }
 
-resource "simple_resource" "ignoreChanges" {
+resource "nestedobject_receiver" "receiverIgnore" {
   lifecycle {
-    ignore_changes = [value]
+    ignore_changes = [details[0].key]
   }
-  value = true
+  details {
+    key   = "a"
+    value = "b"
+  }
 }
-resource "simple_resource" "notIgnoreChanges" {
-  value = true
+resource "nestedobject_mapcontainer" "mapIgnore" {
+  lifecycle {
+    ignore_changes = [tags["env"], tags["with.dot"], tags["with escaped \""]]
+  }
+  tags = {
+    "env" = "prod"
+  }
+}
+resource "nestedobject_target" "noIgnore" {
+  name = "nothing"
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-ignore-changes/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-ignore-changes/main.hcl
@@ -1,18 +1,29 @@
 terraform {
   required_providers {
-    simple = {
-      source  = "pulumi/simple"
-      version = "2.0.0"
+    nestedobject = {
+      source  = "pulumi/nestedobject"
+      version = "1.42.0"
     }
   }
 }
 
-resource "simple_resource" "ignoreChanges" {
+resource "nestedobject_receiver" "receiverIgnore" {
   lifecycle {
-    ignore_changes = [value]
+    ignore_changes = [details[0].key]
   }
-  value = true
+  details {
+    key   = "a"
+    value = "b"
+  }
 }
-resource "simple_resource" "notIgnoreChanges" {
-  value = true
+resource "nestedobject_mapcontainer" "mapIgnore" {
+  lifecycle {
+    ignore_changes = [tags["env"], tags["with.dot"], tags["with escaped \""]]
+  }
+  tags = {
+    "env" = "prod"
+  }
+}
+resource "nestedobject_target" "noIgnore" {
+  name = "nothing"
 }

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -470,6 +470,10 @@ func transformHCLFileToPCL(
 					opts = append(opts, optEntry{pclName, tokens})
 				}
 			}
+			// Separate special sub-blocks (lifecycle, timeouts, dynamic) from
+			// property sub-blocks (e.g. details { ... }) that represent
+			// array-of-object input properties.
+			var propertyBlocks []*hclsyntax.Block
 			for _, subBlock := range block.Body.Blocks {
 				switch subBlock.Type {
 				case "dynamic":
@@ -507,13 +511,13 @@ func transformHCLFileToPCL(
 						opts = append(opts, optEntry{"customTimeouts", hclwrite.TokensForObject(timeoutAttrs)})
 					}
 				default:
-					resultDiags = append(resultDiags, &hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "unsupported resource sub-block",
-						Detail:   fmt.Sprintf("resource sub-block %q is not supported by the HCL converter", subBlock.Type),
-						Subject:  subBlock.TypeRange.Ptr(),
-					})
+					propertyBlocks = append(propertyBlocks, subBlock)
 				}
+			}
+			// Convert property sub-blocks to PCL object-list attributes.
+			for _, objAttr := range ft.blocksToObjectAttrs(propertyBlocks, res.InputProperties) {
+				name := strings.TrimSpace(string(objAttr.Name.Bytes()))
+				blk.Body().SetAttributeRaw(name, objAttr.Value)
 			}
 			if len(opts) > 0 {
 				optBlk := blk.Body().AppendNewBlock("options", nil)

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -422,6 +422,24 @@ func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) 
 				for _, dep := range g.bodyDeps(block.Body, prefix, childExclude) {
 					seen[dep] = true
 				}
+			} else if block.Type == "lifecycle" {
+				// lifecycle blocks contain ignore_changes which holds property
+				// paths (e.g. tags["env"]), not dependency references. We must
+				// skip that attribute to avoid creating spurious graph nodes.
+				for attrName, attr := range block.Body.Attributes {
+					if attrName == "ignore_changes" {
+						continue
+					}
+					for _, dep := range g.exprDepsExcluding(attr.Expr, prefix, exclude) {
+						seen[dep] = true
+					}
+				}
+				// Still recurse into nested blocks (precondition, postcondition).
+				for _, nested := range block.Body.Blocks {
+					for _, dep := range g.bodyDeps(nested.Body, prefix, exclude) {
+						seen[dep] = true
+					}
+				}
 			} else {
 				for _, dep := range g.bodyDeps(block.Body, prefix, exclude) {
 					seen[dep] = true

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1490,28 +1490,31 @@ func formatTraversalForIgnoreChanges(traversal hcl.Traversal) string {
 		return ""
 	}
 
-	var parts []string
-	for _, step := range traversal {
+	var buf strings.Builder
+	for i, step := range traversal {
 		switch s := step.(type) {
 		case hcl.TraverseRoot:
-			parts = append(parts, s.Name)
+			buf.WriteString(s.Name)
 		case hcl.TraverseAttr:
-			parts = append(parts, s.Name)
+			if i > 0 {
+				buf.WriteByte('.')
+			}
+			buf.WriteString(s.Name)
 		case hcl.TraverseIndex:
-			// For index traversals, add [key] or [index]
+			// Index traversals use bracket notation without a leading dot.
 			key := s.Key
 			if key.Type() == cty.String {
-				parts = append(parts, fmt.Sprintf("[%q]", key.AsString()))
+				fmt.Fprintf(&buf, "[%q]", key.AsString())
 			} else if key.Type() == cty.Number {
 				bf := key.AsBigFloat()
 				if i64, acc := bf.Int64(); acc == 0 {
-					parts = append(parts, fmt.Sprintf("[%d]", i64))
+					fmt.Fprintf(&buf, "[%d]", i64)
 				}
 			}
 		}
 	}
 
-	return strings.Join(parts, ".")
+	return buf.String()
 }
 
 // ResourceOptions contains resource registration options.


### PR DESCRIPTION
Three bugs prevented `l2-resource-option-ignore-changes` from passing:

1. **Graph**: `ignore_changes` property paths (like `tags["env"]`) were being resolved as dependency graph nodes, causing "unknown node" errors. Lifecycle blocks now skip `ignore_changes` during dependency analysis since those are property paths, not resource references.

2. **Runtime**: `formatTraversalForIgnoreChanges` joined all traversal parts with `.`, producing `tags.["env"]` instead of `tags["env"]`. Index traversals now use bracket notation without a leading dot.

3. **Converter**: Resource property sub-blocks (e.g. `details { key = "a" }`) hit the "unsupported resource sub-block" error during eject. These are now handled by the existing `blocksToObjectAttrs` helper.