### PR TITLE
Unskip l3-component-config-objects

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -135,7 +135,6 @@ var expectedFailures = map[string]string{
 		" - not compatible with block syntax",
 	"l2-logical-name": "unsupported in HCL: __logicalName support not yet implemented" +
 		" - requires mapping between lexical names (code references) and logical names (resource names)",
-	"l3-component-config-objects":                  "expected resource named plain not found",
 	"l3-rewrite-conversions": "resource direct is invalid",
 }
 

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-objects/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-objects/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-config-objects
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-objects/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-objects/main.pp
@@ -1,0 +1,22 @@
+config "plainNumberArray" "list(int)" {
+}
+
+config "plainBooleanMap" "map(bool)" {
+}
+
+config "secretNumberArray" "list(int)" {
+}
+
+config "secretBooleanMap" "map(bool)" {
+}
+
+component "plain" "./primitiveComponent" {
+  numberArray = plainNumberArray
+  booleanMap  = plainBooleanMap
+}
+
+component "secret" "./primitiveComponent" {
+  numberArray = secretNumberArray
+  booleanMap  = secretBooleanMap
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-objects/primitiveComponent/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-config-objects/primitiveComponent/main.pp
@@ -1,0 +1,15 @@
+resource "res" "primitive:index:Resource" {
+  boolean     = true
+  float       = 3.5
+  integer     = 3
+  string      = "plain"
+  numberArray = numberArray
+  booleanMap  = booleanMap
+}
+
+config "numberArray" "list(int)" {
+}
+
+config "booleanMap" "map(bool)" {
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-objects/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-objects/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-config-objects
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-objects/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-objects/main.hcl
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+variable "plainNumberArray" {
+  type = list(number)
+}
+variable "plainBooleanMap" {
+  type = map(bool)
+}
+variable "secretNumberArray" {
+  type = list(number)
+}
+variable "secretBooleanMap" {
+  type = map(bool)
+}
+module "plain" {
+  source      = "./primitiveComponent"
+  numberArray = var.plainNumberArray
+  booleanMap  = var.plainBooleanMap
+}
+module "secret" {
+  source      = "./primitiveComponent"
+  numberArray = var.secretNumberArray
+  booleanMap  = var.secretBooleanMap
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-objects/primitiveComponent/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-objects/primitiveComponent/main.hcl
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+resource "primitive_resource" "res" {
+  boolean      = true
+  float        = 3.5
+  integer      = 3
+  string       = "plain"
+  number_array = var.numberArray
+  boolean_map  = var.booleanMap
+}
+variable "numberArray" {
+  type = list(number)
+}
+variable "booleanMap" {
+  type = map(bool)
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-objects/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-objects/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-config-objects
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-objects/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-objects/main.hcl
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+variable "plainNumberArray" {
+  type = list(number)
+}
+variable "plainBooleanMap" {
+  type = map(bool)
+}
+variable "secretNumberArray" {
+  type = list(number)
+}
+variable "secretBooleanMap" {
+  type = map(bool)
+}
+module "plain" {
+  source      = "./primitiveComponent"
+  numberArray = var.plainNumberArray
+  booleanMap  = var.plainBooleanMap
+}
+module "secret" {
+  source      = "./primitiveComponent"
+  numberArray = var.secretNumberArray
+  booleanMap  = var.secretBooleanMap
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-objects/primitiveComponent/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-objects/primitiveComponent/main.hcl
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+resource "primitive_resource" "res" {
+  boolean      = true
+  float        = 3.5
+  integer      = 3
+  string       = "plain"
+  number_array = var.numberArray
+  boolean_map  = var.booleanMap
+}
+variable "numberArray" {
+  type = list(number)
+}
+variable "booleanMap" {
+  type = map(bool)
+}


### PR DESCRIPTION
The l3-component-config-objects test was already passing — it just needed to be removed from the expected failures list.