### PR TITLE
Fix data race in processModuleOutput during parallel graph walk

### DIFF
--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/hcl/v2"
@@ -172,6 +173,7 @@ type moduleInstance struct {
 	Index   *int                 // count index (nil if not using count)
 	EachKey *cty.Value           // for_each key (nil if not using for_each)
 	EachVal *cty.Value           // for_each value (nil if not using for_each)
+	mu      sync.Mutex           // protects Outputs
 	Outputs map[string]cty.Value // collected output values
 }
 
@@ -2072,6 +2074,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 			Key:     baseKey,
 			EvalCtx: instCtx,
 			URN:     componentURN,
+			Outputs: make(map[string]cty.Value),
 		}})
 		return nil
 	}
@@ -2105,6 +2108,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 				EvalCtx: instCtx,
 				URN:     componentURN,
 				Index:   &idx,
+				Outputs: make(map[string]cty.Value),
 			})
 		}
 		e.moduleInstances.Set(modInfo.Prefix, instances)
@@ -2141,6 +2145,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 			URN:     componentURN,
 			EachKey: &k,
 			EachVal: &v,
+			Outputs: make(map[string]cty.Value),
 		})
 	}
 	e.moduleInstances.Set(modInfo.Prefix, instances)
@@ -2161,10 +2166,9 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating module output %s: %s", outputName, diags.Error())
 		}
-		if inst.Outputs == nil {
-			inst.Outputs = make(map[string]cty.Value)
-		}
+		inst.mu.Lock()
 		inst.Outputs[outputName] = val
+		inst.mu.Unlock()
 		return nil
 	})
 	if err != nil {
@@ -2181,7 +2185,11 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 
 	if !isCounted && !isForEach {
 		if len(instances) == 1 {
-			if v, has := instances[0].Outputs[outputName]; has {
+			inst := instances[0]
+			inst.mu.Lock()
+			v, has := inst.Outputs[outputName]
+			inst.mu.Unlock()
+			if has {
 				parentCtx.SetModuleOutput(modInfo.ModuleName, outputName, v)
 			}
 		}
@@ -2189,11 +2197,13 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 		// Rebuild the full tuple from all collected outputs so far.
 		tupleVals := make([]cty.Value, len(instances))
 		for i, inst := range instances {
+			inst.mu.Lock()
 			if len(inst.Outputs) > 0 {
 				tupleVals[i] = cty.ObjectVal(inst.Outputs)
 			} else {
 				tupleVals[i] = cty.EmptyObjectVal
 			}
+			inst.mu.Unlock()
 		}
 		if len(tupleVals) > 0 {
 			parentCtx.SetModule(modInfo.ModuleName, cty.TupleVal(tupleVals))
@@ -2208,11 +2218,13 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 				continue
 			}
 			keyStr := inst.EachKey.AsString()
+			inst.mu.Lock()
 			if len(inst.Outputs) > 0 {
 				mapVals[keyStr] = cty.ObjectVal(inst.Outputs)
 			} else {
 				mapVals[keyStr] = cty.EmptyObjectVal
 			}
+			inst.mu.Unlock()
 		}
 		if len(mapVals) > 0 {
 			parentCtx.SetModule(modInfo.ModuleName, cty.ObjectVal(mapVals))

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -1486,6 +1486,71 @@ output "vpc_id" {
 	}
 }
 
+// TestEngine_ModuleOutputRace verifies that concurrent processing of multiple
+// module outputs does not trigger a data race on moduleInstance.Outputs.
+// This is a regression test for https://github.com/pulumi-labs/pulumi-hcl/issues/60.
+func TestEngine_ModuleOutputRace(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a module with many outputs to maximize scheduling contention.
+	moduleDir := tmpDir + "/modules/multi"
+	if err := os.MkdirAll(moduleDir, 0755); err != nil {
+		t.Fatalf("creating module dir: %v", err)
+	}
+
+	moduleMain := `
+variable "input" {
+  type = string
+}
+
+output "out_a" { value = var.input }
+output "out_b" { value = var.input }
+output "out_c" { value = var.input }
+output "out_d" { value = var.input }
+output "out_e" { value = var.input }
+output "out_f" { value = var.input }
+output "out_g" { value = var.input }
+output "out_h" { value = var.input }
+`
+	if err := os.WriteFile(moduleDir+"/main.hcl", []byte(moduleMain), 0644); err != nil {
+		t.Fatalf("writing module file: %v", err)
+	}
+
+	rootMain := `
+module "multi" {
+  source = "./modules/multi"
+  input  = "hello"
+}
+`
+	if err := os.WriteFile(tmpDir+"/main.hcl", []byte(rootMain), 0644); err != nil {
+		t.Fatalf("writing root file: %v", err)
+	}
+
+	p := parser.NewParser()
+	config, diags := p.ParseDirectory(tmpDir)
+	if diags.HasErrors() {
+		t.Fatalf("parse error: %s", diags.Error())
+	}
+
+	mock := &mockResourceMonitor{}
+	engine := NewEngine(config, &EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         tmpDir,
+		RootDir:         tmpDir,
+		SchemaLoader:    newMockReferenceLoader(t, schema.PackageSpec{Name: "empty"}),
+	})
+
+	// Under -race this would fail before the fix due to concurrent map writes
+	// in processModuleOutput.
+	if err := engine.Run(t.Context()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestEngine_Timeouts(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add `sync.Mutex` to `moduleInstance` to protect concurrent access to the `Outputs` map
- Initialize `Outputs` map at all three instance creation sites, eliminating the nil-check race
- Lock around both writes (in `processModuleOutput` callback) and reads (in the "eagerly publish" section) since multiple output nodes run concurrently in the graph walker
- Add `TestEngine_ModuleOutputRace` regression test with 8 outputs to reliably trigger the race under `-race`

## Test plan
- [x] `go test -race -run TestEngine_ModuleOutputRace -count=10 ./pkg/hcl/run/` passes
- [x] Verified the new test fails without the fix (race detected)
- [x] Full `go test -race ./pkg/hcl/run/` passes

Fixes #60