### PR TITLE
Fix logical name support in codegen and runtime, unskip l2-logical-name

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -133,14 +133,14 @@ var expectedFailures = map[string]string{
 	"l2-plain": "unsupported in HCL:" +
 		" requires that HCL can distinguish between an empty and null List<Object>" +
 		" - not compatible with block syntax",
-	"l2-logical-name": "unsupported in HCL: __logicalName support not yet implemented" +
-		" - requires mapping between lexical names (code references) and logical names (resource names)",
 }
 
 // expectedEjectFailures lists tests whose eject (HCL→PCL conversion) step is
 // expected to fail because the converter does not yet support resources, data
 // sources, or other constructs used by those tests.
-var expectedEjectFailures = map[string]string{}
+var expectedEjectFailures = map[string]string{
+	"l2-logical-name": "converter does not yet emit __logicalName when the logical name is not a valid PCL identifier",
+}
 
 func has[K comparable, V any, M ~map[K]V](m M, k K) bool {
 	_, ok := m[k]

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-logical-name/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-logical-name/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-logical-name
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-logical-name/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-logical-name/main.pp
@@ -1,0 +1,15 @@
+resource "aA-Alpha_alpha.🤯⁉️" "simple:index:Resource" {
+  value = cC-Charlie_charlie.😃⁉️
+}
+
+config "cC-Charlie_charlie.😃⁉️" "bool" {
+}
+
+output "bB-Beta_beta.💜⁉" {
+  value = aA-Alpha_alpha.🤯⁉️.value
+}
+
+output "dD-Delta_delta.🔥⁉" {
+  value = aA-Alpha_alpha.🤯⁉️.value
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-logical-name/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-logical-name/main.hcl
@@ -8,14 +8,14 @@ terraform {
 }
 
 resource "simple_resource" "aA-Alpha_alpha.🤯⁉️" {
-  value = var.configLexicalName
+  value = var["cC-Charlie_charlie.😃⁉️"]
 }
 variable "cC-Charlie_charlie.😃⁉️" {
   type = bool
 }
 output "bB-Beta_beta.💜⁉" {
-  value = simple_resource.resourceLexicalName.value
+  value = simple_resource["aA-Alpha_alpha.🤯⁉️"].value
 }
 output "dD-Delta_delta.🔥⁉" {
-  value = simple_resource.resourceLexicalName.value
+  value = simple_resource["aA-Alpha_alpha.🤯⁉️"].value
 }

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1597,6 +1597,16 @@ func findPropertyType(props []*schema.Property, name string) schema.Type {
 	return nil
 }
 
+// traverseNameStep returns a TraverseAttr for valid HCL identifiers (e.g. `.foo`),
+// or a TraverseIndex with a string key for names that contain special characters
+// (e.g. `["aA-Alpha_alpha.🤯⁉️"]`).
+func traverseNameStep(name string) hcl.Traverser {
+	if hclsyntax.ValidIdentifier(name) {
+		return hcl.TraverseAttr{Name: name}
+	}
+	return hcl.TraverseIndex{Key: cty.StringVal(name)}
+}
+
 // scopeTraversalTokens generates HCL tokens for a scope traversal expression.
 // PCL config variables become HCL `var.<name>`, local variables become `local.<name>`,
 // and resource references become `<resource_type>.<name>.<property>`.
@@ -1611,7 +1621,7 @@ func (g *generator) scopeTraversalTokens(expr *model.ScopeTraversalExpression) (
 		// Rewrite "aMap.x" → "var.aMap.x".
 		rewritten := make(hcl.Traversal, 0, len(traversal)+1)
 		rewritten = append(rewritten, hcl.TraverseRoot{Name: "var"})
-		rewritten = append(rewritten, hcl.TraverseAttr{Name: traversal.RootName()})
+		rewritten = append(rewritten, traverseNameStep(part.LogicalName()))
 		return hclwrite.TokensForTraversal(append(rewritten, traversal[1:]...)), nil
 	case *pcl.LocalVariable:
 		// If this local is backed by an invoke call, substitute the data source reference
@@ -1638,7 +1648,7 @@ func (g *generator) scopeTraversalTokens(expr *model.ScopeTraversalExpression) (
 		// Rewrite "myLocal.x" → "local.myLocal.x".
 		rewritten := make(hcl.Traversal, 0, len(traversal)+1)
 		rewritten = append(rewritten, hcl.TraverseRoot{Name: "local"})
-		rewritten = append(rewritten, hcl.TraverseAttr{Name: traversal.RootName()})
+		rewritten = append(rewritten, traverseNameStep(part.LogicalName()))
 		return hclwrite.TokensForTraversal(append(rewritten, traversal[1:]...)), nil
 	case *pcl.Resource:
 		// Rewrite "myResource.property" → "resource_type.myResource.property".
@@ -1652,13 +1662,13 @@ func (g *generator) scopeTraversalTokens(expr *model.ScopeTraversalExpression) (
 		}
 		rewritten := make(hcl.Traversal, 0, len(traversal)+1)
 		rewritten = append(rewritten, hcl.TraverseRoot{Name: hclType})
-		rewritten = append(rewritten, hcl.TraverseAttr{Name: traversal.RootName()})
+		rewritten = append(rewritten, traverseNameStep(part.LogicalName()))
 		return hclwrite.TokensForTraversal(append(rewritten, schemaAwareRewriteTraversal(part.Schema.Properties, traversal[1:])...)), nil
 	case *pcl.Component:
 		// Rewrite "someComponent.output" → "module.someComponent.output".
 		rewritten := make(hcl.Traversal, 0, len(traversal)+1)
 		rewritten = append(rewritten, hcl.TraverseRoot{Name: "module"})
-		rewritten = append(rewritten, hcl.TraverseAttr{Name: traversal.RootName()})
+		rewritten = append(rewritten, traverseNameStep(part.LogicalName()))
 		return hclwrite.TokensForTraversal(append(rewritten, traversal[1:]...)), nil
 	default:
 		if traversal.RootName() == "range" {

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -1070,12 +1070,21 @@ func stripRoot(trav hcl.Traversal) hcl.Traversal {
 	if len(trav) < 2 {
 		return trav
 	}
-	attr, ok := trav[1].(hcl.TraverseAttr)
-	if !ok {
+	var name string
+	switch step := trav[1].(type) {
+	case hcl.TraverseAttr:
+		name = step.Name
+	case hcl.TraverseIndex:
+		if step.Key.Type() == cty.String {
+			name = step.Key.AsString()
+		} else {
+			return trav
+		}
+	default:
 		return trav
 	}
 	result := make(hcl.Traversal, len(trav)-1)
-	result[0] = hcl.TraverseRoot{Name: attr.Name}
+	result[0] = hcl.TraverseRoot{Name: name}
 	copy(result[1:], trav[2:])
 	return result
 }

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -25,8 +25,9 @@ import (
 
 // splitResourceKey splits a resource key like "aws_instance.web" into ["aws_instance", "web"].
 func splitResourceKey(key string) []string {
-	// Find the last dot to split type.name
-	idx := strings.LastIndex(key, ".")
+	// Find the first dot to split type.name — resource types never contain dots,
+	// but logical names can.
+	idx := strings.Index(key, ".")
 	if idx < 0 {
 		return []string{key}
 	}


### PR DESCRIPTION
The codegen used `traversal.RootName()` (the lexical name) when generating HCL references to resources, config variables, locals, and components. Since block labels already used `LogicalName()`, references didn't match their declarations when the two differed.

This fixes the codegen to use `LogicalName()` for all reference sites, with bracket notation (`["name"]`) for names that aren't valid HCL identifiers. Also fixes `splitResourceKey` to split on the first dot (resource types never contain dots, but logical names can) and the converter's `stripRoot` to handle `TraverseIndex` steps.

The eject direction cannot yet roundtrip logical names that aren't valid PCL identifiers, so `l2-logical-name` is added to `expectedEjectFailures`.