### PR TITLE
Fix type coercion for resource and component inputs, unskip l3-rewrite-conversions

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -135,7 +135,6 @@ var expectedFailures = map[string]string{
 		" - not compatible with block syntax",
 	"l2-logical-name": "unsupported in HCL: __logicalName support not yet implemented" +
 		" - requires mapping between lexical names (code references) and logical names (resource names)",
-	"l3-rewrite-conversions": "resource direct is invalid",
 }
 
 // expectedEjectFailures lists tests whose eject (HCL→PCL conversion) step is

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-rewrite-conversions/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-rewrite-conversions/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-rewrite-conversions
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-rewrite-conversions/converted/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-rewrite-conversions/converted/main.pp
@@ -1,0 +1,27 @@
+resource "res" "primitive:index:Resource" {
+  boolean     = boolean
+  float       = float
+  integer     = integer
+  string      = string
+  numberArray = numberArray
+  booleanMap  = booleanMap
+}
+
+config "boolean" "bool" {
+}
+
+config "float" "number" {
+}
+
+config "integer" "number" {
+}
+
+config "string" "string" {
+}
+
+config "numberArray" "list(int)" {
+}
+
+config "booleanMap" "map(bool)" {
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-rewrite-conversions/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-rewrite-conversions/main.pp
@@ -1,0 +1,24 @@
+resource "direct" "primitive:index:Resource" {
+  boolean     = "true"
+  float       = "3.14"
+  integer     = "42"
+  string      = false
+  numberArray = ["-1", "0", "1"]
+  booleanMap = {
+    "t" = "true"
+    "f" = "false"
+  }
+}
+
+component "converted" "./converted" {
+  boolean     = "false"
+  float       = "2.5"
+  integer     = "7"
+  string      = true
+  numberArray = ["10", "11"]
+  booleanMap = {
+    "left"  = "true"
+    "right" = "false"
+  }
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-rewrite-conversions/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-rewrite-conversions/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-rewrite-conversions
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-rewrite-conversions/converted/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-rewrite-conversions/converted/main.hcl
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+resource "primitive_resource" "res" {
+  boolean      = var.boolean
+  float        = var.float
+  integer      = var.integer
+  string       = var.string
+  number_array = var.numberArray
+  boolean_map  = var.booleanMap
+}
+variable "boolean" {
+  type = bool
+}
+variable "float" {
+  type = number
+}
+variable "integer" {
+  type = number
+}
+variable "string" {
+  type = string
+}
+variable "numberArray" {
+  type = list(number)
+}
+variable "booleanMap" {
+  type = map(bool)
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-rewrite-conversions/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-rewrite-conversions/main.hcl
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+resource "primitive_resource" "direct" {
+  boolean      = "true"
+  float        = "3.14"
+  integer      = "42"
+  string       = false
+  number_array = ["-1", "0", "1"]
+  boolean_map = {
+    "t" = "true"
+    "f" = "false"
+  }
+}
+module "converted" {
+  source      = "./converted"
+  boolean     = "false"
+  float       = "2.5"
+  integer     = "7"
+  string      = true
+  numberArray = ["10", "11"]
+  booleanMap = {
+    "left"  = "true"
+    "right" = "false"
+  }
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-rewrite-conversions/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-rewrite-conversions/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-rewrite-conversions
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-rewrite-conversions/converted/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-rewrite-conversions/converted/main.hcl
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+resource "primitive_resource" "res" {
+  boolean      = var.boolean
+  float        = var.float
+  integer      = var.integer
+  string       = var.string
+  number_array = var.numberArray
+  boolean_map  = var.booleanMap
+}
+variable "boolean" {
+  type = bool
+}
+variable "float" {
+  type = number
+}
+variable "integer" {
+  type = number
+}
+variable "string" {
+  type = string
+}
+variable "numberArray" {
+  type = list(number)
+}
+variable "booleanMap" {
+  type = map(bool)
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-rewrite-conversions/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-rewrite-conversions/main.hcl
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    primitive = {
+      source  = "pulumi/primitive"
+      version = "7.0.0"
+    }
+  }
+}
+
+resource "primitive_resource" "direct" {
+  boolean      = "true"
+  float        = "3.14"
+  integer      = "42"
+  string       = false
+  number_array = ["-1", "0", "1"]
+  boolean_map = {
+    "t" = "true"
+    "f" = "false"
+  }
+}
+module "converted" {
+  source      = "./converted"
+  boolean     = "false"
+  float       = "2.5"
+  integer     = "7"
+  string      = true
+  numberArray = ["10", "11"]
+  booleanMap = {
+    "left"  = "true"
+    "right" = "false"
+  }
+}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
+	ctyconvert "github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 	"github.com/zclconf/go-cty/cty/json"
 )
@@ -2008,6 +2009,13 @@ func (e *Engine) processModuleVariable(node *graph.Node) error {
 			}
 		}
 
+		// Coerce the value to match the variable's type constraint.
+		if v.TypeConstraint != cty.NilType && !val.IsNull() && val.IsKnown() {
+			if converted, err := ctyconvert.Convert(val, v.TypeConstraint); err == nil {
+				val = converted
+			}
+		}
+
 		if v.Sensitive {
 			val = val.Mark("sensitive")
 		}
@@ -2041,6 +2049,12 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 
 	baseKey := modInfo.ParentPrefix + "module." + modInfo.ModuleName
 
+	// Load the child module to get variable type constraints for input coercion.
+	childMod, err := e.moduleLoader.LoadModule(mod.Source, e.workDir)
+	if err != nil {
+		return fmt.Errorf("loading module %s for input types: %w", mod.Source, err)
+	}
+
 	// Evaluate module inputs for the component resource registration
 	inputs := make(map[string]property.Value)
 	attrs, _ := mod.Config.JustAttributes()
@@ -2048,6 +2062,12 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 		val, diags := attr.Expr.Value(parentEvalCtx.HCLContext())
 		if diags.HasErrors() {
 			continue
+		}
+		// Coerce to the variable's declared type if available.
+		if v, ok := childMod.Config.Variables[name]; ok && v.TypeConstraint != cty.NilType {
+			if converted, convErr := ctyconvert.Convert(val, v.TypeConstraint); convErr == nil {
+				val = converted
+			}
 		}
 		pv, err := transform.CtyToPropertyValue(val)
 		if err == nil {

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 const SensativeMark = "sensitive"
@@ -298,6 +299,21 @@ func evalDynamicBlocks(
 	return diags
 }
 
+// schemaToCtyPrimitive returns the cty primitive type corresponding to a
+// Pulumi schema type, if applicable.
+func schemaToCtyPrimitive(typ schema.Type) (cty.Type, bool) {
+	switch codegen.UnwrapType(typ) {
+	case schema.BoolType:
+		return cty.Bool, true
+	case schema.IntType, schema.NumberType:
+		return cty.Number, true
+	case schema.StringType:
+		return cty.String, true
+	default:
+		return cty.NilType, false
+	}
+}
+
 func conformCtyToType(val cty.Value, typ cty.Type) cty.Value {
 	if val.Type().Equals(typ) {
 		return val
@@ -470,6 +486,18 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, already
 		return property.Value{}, nil
 	case !val.IsKnown():
 		return property.New(property.Computed), nil
+	}
+
+	// Coerce the value to match the expected schema type when possible.
+	// This handles cases like boolean = "true" where the HCL literal is a
+	// string but the schema expects a boolean.
+	if targetCtyType, ok := schemaToCtyPrimitive(prop); ok && !val.Type().Equals(targetCtyType) {
+		if converted, err := convert.Convert(val, targetCtyType); err == nil {
+			val = converted
+		}
+	}
+
+	switch {
 	case val.Type().Equals(cty.String):
 		return property.New(val.AsString()), nil
 	case val.Type().Equals(cty.Bool):


### PR DESCRIPTION
Coerce cty values to match schema types when converting to property values. This fixes cases where HCL literals have the wrong primitive type (e.g. `boolean = "true"`) by applying cty's built-in conversion before constructing the Pulumi property value.

For component resources, coerce module inputs to match the child module's variable type constraints so the registered component inputs reflect the expected types.