### PR TITLE
Fix l1-builtin-file

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -130,7 +130,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 }
 
 var expectedFailures = map[string]string{
-	"l1-builtin-file": "not yet implemented",
 	"l2-plain": "unsupported in HCL:" +
 		" requires that HCL can distinguish between an empty and null List<Object>" +
 		" - not compatible with block syntax",

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-file/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-file/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-file
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-file/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-file/main.pp
@@ -1,0 +1,18 @@
+fileContent = readFile("testfile.txt")
+
+fileB64 = filebase64("testfile.txt")
+
+fileSha = filebase64sha256("testfile.txt")
+
+output "fileContent" {
+  value = fileContent
+}
+
+output "fileB64" {
+  value = fileB64
+}
+
+output "fileSha" {
+  value = fileSha
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-file/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-file/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-file
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-file/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-file/main.hcl
@@ -1,0 +1,18 @@
+locals {
+  fileContent = file("testfile.txt")
+}
+locals {
+  fileB64 = filebase64("testfile.txt")
+}
+locals {
+  fileSha = filebase64sha256("testfile.txt")
+}
+output "fileContent" {
+  value = local.fileContent
+}
+output "fileB64" {
+  value = local.fileB64
+}
+output "fileSha" {
+  value = local.fileSha
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-file/testfile.txt
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-file/testfile.txt
@@ -1,0 +1,1 @@
+The quick brown fox jumps over the lazy dog

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-file/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-file/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-builtin-file
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-file/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-file/main.hcl
@@ -1,0 +1,18 @@
+locals {
+  fileContent = file("testfile.txt")
+}
+locals {
+  fileB64 = filebase64("testfile.txt")
+}
+locals {
+  fileSha = filebase64sha256("testfile.txt")
+}
+output "fileContent" {
+  value = local.fileContent
+}
+output "fileB64" {
+  value = local.fileB64
+}
+output "fileSha" {
+  value = local.fileSha
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-file/testfile.txt
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-file/testfile.txt
@@ -1,0 +1,1 @@
+The quick brown fox jumps over the lazy dog

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1333,6 +1333,8 @@ func (g *generator) funcCallTokens(expr *model.FunctionCallExpression) (hclwrite
 		return g.passthroughFuncCallTokens("base64decode", expr.Args)
 	case "toJSON":
 		return g.passthroughFuncCallTokens("jsonencode", expr.Args)
+	case "readFile":
+		return g.passthroughFuncCallTokens("file", expr.Args)
 	case "notImplemented":
 		return g.notImplementedTokens(expr)
 	default:

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -1713,6 +1713,8 @@ func transformFunctionName(name string) string {
 		return "singleOrNone"
 	case "nonsensitive":
 		return "unsecret"
+	case "file":
+		return "readFile"
 	default:
 		return name
 	}


### PR DESCRIPTION
Map PCL's `readFile` to HCL's `file` function in codegen, and the reverse in the converter. This lets the l1-builtin-file language test pass for both runtime and eject.