### PR TITLE
Correct a bug when generating invoke tokens

### DIFF
--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -38,7 +38,6 @@ func TestConvertedPCL(t *testing.T) {
 
 	t.Run("function_blocks", func(t *testing.T) {
 		t.Parallel()
-		t.Skip("TODO: Skipping: PCL-to-HCL conversion now emits list syntax instead of block syntax for invoke array-of-object inputs")
 
 		pclSource := `output filteredId {
     value = invoke("test:index:getFiltered", {

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -355,15 +355,13 @@ func (g *generator) genInvokeDataSource(body *hclwrite.Body, invoke *model.Funct
 	var invokeSchema *schema.Function
 	for _, p := range g.program.PackageReferences() {
 		if p.Name() == tokens.Type(token).Package().String() {
+			pkg, mod, name, _ := pcl.DecomposeToken(token, hcl.Range{})
+			// PCL normalizes "pkg:index:name" to "pkg::name", but schema
+			// stores the original token. Reconstruct the canonical form
+			// using DecomposeToken (which fills in "index" for an empty module)
+			// and retry.
+			token = pkg + ":" + mod + ":" + name
 			f, ok, err := p.Functions().Get(token)
-			if !ok && err == nil {
-				// PCL normalizes "pkg:index:name" to "pkg::name", but schema
-				// stores the original token. Retry with "index" module.
-				pkg, mod, name, _ := pcl.DecomposeToken(token, hcl.Range{})
-				if mod == "" {
-					f, ok, err = p.Functions().Get(pkg + ":index:" + name)
-				}
-			}
 			if err != nil {
 				return hcl.Diagnostics{{
 					Severity: hcl.DiagError,


### PR DESCRIPTION
Previously, we were not correctly handling decomposed tokens, likely due to the changing behavior of `pcl.DecomposeToken`.