### PR TITLE
Process `for_each` for data sources

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,3 +3,9 @@ version: "2"
 linters:
   enable:
     - modernize
+    - usetesting
+  settings:
+    usetesting:
+      os-temp-dir: true
+      context-background: true
+      context-todo: true

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -451,6 +451,196 @@ resource target "test:index:Item" {
 
 }
 
+// TestStdLookupInlinedInForEachResource checks that a `std:index:*` function (which has a
+// TF-builtin equivalent) is hoisted into a top-level `data "std_*"` block instead of
+// being inlined as a TF builtin call. When the invoke closes over `range.value` from an
+// enclosing for_each resource, the hoisted block has no for_each and the rewritten
+// `each.value` reference is unbound at plan time.
+//
+// The fix is to reverse the `std:index:lookup` → `lookup(...)` mapping,
+// emitting an inline TF function call:
+//
+//	resource "test_item" "inbound" {
+//	  for_each = { a = { thing = "alpha" }, b = { thing = "bravo" } }
+//	  value    = lookup(each.value, "thing", "none")
+//	}
+func TestStdLookupInlinedInForEachResource(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+	stdSchema := schema.PackageSpec{
+		Name:    "std",
+		Version: "1.0.0",
+		Functions: map[string]schema.FunctionSpec{
+			"std:index:lookup": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"map":     {TypeSpec: schema.TypeSpec{Ref: "pulumi.json#/Any"}},
+						"key":     {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"default": {TypeSpec: schema.TypeSpec{Ref: "pulumi.json#/Any"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Ref: "pulumi.json#/Any"}},
+					},
+				},
+			},
+		},
+	}
+
+	pclSource := `resource inbound "test:index:Item" {
+    options {
+        range = {
+            a = { thing = "alpha" }
+            b = { thing = "bravo" }
+        }
+    }
+    value = invoke("std:index:lookup", {
+        map     = range.value
+        key     = "thing"
+        default = "none"
+    }).result
+}
+`
+
+	// No InvokeHandler: std:index:lookup must be inlined as the TF builtin
+	// `lookup(...)`, which the engine evaluates natively. If the generator
+	// still emits a `data "std_lookup"` block, the engine will either fail
+	// to bind `each.value` or fail to resolve the std provider.
+	mock := testConvertedPCLWithComponent(t, pclSource, nil, nil, testSchema, stdSchema)
+
+	require.Len(t, mock.RegisteredResources, 3, "expected stack + 2 items")
+	assert.Equal(t, "pulumi:pulumi:Stack", mock.RegisteredResources[0].Type)
+	assert.Empty(t, mock.InvokedFunctions,
+		"std:index:lookup should be inlined, not sent as an Invoke")
+
+	values := []property.Value{
+		mock.RegisteredResources[1].Inputs.Get("value"),
+		mock.RegisteredResources[2].Inputs.Get("value"),
+	}
+	assert.ElementsMatch(t, []property.Value{
+		property.New("alpha"),
+		property.New("bravo"),
+	}, values)
+}
+
+// TestCustomInvokeHoistedWithForEach checks a custom provider invoke that has no
+// TF-builtin equivalent must still be emitted as a `data` block, but when it closes over
+// `range.value` the data block needs its own `for_each` and the resource must reference
+// it per-iteration:
+//
+//	data "test_echo" "invoke_0" {
+//	  for_each = { a = "alpha", b = "bravo" }
+//	  input    = each.value
+//	}
+//	resource "test_item" "inbound" {
+//	  for_each = data.test_echo.invoke_0
+//	  value    = each.value.result
+//	}
+func TestCustomInvokeHoistedWithForEach(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	pclSource := `resource inbound "test:index:Item" {
+    options {
+        range = {
+            a = "alpha"
+            b = "bravo"
+        }
+    }
+    value = invoke("test:index:echo", {
+        input = range.value
+    }).result
+}
+`
+
+	monitor := &testutil.MockResourceMonitor{
+		InvokeHandler: func(_ context.Context, req hclrun.InvokeRequest) (*hclrun.InvokeResponse, error) {
+			input, _ := req.Args.GetOk("input")
+			return &hclrun.InvokeResponse{
+				Return: property.NewMap(map[string]property.Value{
+					"result": property.New(input.AsString() + "+"),
+				}),
+			}, nil
+		},
+	}
+
+	mock := testConvertedPCLWithComponent(t, pclSource, nil, monitor, testSchema)
+
+	// The invoke must fire once per range entry with the corresponding
+	// range.value, not once with an unbound placeholder.
+	invokeInputs := make([]property.Value, 0, len(mock.InvokedFunctions))
+	for _, inv := range mock.InvokedFunctions {
+		assert.Equal(t, "test:index:echo", inv.Token)
+		input, ok := inv.Args.GetOk("input")
+		require.True(t, ok, "invoke missing `input` arg: %v", inv.Args)
+		invokeInputs = append(invokeInputs, input)
+	}
+	assert.ElementsMatch(t, []property.Value{
+		property.New("alpha"),
+		property.New("bravo"),
+	}, invokeInputs)
+
+	// Each registered resource should receive the per-iteration invoke
+	// result.
+	require.Len(t, mock.RegisteredResources, 3, "expected stack + 2 items")
+	assert.Equal(t, "pulumi:pulumi:Stack", mock.RegisteredResources[0].Type)
+	values := []property.Value{
+		mock.RegisteredResources[1].Inputs.Get("value"),
+		mock.RegisteredResources[2].Inputs.Get("value"),
+	}
+	assert.ElementsMatch(t, []property.Value{
+		property.New("alpha+"),
+		property.New("bravo+"),
+	}, values)
+}
+
 func TestNotImplemented(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -641,6 +641,453 @@ func TestCustomInvokeHoistedWithForEach(t *testing.T) {
 	}, values)
 }
 
+// TestCustomInvokeHoistedWithCount mirrors TestCustomInvokeHoistedWithForEach
+// but uses a numeric range, which maps to `count` instead of `for_each`. The
+// hoisted data block should carry a matching `count` and the resource should
+// reference it with `[count.index]`.
+func TestCustomInvokeHoistedWithCount(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	pclSource := `resource inbound "test:index:Item" {
+    options {
+        range = 2
+    }
+    value = invoke("test:index:echo", {
+        input = "item-${range.value}"
+    }).result
+}
+`
+
+	monitor := &testutil.MockResourceMonitor{
+		InvokeHandler: func(_ context.Context, req hclrun.InvokeRequest) (*hclrun.InvokeResponse, error) {
+			input, _ := req.Args.GetOk("input")
+			return &hclrun.InvokeResponse{
+				Return: property.NewMap(map[string]property.Value{
+					"result": property.New(input.AsString() + "+"),
+				}),
+			}, nil
+		},
+	}
+
+	mock := testConvertedPCLWithComponent(t, pclSource, nil, monitor, testSchema)
+
+	invokeInputs := make([]property.Value, 0, len(mock.InvokedFunctions))
+	for _, inv := range mock.InvokedFunctions {
+		assert.Equal(t, "test:index:echo", inv.Token)
+		input, ok := inv.Args.GetOk("input")
+		require.True(t, ok, "invoke missing `input` arg: %v", inv.Args)
+		invokeInputs = append(invokeInputs, input)
+	}
+	assert.ElementsMatch(t, []property.Value{
+		property.New("item-0"),
+		property.New("item-1"),
+	}, invokeInputs)
+
+	require.Len(t, mock.RegisteredResources, 3, "expected stack + 2 items")
+	assert.Equal(t, "pulumi:pulumi:Stack", mock.RegisteredResources[0].Type)
+	values := []property.Value{
+		mock.RegisteredResources[1].Inputs.Get("value"),
+		mock.RegisteredResources[2].Inputs.Get("value"),
+	}
+	assert.ElementsMatch(t, []property.Value{
+		property.New("item-0+"),
+		property.New("item-1+"),
+	}, values)
+}
+
+// TestCustomInvokeHoistedInListComprehension checks that a custom provider
+// invoke that appears inside a PCL list comprehension is hoisted into a data
+// block whose `for_each` matches the comprehension's collection, and that the
+// reference is spliced back into the list comprehension indexed by the
+// comprehension's key variable.
+func TestCustomInvokeHoistedInListComprehension(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	pclSource := `output results {
+    value = [for k, v in {
+        a = "alpha"
+        b = "bravo"
+    } : invoke("test:index:echo", {
+        input = v
+    }).result]
+}
+`
+
+	monitor := &testutil.MockResourceMonitor{
+		InvokeHandler: func(_ context.Context, req hclrun.InvokeRequest) (*hclrun.InvokeResponse, error) {
+			input, _ := req.Args.GetOk("input")
+			return &hclrun.InvokeResponse{
+				Return: property.NewMap(map[string]property.Value{
+					"result": property.New(input.AsString() + "+"),
+				}),
+			}, nil
+		},
+	}
+
+	mock := testConvertedPCLWithComponent(t, pclSource, nil, monitor, testSchema)
+
+	invokeInputs := make([]property.Value, 0, len(mock.InvokedFunctions))
+	for _, inv := range mock.InvokedFunctions {
+		assert.Equal(t, "test:index:echo", inv.Token)
+		input, ok := inv.Args.GetOk("input")
+		require.True(t, ok, "invoke missing `input` arg: %v", inv.Args)
+		invokeInputs = append(invokeInputs, input)
+	}
+	assert.ElementsMatch(t, []property.Value{
+		property.New("alpha"),
+		property.New("bravo"),
+	}, invokeInputs)
+
+	require.Len(t, mock.RegisteredResources, 1, "expected just the stack")
+	assert.Equal(t, "pulumi:pulumi:Stack", mock.RegisteredResources[0].Type)
+	results, ok := mock.StackOutputs.GetOk("results")
+	require.True(t, ok, "missing `results` stack output")
+	assert.ElementsMatch(t, []property.Value{
+		property.New("alpha+"),
+		property.New("bravo+"),
+	}, results.AsArray().AsSlice())
+}
+
+// TestCustomInvokeHoistedInListComprehensionKeyVar verifies the branch of the
+// for-variable rewrite that maps a reference to the comprehension's
+// KeyVariable onto `each.key` in the hoisted data block.
+func TestCustomInvokeHoistedInListComprehensionKeyVar(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	pclSource := `output results {
+    value = [for k, v in {
+        a = "alpha"
+        b = "bravo"
+    } : invoke("test:index:echo", {
+        input = k
+    }).result]
+}
+`
+
+	monitor := &testutil.MockResourceMonitor{
+		InvokeHandler: func(_ context.Context, req hclrun.InvokeRequest) (*hclrun.InvokeResponse, error) {
+			input, _ := req.Args.GetOk("input")
+			return &hclrun.InvokeResponse{
+				Return: property.NewMap(map[string]property.Value{
+					"result": property.New(input.AsString() + "!"),
+				}),
+			}, nil
+		},
+	}
+
+	mock := testConvertedPCLWithComponent(t, pclSource, nil, monitor, testSchema)
+
+	invokeInputs := make([]property.Value, 0, len(mock.InvokedFunctions))
+	for _, inv := range mock.InvokedFunctions {
+		input, ok := inv.Args.GetOk("input")
+		require.True(t, ok)
+		invokeInputs = append(invokeInputs, input)
+	}
+	assert.ElementsMatch(t, []property.Value{
+		property.New("a"),
+		property.New("b"),
+	}, invokeInputs)
+
+	results, ok := mock.StackOutputs.GetOk("results")
+	require.True(t, ok)
+	assert.ElementsMatch(t, []property.Value{
+		property.New("a!"),
+		property.New("b!"),
+	}, results.AsArray().AsSlice())
+}
+
+// TestStdInvokeInListComprehensionInlined checks that a std:index:* invoke
+// with a TF-builtin equivalent is inlined at the reference site (no data
+// block is spilled) even when the invoke appears inside a list comprehension
+// and closes over the comprehension's value variable.
+func TestStdInvokeInListComprehensionInlined(t *testing.T) {
+	t.Parallel()
+
+	stdSchema := schema.PackageSpec{
+		Name:    "std",
+		Version: "1.0.0",
+		Functions: map[string]schema.FunctionSpec{
+			"std:index:lower": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	pclSource := `output results {
+    value = [for _, v in {
+        a = "ALPHA"
+        b = "BRAVO"
+    } : invoke("std:index:lower", {
+        input = v
+    }).result]
+}
+`
+
+	mock := testConvertedPCLWithComponent(t, pclSource, nil, nil, stdSchema)
+
+	assert.Empty(t, mock.InvokedFunctions,
+		"std:index:lower should be inlined as the TF builtin, not sent as an Invoke")
+
+	results, ok := mock.StackOutputs.GetOk("results")
+	require.True(t, ok)
+	assert.ElementsMatch(t, []property.Value{
+		property.New("alpha"),
+		property.New("bravo"),
+	}, results.AsArray().AsSlice())
+}
+
+// TestCustomInvokeHoistedInMapComprehension verifies hoisting works for the
+// map-result form of a for-comprehension: {for k, v in xs : k => invoke(...)}.
+func TestCustomInvokeHoistedInMapComprehension(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	pclSource := `output results {
+    value = {for k, v in {
+        a = "alpha"
+        b = "bravo"
+    } : k => invoke("test:index:echo", {
+        input = v
+    }).result}
+}
+`
+
+	monitor := &testutil.MockResourceMonitor{
+		InvokeHandler: func(_ context.Context, req hclrun.InvokeRequest) (*hclrun.InvokeResponse, error) {
+			input, _ := req.Args.GetOk("input")
+			return &hclrun.InvokeResponse{
+				Return: property.NewMap(map[string]property.Value{
+					"result": property.New(input.AsString() + "+"),
+				}),
+			}, nil
+		},
+	}
+
+	mock := testConvertedPCLWithComponent(t, pclSource, nil, monitor, testSchema)
+
+	results, ok := mock.StackOutputs.GetOk("results")
+	require.True(t, ok)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"a": property.New("alpha+"),
+		"b": property.New("bravo+"),
+	}), results.AsMap())
+}
+
+// TestCustomInvokeHoistedInNestedComprehension verifies that when an invoke
+// inside nested comprehensions references an OUTER comprehension's iteration
+// variable, the walk-from-innermost-out loop in collectInvokesInExpr picks
+// the outer for-expression as the one whose collection drives the data
+// block's for_each.
+func TestCustomInvokeHoistedInNestedComprehension(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	pclSource := `output results {
+    value = [for ko, vo in {
+        a = "alpha"
+    } : [for ki, vi in {
+        x = "xylo"
+    } : invoke("test:index:echo", {
+        input = vo
+    }).result]]
+}
+`
+
+	monitor := &testutil.MockResourceMonitor{
+		InvokeHandler: func(_ context.Context, req hclrun.InvokeRequest) (*hclrun.InvokeResponse, error) {
+			input, _ := req.Args.GetOk("input")
+			return &hclrun.InvokeResponse{
+				Return: property.NewMap(map[string]property.Value{
+					"result": property.New(input.AsString() + "+"),
+				}),
+			}, nil
+		},
+	}
+
+	mock := testConvertedPCLWithComponent(t, pclSource, nil, monitor, testSchema)
+
+	assert.Len(t, mock.InvokedFunctions, 1,
+		"invoke should fire once per outer iteration (not inner × outer)")
+
+	results, ok := mock.StackOutputs.GetOk("results")
+	require.True(t, ok)
+	outer := results.AsArray().AsSlice()
+	require.Len(t, outer, 1)
+	inner := outer[0].AsArray().AsSlice()
+	require.Len(t, inner, 1)
+	assert.Equal(t, property.New("alpha+"), inner[0])
+}
+
+// TestCustomInvokeHoistedInListComprehensionNoKey exercises the branch where a
+// for-comprehension has no KeyVariable. The current codegen tags the invoke
+// with the for-expression anyway and emits `for_each = <list>` on the data
+// block, but the reference rewrite cannot index the data block (no key in
+// scope) — so the per-iteration semantics break. This test documents the
+// current behavior; it is expected to fail until the no-key case is fixed.
+func TestCustomInvokeHoistedInListComprehensionNoKey(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	pclSource := `output results {
+    value = [for v in ["alpha", "bravo"] : invoke("test:index:echo", {
+        input = v
+    }).result]
+}
+`
+
+	monitor := &testutil.MockResourceMonitor{
+		InvokeHandler: func(_ context.Context, req hclrun.InvokeRequest) (*hclrun.InvokeResponse, error) {
+			input, _ := req.Args.GetOk("input")
+			return &hclrun.InvokeResponse{
+				Return: property.NewMap(map[string]property.Value{
+					"result": property.New(input.AsString() + "+"),
+				}),
+			}, nil
+		},
+	}
+
+	mock := testConvertedPCLWithComponent(t, pclSource, nil, monitor, testSchema)
+
+	results, ok := mock.StackOutputs.GetOk("results")
+	require.True(t, ok)
+	assert.ElementsMatch(t, []property.Value{
+		property.New("alpha+"),
+		property.New("bravo+"),
+	}, results.AsArray().AsSlice())
+}
+
 func TestNotImplemented(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedInListComprehension/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedInListComprehension/main.hcl
@@ -15,10 +15,9 @@ data "test_echo" "invoke_0" {
   input = each.value
 }
 
-resource "test_item" "inbound" {
-  for_each = {
+output "results" {
+  value = [for k, v in {
     "a" = "alpha"
     "b" = "bravo"
-  }
-  value = data.test_echo.invoke_0[each.key].result
+  } : data.test_echo.invoke_0[k].result]
 }

--- a/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedInListComprehensionKeyVar/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedInListComprehensionKeyVar/main.hcl
@@ -12,13 +12,12 @@ data "test_echo" "invoke_0" {
     "a" = "alpha"
     "b" = "bravo"
   }
-  input = each.value
+  input = each.key
 }
 
-resource "test_item" "inbound" {
-  for_each = {
+output "results" {
+  value = [for k, v in {
     "a" = "alpha"
     "b" = "bravo"
-  }
-  value = data.test_echo.invoke_0[each.key].result
+  } : data.test_echo.invoke_0[k].result]
 }

--- a/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedInListComprehensionNoKey/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedInListComprehensionNoKey/main.hcl
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+data "test_echo" "invoke_0" {
+  for_each = toset(["alpha", "bravo"])
+  input    = each.value
+}
+
+output "results" {
+  value = [for v in ["alpha", "bravo"] : data.test_echo.invoke_0[v].result]
+}

--- a/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedInMapComprehension/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedInMapComprehension/main.hcl
@@ -15,10 +15,9 @@ data "test_echo" "invoke_0" {
   input = each.value
 }
 
-resource "test_item" "inbound" {
-  for_each = {
+output "results" {
+  value = {for k, v in {
     "a" = "alpha"
     "b" = "bravo"
-  }
-  value = data.test_echo.invoke_0[each.key].result
+  } : k => data.test_echo.invoke_0[k].result}
 }

--- a/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedInNestedComprehension/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedInNestedComprehension/main.hcl
@@ -10,15 +10,14 @@ terraform {
 data "test_echo" "invoke_0" {
   for_each = {
     "a" = "alpha"
-    "b" = "bravo"
   }
   input = each.value
 }
 
-resource "test_item" "inbound" {
-  for_each = {
+output "results" {
+  value = [for ko, vo in {
     "a" = "alpha"
-    "b" = "bravo"
-  }
-  value = data.test_echo.invoke_0[each.key].result
+    } : [for ki, vi in {
+      "x" = "xylo"
+  } : data.test_echo.invoke_0[ko].result]]
 }

--- a/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedWithCount/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedWithCount/main.hcl
@@ -8,17 +8,11 @@ terraform {
 }
 
 data "test_echo" "invoke_0" {
-  for_each = {
-    "a" = "alpha"
-    "b" = "bravo"
-  }
-  input = each.value
+  count = 2
+  input ="item-${count.index}"
 }
 
 resource "test_item" "inbound" {
-  for_each = {
-    "a" = "alpha"
-    "b" = "bravo"
-  }
-  value = data.test_echo.invoke_0[each.key].result
+  count = 2
+  value = data.test_echo.invoke_0[count.index].result
 }

--- a/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedWithForEach/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestCustomInvokeHoistedWithForEach/main.hcl
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+data "test_echo" "invoke_0" {
+  input = each.value
+}
+
+resource "test_item" "inbound" {
+  for_each = {
+    "a" = "alpha"
+    "b" = "bravo"
+  }
+  value = data.test_echo.invoke_0.result
+}

--- a/cmd/pulumi-language-hcl/testdata/TestStdInvokeInListComprehensionInlined/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestStdInvokeInListComprehensionInlined/main.hcl
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    std = {
+      source  = "pulumi/std"
+      version = "1.0.0"
+    }
+  }
+}
+
+output "results" {
+  value = [for _, v in {
+    "a" = "ALPHA"
+    "b" = "BRAVO"
+  } : lower(v)]
+}

--- a/cmd/pulumi-language-hcl/testdata/TestStdLookupInlinedInForEachResource/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestStdLookupInlinedInForEachResource/main.hcl
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    std = {
+      source  = "pulumi/std"
+      version = "1.0.0"
+    }
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+data "std_lookup" "invoke_0" {
+  map     = each.value
+  key     = "thing"
+  default = "none"
+}
+
+resource "test_item" "inbound" {
+  for_each = {
+    "a" = {
+      "thing" = "alpha"
+    }
+    "b" = {
+      "thing" = "bravo"
+    }
+  }
+  value = data.std_lookup.invoke_0.result
+}

--- a/cmd/pulumi-language-hcl/testdata/TestStdLookupInlinedInForEachResource/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestStdLookupInlinedInForEachResource/main.hcl
@@ -11,12 +11,6 @@ terraform {
   }
 }
 
-data "std_lookup" "invoke_0" {
-  map     = each.value
-  key     = "thing"
-  default = "none"
-}
-
 resource "test_item" "inbound" {
   for_each = {
     "a" = {
@@ -26,5 +20,5 @@ resource "test_item" "inbound" {
       "thing" = "bravo"
     }
   }
-  value = data.std_lookup.invoke_0.result
+  value = lookup(each.value, "thing", "none")
 }

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -56,7 +56,7 @@ func GenerateProgram(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, 
 
 	// Generate data source blocks for invokes
 	for _, ds := range gen.invokeDataSources {
-		d := gen.genInvokeDataSource(body, ds.expr, ds.name)
+		d := gen.genInvokeDataSource(body, ds)
 		diags = append(diags, d...)
 	}
 
@@ -142,11 +142,187 @@ type generator struct {
 	callBlocks        []spilledCall
 	currentRangeKind  rangeKind
 	dynamicBlock      *dynamicBlockContext
+	// forDataBlock, when non-nil, indicates we are generating the body of a
+	// data block hoisted from an invoke inside a for-comprehension. References
+	// to its KeyVariable / ValueVariable are rewritten to each.key / each.value.
+	forDataBlock *model.ForExpression
 }
 
 type spilledDataSource struct {
 	expr *model.FunctionCallExpression
 	name string
+	// parentResource is non-nil when the invoke closes over range.* from this
+	// resource's for_each/count. The data block is emitted with a matching
+	// for_each, and the resource's reference is indexed with [each.key].
+	parentResource *pcl.Resource
+	// enclosingForExpr is non-nil when the invoke closes over iteration
+	// variables of a PCL for-comprehension. The data block is emitted with a
+	// matching for_each over that comprehension's collection, and the
+	// reference is indexed by the comprehension's key variable.
+	enclosingForExpr *model.ForExpression
+}
+
+// stdTFFunc describes how to inline a pulumi-std invoke as a TF builtin function
+// call. Used to reverse the forward mapping that pulumi-converter-terraform applies
+// when turning TF builtins into std:index:* invokes.
+type stdTFFunc struct {
+	name   string
+	inputs []string
+}
+
+// stdInvokeToTFFunction maps a pulumi-std invoke token back to its TF builtin
+// function. Mirrors the forward mapping in pulumi-converter-terraform's
+// tfFunctionStd. Only non-variadic (paramArgs=false) entries appear here —
+// variadic functions receive their trailing args packed into a single list by
+// the forward direction, which cannot be reliably unpacked without knowing the
+// list length statically, so those remain hoisted as data blocks.
+var stdInvokeToTFFunction = map[string]stdTFFunc{
+	"std:index:abs":              {name: "abs", inputs: []string{"input"}},
+	"std:index:abspath":          {name: "abspath", inputs: []string{"input"}},
+	"std:index:alltrue":          {name: "alltrue", inputs: []string{"input"}},
+	"std:index:anytrue":          {name: "anytrue", inputs: []string{"input"}},
+	"std:index:base64decode":     {name: "base64decode", inputs: []string{"input"}},
+	"std:index:base64encode":     {name: "base64encode", inputs: []string{"input"}},
+	"std:index:base64gzip":       {name: "base64gzip", inputs: []string{"input"}},
+	"std:index:base64sha256":     {name: "base64sha256", inputs: []string{"input"}},
+	"std:index:base64sha512":     {name: "base64sha512", inputs: []string{"input"}},
+	"std:index:basename":         {name: "basename", inputs: []string{"input"}},
+	"std:index:bcrypt":           {name: "bcrypt", inputs: []string{"input", "cost"}},
+	"std:index:ceil":             {name: "ceil", inputs: []string{"input"}},
+	"std:index:chomp":            {name: "chomp", inputs: []string{"input"}},
+	"std:index:chunklist":        {name: "chunklist", inputs: []string{"input", "size"}},
+	"std:index:compact":          {name: "compact", inputs: []string{"input"}},
+	"std:index:contains":         {name: "contains", inputs: []string{"input", "element"}},
+	"std:index:cidrhost":         {name: "cidrhost", inputs: []string{"input", "host"}},
+	"std:index:cidrnetmask":      {name: "cidrnetmask", inputs: []string{"input"}},
+	"std:index:cidrsubnet":       {name: "cidrsubnet", inputs: []string{"input", "newbits", "netnum"}},
+	"std:index:csvdecode":        {name: "csvdecode", inputs: []string{"input"}},
+	"std:index:dirname":          {name: "dirname", inputs: []string{"input"}},
+	"std:index:distinct":         {name: "distinct", inputs: []string{"input"}},
+	"std:index:endswith":         {name: "endswith", inputs: []string{"input", "suffix"}},
+	"std:index:file":             {name: "file", inputs: []string{"input"}},
+	"std:index:filebase64":       {name: "filebase64", inputs: []string{"input"}},
+	"std:index:filebase64sha256": {name: "filebase64sha256", inputs: []string{"input"}},
+	"std:index:filebase64sha512": {name: "filebase64sha512", inputs: []string{"input"}},
+	"std:index:fileexists":       {name: "fileexists", inputs: []string{"input"}},
+	"std:index:filemd5":          {name: "filemd5", inputs: []string{"input"}},
+	"std:index:filesha1":         {name: "filesha1", inputs: []string{"input"}},
+	"std:index:filesha256":       {name: "filesha256", inputs: []string{"input"}},
+	"std:index:filesha512":       {name: "filesha512", inputs: []string{"input"}},
+	"std:index:flatten":          {name: "flatten", inputs: []string{"input"}},
+	"std:index:floor":            {name: "floor", inputs: []string{"input"}},
+	"std:index:indent":           {name: "indent", inputs: []string{"spaces", "input"}},
+	"std:index:join":             {name: "join", inputs: []string{"separator", "input"}},
+	"std:index:jsondecode":       {name: "jsondecode", inputs: []string{"input"}},
+	"std:index:keys":             {name: "keys", inputs: []string{"input"}},
+	"std:index:log":              {name: "log", inputs: []string{"base", "input"}},
+	"std:index:lookup":           {name: "lookup", inputs: []string{"map", "key", "default"}},
+	"std:index:lower":            {name: "lower", inputs: []string{"input"}},
+	"std:index:md5":              {name: "md5", inputs: []string{"input"}},
+	"std:index:parseint":         {name: "parseint", inputs: []string{"input", "base"}},
+	"std:index:pathexpand":       {name: "pathexpand", inputs: []string{"input"}},
+	"std:index:pow":              {name: "pow", inputs: []string{"base", "exponent"}},
+	"std:index:range":            {name: "range", inputs: []string{"limit", "start", "step"}},
+	"std:index:regex":            {name: "regex", inputs: []string{"pattern", "string"}},
+	"std:index:regexall":         {name: "regexall", inputs: []string{"pattern", "string"}},
+	"std:index:replace":          {name: "replace", inputs: []string{"text", "search", "replace"}},
+	"std:index:rsadecrypt":       {name: "rsadecrypt", inputs: []string{"cipherText", "key"}},
+	"std:index:sha1":             {name: "sha1", inputs: []string{"input"}},
+	"std:index:sha256":           {name: "sha256", inputs: []string{"input"}},
+	"std:index:sha512":           {name: "sha512", inputs: []string{"input"}},
+	"std:index:signum":           {name: "signum", inputs: []string{"input"}},
+	"std:index:slice":            {name: "slice", inputs: []string{"list", "from", "to"}},
+	"std:index:sort":             {name: "sort", inputs: []string{"input"}},
+	"std:index:split":            {name: "split", inputs: []string{"separator", "text"}},
+	"std:index:startswith":       {name: "startswith", inputs: []string{"input", "prefix"}},
+	"std:index:strrev":           {name: "strrev", inputs: []string{"input"}},
+	"std:index:substr":           {name: "substr", inputs: []string{"input", "offset", "length"}},
+	"std:index:sum":              {name: "sum", inputs: []string{"input"}},
+	"std:index:timeadd":          {name: "timeadd", inputs: []string{"duration", "timestamp"}},
+	"std:index:timecmp":          {name: "timecmp", inputs: []string{"timestampa", "timestampb"}},
+	"std:index:timestamp":        {name: "timestamp", inputs: []string{}},
+	"std:index:title":            {name: "title", inputs: []string{"input"}},
+	"std:index:tobool":           {name: "tobool", inputs: []string{"input"}},
+	"std:index:toset":            {name: "toset", inputs: []string{"input"}},
+	"std:index:transpose":        {name: "transpose", inputs: []string{"input"}},
+	"std:index:trim":             {name: "trim", inputs: []string{"input", "cutset"}},
+	"std:index:trimprefix":       {name: "trimprefix", inputs: []string{"input", "prefix"}},
+	"std:index:trimspace":        {name: "trimspace", inputs: []string{"input"}},
+	"std:index:trimsuffix":       {name: "trimsuffix", inputs: []string{"input", "suffix"}},
+	"std:index:upper":            {name: "upper", inputs: []string{"input"}},
+	"std:index:urlencode":        {name: "urlencode", inputs: []string{"input"}},
+	"std:index:uuid":             {name: "uuid", inputs: []string{}},
+}
+
+// lookupStdTFFunc finds a TF-builtin mapping for a pulumi-std invoke token.
+// It accepts both the fully-qualified "std:index:name" form and the canonical
+// "std::name" form that pcl's binder produces after token canonicalization.
+func lookupStdTFFunc(token string) (stdTFFunc, bool) {
+	if fn, ok := stdInvokeToTFFunction[token]; ok {
+		return fn, true
+	}
+	pkg, _, member, diags := pcl.DecomposeToken(token, hcl.Range{})
+	if diags.HasErrors() || pkg != "std" {
+		return stdTFFunc{}, false
+	}
+	fn, ok := stdInvokeToTFFunction["std:index:"+member]
+	return fn, ok
+}
+
+// inlinableStdFunc reports whether the given invoke call can be inlined as a TF
+// builtin function. It checks both the token and the argument shape (the args
+// object must be an ObjectConsExpression).
+func inlinableStdFunc(call *model.FunctionCallExpression) (stdTFFunc, bool) {
+	if call.Name != pcl.Invoke || len(call.Args) < 2 {
+		return stdTFFunc{}, false
+	}
+	token, ok := extractStringLiteral(call.Args[0])
+	if !ok {
+		return stdTFFunc{}, false
+	}
+	fn, ok := lookupStdTFFunc(token)
+	if !ok {
+		return stdTFFunc{}, false
+	}
+	if _, ok := call.Args[1].(*model.ObjectConsExpression); !ok {
+		return stdTFFunc{}, false
+	}
+	return fn, true
+}
+
+// invokeReferencesRange reports whether any scope traversal inside the invoke
+// is rooted at `range`, meaning the invoke closes over an enclosing resource's
+// for_each / count iterator.
+func invokeReferencesRange(call *model.FunctionCallExpression) bool {
+	var found bool
+	_, _ = model.VisitExpression(call, nil, func(e model.Expression) (model.Expression, hcl.Diagnostics) {
+		if st, ok := e.(*model.ScopeTraversalExpression); ok {
+			if st.Traversal.RootName() == "range" {
+				found = true
+			}
+		}
+		return e, nil
+	})
+	return found
+}
+
+// invokeReferencesForVars reports whether any scope traversal inside the
+// invoke references the given for-expression's iteration variables.
+func invokeReferencesForVars(call *model.FunctionCallExpression, fe *model.ForExpression) bool {
+	var found bool
+	_, _ = model.VisitExpression(call, nil, func(e model.Expression) (model.Expression, hcl.Diagnostics) {
+		st, ok := e.(*model.ScopeTraversalExpression)
+		if !ok || len(st.Parts) == 0 {
+			return e, nil
+		}
+		if v, ok := st.Parts[0].(*model.Variable); ok {
+			if v == fe.ValueVariable || (fe.KeyVariable != nil && v == fe.KeyVariable) {
+				found = true
+			}
+		}
+		return e, nil
+	})
+	return found
 }
 
 type spilledCall struct {
@@ -191,32 +367,66 @@ func genRequiredProviders(body *hclwrite.Body, program *pcl.Program) {
 }
 
 // collectInvokes walks the node and collects all invoke function calls.
+// Resource inputs pass the enclosing resource so invokes that close over its
+// range iterator can be identified.
 func (g *generator) collectInvokes(node pcl.Node) {
 	switch n := node.(type) {
 	case *pcl.Resource:
 		for _, attr := range n.Inputs {
-			g.collectInvokesInExpr(attr.Value)
+			g.collectInvokesInExpr(attr.Value, n)
 		}
 	case *pcl.OutputVariable:
-		g.collectInvokesInExpr(n.Value)
+		g.collectInvokesInExpr(n.Value, nil)
 	case *pcl.LocalVariable:
-		g.collectInvokesInExpr(n.Definition.Value)
+		g.collectInvokesInExpr(n.Definition.Value, nil)
 	}
 }
 
 // collectInvokesInExpr walks an expression tree and collects invoke calls.
-func (g *generator) collectInvokesInExpr(expr model.Expression) {
-	_, diags := model.VisitExpression(expr, nil, func(expr model.Expression) (model.Expression, hcl.Diagnostics) {
-		if call, ok := expr.(*model.FunctionCallExpression); ok {
-			if call.Name == pcl.Invoke {
-				g.invokeDataSources = append(g.invokeDataSources, spilledDataSource{
-					expr: call,
-					name: fmt.Sprintf("invoke_%d", len(g.invokeDataSources)),
-				})
-			}
+// Invokes that map to TF builtins (std:index:*) are skipped — they will be
+// inlined at their reference site. Invokes that close over range.* from the
+// enclosing resource are tagged so the hoisted data block can carry a matching
+// for_each.
+func (g *generator) collectInvokesInExpr(expr model.Expression, parent *pcl.Resource) {
+	var forStack []*model.ForExpression
+	pre := func(e model.Expression) (model.Expression, hcl.Diagnostics) {
+		if fe, ok := e.(*model.ForExpression); ok {
+			forStack = append(forStack, fe)
 		}
-		return expr, nil
-	})
+		return e, nil
+	}
+	post := func(e model.Expression) (model.Expression, hcl.Diagnostics) {
+		if fe, ok := e.(*model.ForExpression); ok {
+			contract.Assertf(len(forStack) > 0 && forStack[len(forStack)-1] == fe,
+				"for-expression stack out of sync")
+			forStack = forStack[:len(forStack)-1]
+		}
+		if call, ok := e.(*model.FunctionCallExpression); ok && call.Name == pcl.Invoke {
+			if _, inlinable := inlinableStdFunc(call); inlinable {
+				return e, nil
+			}
+			ds := spilledDataSource{
+				expr: call,
+				name: fmt.Sprintf("invoke_%d", len(g.invokeDataSources)),
+			}
+			if parent != nil && parent.Options != nil && parent.Options.Range != nil &&
+				invokeReferencesRange(call) {
+				ds.parentResource = parent
+			} else {
+				// Walk from innermost for outward to find the one whose
+				// iteration variables this invoke closes over.
+				for i := len(forStack) - 1; i >= 0; i-- {
+					if invokeReferencesForVars(call, forStack[i]) {
+						ds.enclosingForExpr = forStack[i]
+						break
+					}
+				}
+			}
+			g.invokeDataSources = append(g.invokeDataSources, ds)
+		}
+		return e, nil
+	}
+	_, diags := model.VisitExpression(expr, pre, post)
 	contract.Assertf(len(diags) == 0, "we never return diags")
 }
 
@@ -333,7 +543,11 @@ func (g *generator) genCallBlock(body *hclwrite.Body, cb spilledCall) hcl.Diagno
 }
 
 // genInvokeDataSource generates a data source block for an invoke call.
-func (g *generator) genInvokeDataSource(body *hclwrite.Body, invoke *model.FunctionCallExpression, dsName string) hcl.Diagnostics {
+// If ds.parentResource is set, the block is emitted with a for_each matching
+// the resource's range so range.* references rewrite correctly.
+func (g *generator) genInvokeDataSource(body *hclwrite.Body, ds spilledDataSource) hcl.Diagnostics {
+	invoke := ds.expr
+	dsName := ds.name
 	if len(invoke.Args) < 2 {
 		return hcl.Diagnostics{{
 			Severity: hcl.DiagError,
@@ -382,6 +596,36 @@ func (g *generator) genInvokeDataSource(body *hclwrite.Body, invoke *model.Funct
 	}
 
 	block := body.AppendNewBlock("data", []string{dsType, dsName})
+
+	// If this invoke closed over range.* from a for_each/count resource,
+	// give the data block its own matching range so the rewrite in
+	// scopeTraversalTokens (range.* → each.* / count.index) is well-bound.
+	if ds.parentResource != nil && ds.parentResource.Options != nil && ds.parentResource.Options.Range != nil {
+		d := g.genRange(block.Body(), ds.parentResource.Options.Range)
+		diags = append(diags, d...)
+		defer func() { g.currentRangeKind = rangeKindNone }()
+	}
+
+	// If this invoke closed over a for-comprehension's iteration variables,
+	// emit a matching for_each over the comprehension's collection. References
+	// to the for-expression's variables inside the body will be rewritten to
+	// each.key / each.value via scopeTraversalTokens.
+	if ds.enclosingForExpr != nil {
+		collTokens, d := g.exprTokens(ds.enclosingForExpr.Collection, schema.AnyType)
+		diags = append(diags, d...)
+		if d.HasErrors() {
+			return diags
+		}
+		// HCL for_each requires a map or set. When the PCL comprehension has no
+		// KeyVariable the collection is a list/tuple, so wrap it with toset() to
+		// coerce into a set keyed by its own elements (each.key == each.value).
+		if ds.enclosingForExpr.KeyVariable == nil {
+			collTokens = hclwrite.TokensForFunctionCall("toset", collTokens)
+		}
+		block.Body().SetAttributeRaw("for_each", collTokens)
+		g.forDataBlock = ds.enclosingForExpr
+		defer func() { g.forDataBlock = nil }()
+	}
 
 	// Second arg is the args object
 	if len(invoke.Args) >= 2 {
@@ -1129,16 +1373,30 @@ func (g *generator) exprTokens(expr model.Expression, typ schema.Type) (hclwrite
 	case *model.TemplateExpression:
 		return g.templateTokens(e)
 	case *model.FunctionCallExpression:
+		// Check if this is an invoke that maps to a TF builtin — inline it.
+		// Standalone use (not wrapped in .result) wraps the call in a single-
+		// field object so downstream .result access resolves correctly; the
+		// common .result wrapping is intercepted in relativeTraversalTokens
+		// to avoid the wrapper.
+		if e.Name == pcl.Invoke {
+			if fn, inlinable := inlinableStdFunc(e); inlinable {
+				callTokens, diags := g.inlineStdInvoke(e, fn)
+				if diags.HasErrors() {
+					return nil, diags
+				}
+				return wrapInResultObject(callTokens), nil
+			}
+		}
 		// Check if this is an invoke call that we've replaced with a data source
 		if e.Name == pcl.Invoke {
-			var dsName string
-			for _, v := range g.invokeDataSources {
-				if v.expr == e {
-					dsName = v.name
+			var matchedDS *spilledDataSource
+			for i := range g.invokeDataSources {
+				if g.invokeDataSources[i].expr == e {
+					matchedDS = &g.invokeDataSources[i]
 					break
 				}
 			}
-			if dsName != "" {
+			if matchedDS != nil {
 				// Generate reference to data source: data.type.name
 				token, ok := extractStringLiteral(e.Args[0])
 				if !ok {
@@ -1152,11 +1410,37 @@ func (g *generator) exprTokens(expr model.Expression, typ schema.Type) (hclwrite
 				if diags.HasErrors() {
 					return nil, diags
 				}
-				return hclwrite.TokensForTraversal(hcl.Traversal{
+				tokens := hclwrite.TokensForTraversal(hcl.Traversal{
 					hcl.TraverseRoot{Name: "data"},
 					hcl.TraverseAttr{Name: dsType},
-					hcl.TraverseAttr{Name: dsName},
-				}), nil
+					hcl.TraverseAttr{Name: matchedDS.name},
+				})
+				// If the data block carries a for_each matching the enclosing
+				// resource's range, index into it so the reference is per-iteration.
+				if matchedDS.parentResource != nil {
+					tokens = append(tokens, perIterationIndexTokens(g.currentRangeKind)...)
+				}
+				// If the data block carries a for_each matching an enclosing
+				// for-comprehension, index into it with a variable that remains
+				// in scope at the reference site. Prefer the comprehension's key
+				// variable; for no-key comprehensions the collection was wrapped
+				// with toset(), so the element value is its own key.
+				if fe := matchedDS.enclosingForExpr; fe != nil {
+					indexName := ""
+					if fe.KeyVariable != nil {
+						indexName = fe.KeyVariable.Name
+					} else if fe.ValueVariable != nil {
+						indexName = fe.ValueVariable.Name
+					}
+					if indexName != "" {
+						tokens = append(tokens,
+							&hclwrite.Token{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")},
+							&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(indexName)},
+							&hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")},
+						)
+					}
+				}
+				return tokens, nil
 			}
 		}
 		// Check if this is a call expression that we've replaced with a call block
@@ -1689,6 +1973,24 @@ func (g *generator) scopeTraversalTokens(expr *model.ScopeTraversalExpression) (
 				)), nil
 			}
 		}
+		if fe := g.forDataBlock; fe != nil && len(expr.Parts) > 0 {
+			if v, ok := expr.Parts[0].(*model.Variable); ok {
+				var attr string
+				switch v {
+				case fe.ValueVariable:
+					attr = "value"
+				case fe.KeyVariable:
+					attr = "key"
+				}
+				if attr != "" {
+					rewritten := hcl.Traversal{
+						hcl.TraverseRoot{Name: "each"},
+						hcl.TraverseAttr{Name: attr},
+					}
+					return hclwrite.TokensForTraversal(append(rewritten, traversal[1:]...)), nil
+				}
+			}
+		}
 		if db := g.dynamicBlock; db != nil {
 			// Rewrite references to the for-expression's iterator variables:
 			//   valueVar.field → blockName.value.field
@@ -1755,12 +2057,114 @@ func (g *generator) indexExprTokens(expr *model.IndexExpression) (hclwrite.Token
 }
 
 // relativeTraversalTokens generates tokens for a relative traversal expression: source.attr.
+// When the source is an inlinable std invoke followed by .result, the .result
+// step is stripped so we emit the TF builtin call directly (e.g. lookup(...) instead
+// of {result = lookup(...)}.result).
 func (g *generator) relativeTraversalTokens(expr *model.RelativeTraversalExpression) (hclwrite.Tokens, hcl.Diagnostics) {
+	if call, ok := expr.Source.(*model.FunctionCallExpression); ok {
+		if fn, inlinable := inlinableStdFunc(call); inlinable && traversalStartsWithResult(expr.Traversal) {
+			tokens, diags := g.inlineStdInvoke(call, fn)
+			if diags.HasErrors() {
+				return nil, diags
+			}
+			return append(tokens, traversalStepsToTokens(naiveRewriteTraversal(expr.Traversal[1:]))...), nil
+		}
+	}
 	sourceTokens, diags := g.exprTokens(expr.Source, schema.AnyType)
 	if diags.HasErrors() {
 		return nil, diags
 	}
 	return append(sourceTokens, traversalStepsToTokens(naiveRewriteTraversal(expr.Traversal))...), diags
+}
+
+// traversalStartsWithResult reports whether the first step of a relative traversal
+// is the attribute `.result`.
+func traversalStartsWithResult(traversal hcl.Traversal) bool {
+	if len(traversal) == 0 {
+		return false
+	}
+	attr, ok := traversal[0].(hcl.TraverseAttr)
+	return ok && attr.Name == "result"
+}
+
+// inlineStdInvoke emits a TF builtin function call for a std:index:* invoke.
+// The call's named args are looked up by the positional names in fn.inputs;
+// trailing missing args (e.g. an omitted `default` on lookup) are omitted from
+// the emitted call. Missing required args return unchanged args in positional
+// order, which is the responsibility of the PCL binder to validate.
+func (g *generator) inlineStdInvoke(call *model.FunctionCallExpression, fn stdTFFunc) (hclwrite.Tokens, hcl.Diagnostics) {
+	argsObj, ok := call.Args[1].(*model.ObjectConsExpression)
+	if !ok {
+		return nil, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "invalid std invoke",
+			Detail:   "expected args object",
+		}}
+	}
+	byName := make(map[string]model.Expression, len(argsObj.Items))
+	for _, item := range argsObj.Items {
+		name, ok := extractStringLiteral(item.Key)
+		if !ok {
+			continue
+		}
+		byName[name] = item.Value
+	}
+	// Collect args in the declared order, dropping trailing nil entries so that
+	// optional trailing params (e.g. lookup's `default`) don't show up as empty
+	// slots. Non-trailing missing params are left unresolved — the binder should
+	// have rejected that already.
+	var positional []model.Expression
+	for _, name := range fn.inputs {
+		positional = append(positional, byName[name])
+	}
+	for len(positional) > 0 && positional[len(positional)-1] == nil {
+		positional = positional[:len(positional)-1]
+	}
+	return g.passthroughFuncCallTokens(fn.name, positional)
+}
+
+// wrapInResultObject wraps a token stream in `{ result = <tokens> }` so that
+// later `.result` access on the wrapped expression resolves to the original
+// tokens. Used when an inlinable std invoke is referenced without an immediate
+// .result traversal (e.g. assigned to a local).
+func wrapInResultObject(inner hclwrite.Tokens) hclwrite.Tokens {
+	tokens := hclwrite.Tokens{
+		{Type: hclsyntax.TokenOBrace, Bytes: []byte("{")},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(" result ")},
+		{Type: hclsyntax.TokenEqual, Bytes: []byte("=")},
+	}
+	if len(inner) > 0 {
+		inner[0].SpacesBefore = 1
+	}
+	tokens = append(tokens, inner...)
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCBrace, Bytes: []byte(" }")})
+	return tokens
+}
+
+// perIterationIndexTokens returns the index expression that selects the current
+// iteration's entry from a data block hoisted with a matching for_each / count.
+// For for_each this is `[each.key]`; for count this is `[count.index]`.
+func perIterationIndexTokens(kind rangeKind) hclwrite.Tokens {
+	open := &hclwrite.Token{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")}
+	close := &hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")}
+	switch kind {
+	case rangeKindCount:
+		return hclwrite.Tokens{
+			open,
+			{Type: hclsyntax.TokenIdent, Bytes: []byte("count")},
+			{Type: hclsyntax.TokenDot, Bytes: []byte(".")},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte("index")},
+			close,
+		}
+	default:
+		return hclwrite.Tokens{
+			open,
+			{Type: hclsyntax.TokenIdent, Bytes: []byte("each")},
+			{Type: hclsyntax.TokenDot, Bytes: []byte(".")},
+			{Type: hclsyntax.TokenIdent, Bytes: []byte("key")},
+			close,
+		}
+	}
 }
 
 // splatTokens generates HCL tokens for a PCL SplatExpression.

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -190,6 +190,25 @@ type fileTransformer struct {
 	resourceSchemas map[string]*schema.Resource // cache: HCL type label → resolved schema resource
 	functionSchemas map[string]*schema.Function // cache: HCL type label → resolved schema function
 	nameRewrites    map[string]string           // logical name → sanitized PCL identifier (only for invalid names)
+	// comprehensionStack tracks the iteration variables of enclosing PCL
+	// for-expressions while we are emitting their body. When non-empty and we
+	// are inside an inlined invoke body, each.key / each.value references
+	// (which originated in a ranged data block) rewrite to the innermost
+	// comprehension's key / value variable names rather than range.*.
+	comprehensionStack []comprehensionCtx
+	// inlineDepth is incremented while invokeExprTokens is expanding a data
+	// block body at a reference site, so transformTraversal can distinguish
+	// "each.* in an inlined invoke" from "each.* at the top level of a
+	// ranged block's own body".
+	inlineDepth int
+}
+
+// comprehensionCtx records the variable names of a PCL for-expression so
+// references to its iteration variables survive inlining.
+type comprehensionCtx struct {
+	// KeyVar is empty when the PCL for-expression has no explicit key variable.
+	KeyVar string
+	ValVar string
 }
 
 // newFileTransformer creates a fileTransformer by pre-scanning body for resource and data definitions.
@@ -807,12 +826,88 @@ func (ft *fileTransformer) transformExpr(expr hclsyntax.Expression) hclwrite.Tok
 		return ft.transformForExpr(e)
 	case *hclsyntax.SplatExpr:
 		return ft.transformSplatExpr(e)
+	case *hclsyntax.IndexExpr:
+		return ft.transformIndexExpr(e)
+	case *hclsyntax.RelativeTraversalExpr:
+		return ft.transformRelativeTraversal(e)
 	default:
 		r := expr.Range()
 		return hclwrite.Tokens{
 			&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: ft.src[r.Start.Byte:r.End.Byte]},
 		}
 	}
+}
+
+// transformIndexExpr converts an HCL index expression (collection[key]) to PCL tokens.
+// When the collection is a reference to a ranged data block (one with for_each/count)
+// and the key is the per-iteration index, we drop the index and inline the invoke —
+// the inlined invoke's arguments already close over the enclosing resource's range.
+func (ft *fileTransformer) transformIndexExpr(e *hclsyntax.IndexExpr) hclwrite.Tokens {
+	if coll, ok := e.Collection.(*hclsyntax.ScopeTraversalExpr); ok &&
+		coll.Traversal.RootName() == "data" && len(coll.Traversal) >= 3 {
+		typeAttr, ok1 := coll.Traversal[1].(hcl.TraverseAttr)
+		nameAttr, ok2 := coll.Traversal[2].(hcl.TraverseAttr)
+		if ok1 && ok2 {
+			if body, ok := ft.dataBlocks[dataReference{typeAttr.Name, nameAttr.Name}]; ok {
+				_, hasForEach := body.Attributes["for_each"]
+				_, hasCount := body.Attributes["count"]
+				if hasForEach || hasCount {
+					return ft.invokeExprTokens(typeAttr.Name, nameAttr.Name)
+				}
+			}
+		}
+	}
+
+	tokens := ft.transformExpr(e.Collection)
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")})
+	tokens = append(tokens, ft.transformExpr(e.Key)...)
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")})
+	return tokens
+}
+
+// transformRelativeTraversal converts an HCL relative traversal expression
+// (source.attr...) to PCL tokens. The source is transformed recursively, then
+// the trailing traversal steps are appended with schema-aware name mapping.
+func (ft *fileTransformer) transformRelativeTraversal(e *hclsyntax.RelativeTraversalExpr) hclwrite.Tokens {
+	tokens := ft.transformExpr(e.Source)
+	props := ft.relativeTraversalSourceProps(e.Source)
+	dummy := make(hcl.Traversal, len(e.Traversal)+1)
+	dummy[0] = hcl.TraverseRoot{Name: "_"}
+	copy(dummy[1:], e.Traversal)
+	converted := schemaAwareTraversalAttrs(dummy, props)
+	for _, step := range converted[1:] {
+		switch s := step.(type) {
+		case hcl.TraverseAttr:
+			tokens = append(tokens,
+				&hclwrite.Token{Type: hclsyntax.TokenDot, Bytes: []byte(".")},
+				&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(s.Name)},
+			)
+		case hcl.TraverseIndex:
+			tokens = append(tokens, hclwrite.TokensForTraversal(hcl.Traversal{s})...)
+		}
+	}
+	return tokens
+}
+
+// relativeTraversalSourceProps returns the schema properties of the value
+// produced by `source`, used to map subsequent traversal attribute names.
+func (ft *fileTransformer) relativeTraversalSourceProps(source hclsyntax.Expression) []*schema.Property {
+	if idx, ok := source.(*hclsyntax.IndexExpr); ok {
+		source = idx.Collection
+	}
+	coll, ok := source.(*hclsyntax.ScopeTraversalExpr)
+	if !ok || coll.Traversal.RootName() != "data" || len(coll.Traversal) < 3 {
+		return nil
+	}
+	typeAttr, ok := coll.Traversal[1].(hcl.TraverseAttr)
+	if !ok {
+		return nil
+	}
+	fn := ft.functionSchemas[typeAttr.Name]
+	if fn == nil || fn.ReturnType == nil {
+		return nil
+	}
+	return propertiesOf(fn.ReturnType)
 }
 
 // transformSplatExpr converts a splat expression (source[*].attr) to PCL tokens.
@@ -1079,6 +1174,30 @@ func (ft *fileTransformer) transformTraversal(e *hclsyntax.ScopeTraversalExpr) h
 		}
 		return hclwrite.TokensForTraversal(trav)
 	case "each":
+		// When inlining a ranged data block inside a PCL for-comprehension,
+		// rewrite each.key / each.value to the comprehension's own variable
+		// names — the range.* scope belongs to the data block we are erasing
+		// and is not in scope at the inlined reference site.
+		if ft.inlineDepth > 0 && len(ft.comprehensionStack) > 0 {
+			top := ft.comprehensionStack[len(ft.comprehensionStack)-1]
+			if len(e.Traversal) >= 2 {
+				if attr, ok := e.Traversal[1].(hcl.TraverseAttr); ok {
+					var name string
+					switch attr.Name {
+					case "value":
+						name = top.ValVar
+					case "key":
+						name = top.KeyVar
+					}
+					if name != "" {
+						trav := make(hcl.Traversal, len(e.Traversal)-1)
+						trav[0] = hcl.TraverseRoot{Name: name}
+						copy(trav[1:], e.Traversal[2:])
+						return hclwrite.TokensForTraversal(trav)
+					}
+				}
+			}
+		}
 		// each.key → range.key, each.value → range.value
 		trav := make(hcl.Traversal, len(e.Traversal))
 		trav[0] = hcl.TraverseRoot{Name: "range"}
@@ -1249,6 +1368,9 @@ func (ft *fileTransformer) callExprTokens(resourceName, snakeMethod string) hclw
 // invoke("token", {args...}, {opts...}) when invoke options are present.
 // It looks up the matching data block to extract the argument and option objects.
 func (ft *fileTransformer) invokeExprTokens(hclType, dsName string) hclwrite.Tokens {
+	ft.inlineDepth++
+	defer func() { ft.inlineDepth-- }()
+
 	tokenTokens := hclwrite.TokensForValue(cty.StringVal(ft.dataTokens[hclType]))
 
 	var inputProps []*schema.Property
@@ -1259,6 +1381,9 @@ func (ft *fileTransformer) invokeExprTokens(hclType, dsName string) hclwrite.Tok
 	var argAttrs, optAttrs []hclwrite.ObjectAttrTokens
 	if body, ok := ft.dataBlocks[dataReference{hclType, dsName}]; ok {
 		for _, attr := range sortedAttributes(body.Attributes) {
+			if attr.Name == "for_each" || attr.Name == "count" {
+				continue
+			}
 			if pclName, isOpt := invokeOptionHCLToPCL[attr.Name]; isOpt {
 				optAttrs = append(optAttrs, hclwrite.ObjectAttrTokens{
 					Name:  hclwrite.TokensForIdentifier(pclName),
@@ -1484,6 +1609,17 @@ func (ft *fileTransformer) transformDynamicIteratorTraversal(trav hcl.Traversal,
 // sub-expressions (e.g., var.names → names).
 func (ft *fileTransformer) transformForExpr(e *hclsyntax.ForExpr) hclwrite.Tokens {
 	collTokens := ft.transformExpr(e.CollExpr)
+
+	// Push this for-expression's iteration variables so nested traversals of
+	// each.* inside any inlined invoke resolve to them instead of range.*.
+	ft.comprehensionStack = append(ft.comprehensionStack, comprehensionCtx{
+		KeyVar: e.KeyVar,
+		ValVar: e.ValVar,
+	})
+	defer func() {
+		ft.comprehensionStack = ft.comprehensionStack[:len(ft.comprehensionStack)-1]
+	}()
+
 	valTokens := ft.transformExpr(e.ValExpr)
 
 	isMap := e.KeyExpr != nil

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -259,6 +260,165 @@ func TestTransformFunctionCall(t *testing.T) {
 			assert.Equal(t, tt.expected, string(tokens.Bytes()))
 		})
 	}
+}
+
+// TestEjectDataBlockWithForEach verifies that an HCL program containing a data
+// block with `for_each` (the shape produced by the PCL → HCL codegen for invokes
+// that close over range.*) round-trips back to valid PCL. The inlined invoke
+// picks up the resource's range iterator via `range.value`, and the per-instance
+// indexing (`[each.key]`) collapses into the single inlined invoke expression.
+func TestEjectDataBlockWithForEach(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+	loader := testutil.NewMockReferenceLoader(t, testSchema)
+
+	src := []byte(`terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+data "test_echo" "invoke_0" {
+  for_each = {
+    "a" = "alpha"
+    "b" = "bravo"
+  }
+  input = each.value
+}
+
+resource "test_item" "inbound" {
+  for_each = {
+    "a" = "alpha"
+    "b" = "bravo"
+  }
+  value = data.test_echo.invoke_0[each.key].result
+}
+`)
+
+	out := hclwrite.NewEmptyFile()
+	diags, err := transformHCLFileToPCL(t.Context(), src, "main.hcl", out.Body(), loader, nil)
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	expected := `resource "inbound" "test:index:Item" {
+  value = invoke("test:index:echo", {
+    input = range.value
+  }).result
+  options {
+    range = {
+      "a" = "alpha"
+      "b" = "bravo"
+    }
+  }
+}
+
+`
+	assert.Equal(t, expected, string(out.Bytes()))
+}
+
+// TestEjectInvokeInListComprehension feeds in the HCL shape produced by the
+// codegen when a PCL invoke inside a list comprehension is hoisted: a data
+// block with for_each over the comprehension's collection, plus a
+// comprehension that indexes the data source by its key variable. The eject
+// should inline the invoke back inside the comprehension, with references to
+// each.value / each.key rewritten to the comprehension's iteration
+// variables — NOT to range.* (which would be unbound inside a comprehension).
+func TestEjectInvokeInListComprehension(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+	loader := testutil.NewMockReferenceLoader(t, testSchema)
+	src := []byte(`terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+data "test_echo" "invoke_0" {
+  for_each = {
+    "a" = "alpha"
+    "b" = "bravo"
+  }
+  input = each.value
+}
+
+output "results" {
+  value = [for k, v in {
+    "a" = "alpha"
+    "b" = "bravo"
+  } : data.test_echo.invoke_0[k].result]
+}
+`)
+
+	out := hclwrite.NewEmptyFile()
+	diags, err := transformHCLFileToPCL(t.Context(), src, "main.hcl", out.Body(), loader, nil)
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	expected := `output "results" {
+  value = [for k, v in {
+    "a" = "alpha"
+    "b" = "bravo"
+    } : invoke("test:index:echo", {
+      input = v
+  }).result]
+}
+
+`
+	assert.Equal(t, expected, string(out.Bytes()))
 }
 
 func TestTransformSplatExpr(t *testing.T) {

--- a/pkg/hcl/packages/packages_test.go
+++ b/pkg/hcl/packages/packages_test.go
@@ -63,7 +63,7 @@ func newTestLoader(t *testing.T, specs ...schema.PackageSpec) schema.ReferenceLo
 		pkg, diag, err := schema.BindSpec(spec, loader, schema.ValidationOptions{})
 		require.NoError(t, err)
 		require.Empty(t, diag)
-		d, err := pkg.Descriptor(context.Background())
+		d, err := pkg.Descriptor(t.Context())
 		require.NoError(t, err)
 
 		params := func() *schema.ParameterizationDescriptor {
@@ -155,7 +155,7 @@ func TestResolveResource(t *testing.T) {
 		},
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name           string
@@ -292,7 +292,7 @@ func TestResolveFunction(t *testing.T) {
 		},
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name           string

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1626,12 +1626,123 @@ func (e *Engine) processDataSource(ctx context.Context, node *graph.Node) error 
 func (e *Engine) processDataSourceInContext(
 	ctx context.Context, node *graph.Node, ds *ast.Resource, evalCtx *eval.Context,
 ) error {
-	// Resolve the data source type to a Pulumi function token
 	funcSchema, err := packages.ResolveFunction(ctx, e.pkgLoader, e.knownProviders(), ds.Type)
 	if err != nil {
 		return fmt.Errorf("resolving data source type %s: %w", ds.Type, err)
 	}
 
+	dsKey := node.Key
+	if node.ModuleInfo != nil {
+		dsKey = strings.TrimPrefix(dsKey, node.ModuleInfo.Prefix)
+	}
+	dsKey = strings.TrimPrefix(dsKey, "data.")
+
+	if ds.Count != nil || ds.ForEach != nil {
+		return e.processRangedDataSource(ctx, node, ds, funcSchema, evalCtx, dsKey)
+	}
+
+	ctyOutputs, allDeps, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx)
+	if err != nil {
+		return err
+	}
+	evalCtx.SetDataSource(dsKey, ctyOutputs)
+	e.dataSourceDependencies.Set(dsKey, allDeps)
+	return nil
+}
+
+// processRangedDataSource handles a data source with count or for_each.
+// It expands into N instances, invokes each, and stores the aggregated
+// outputs as a tuple (count) or object keyed by each.key (for_each) so that
+// `data.<type>.<name>[<index>|<key>].<attr>` resolves as expected.
+func (e *Engine) processRangedDataSource(
+	ctx context.Context, node *graph.Node, ds *ast.Resource, funcSchema *schema.Function,
+	evalCtx *eval.Context, dsKey string,
+) error {
+	tempEvaluator := eval.NewEvaluator(evalCtx)
+	expander := graph.NewResourceExpander()
+
+	if ds.Count != nil {
+		count, isBool, diags := tempEvaluator.EvaluateCount(ds.Count)
+		if diags.HasErrors() {
+			return fmt.Errorf("evaluating count: %s", diags.Error())
+		}
+		if isBool {
+			expander.SetBoolCount(node.Key, count)
+		} else {
+			expander.SetCount(node.Key, count)
+		}
+	}
+
+	if ds.ForEach != nil {
+		forEach, diags := tempEvaluator.EvaluateForEach(ds.ForEach)
+		if diags.HasErrors() {
+			return fmt.Errorf("evaluating for_each: %s", diags.Error())
+		}
+		expander.SetForEach(node.Key, forEach)
+	}
+
+	result := expander.Expand(node)
+
+	var allDeps []resource.URN
+	var tupleOutputs []cty.Value
+	eachOutputs := make(map[string]cty.Value)
+	isForEach := ds.ForEach != nil
+
+	for _, instance := range result.Instances {
+		if instance.Index != nil {
+			evalCtx.SetCount(*instance.Index)
+		}
+		if instance.EachKey != nil && instance.EachValue != nil {
+			evalCtx.SetEach(*instance.EachKey, *instance.EachValue)
+		}
+
+		ctyOut, deps, invokeErr := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx)
+
+		if instance.Index != nil {
+			evalCtx.ClearCount()
+		}
+		if instance.EachKey != nil {
+			evalCtx.ClearEach()
+		}
+
+		if invokeErr != nil {
+			return invokeErr
+		}
+		allDeps = append(allDeps, deps...)
+		if isForEach {
+			eachOutputs[instance.EachKey.AsString()] = ctyOut
+		} else {
+			tupleOutputs = append(tupleOutputs, ctyOut)
+		}
+	}
+
+	var aggregated cty.Value
+	if isForEach {
+		if len(eachOutputs) == 0 {
+			aggregated = cty.EmptyObjectVal
+		} else {
+			aggregated = cty.ObjectVal(eachOutputs)
+		}
+	} else {
+		if len(tupleOutputs) == 0 {
+			aggregated = cty.EmptyTupleVal
+		} else {
+			aggregated = cty.TupleVal(tupleOutputs)
+		}
+	}
+
+	evalCtx.SetDataSource(dsKey, aggregated)
+	e.dataSourceDependencies.Set(dsKey, allDeps)
+	return nil
+}
+
+// invokeDataSourceOnce performs a single data-source invocation using the
+// current state of evalCtx (which may have each/count set by the caller).
+// It returns the converted outputs and the URNs this invocation depended on.
+func (e *Engine) invokeDataSourceOnce(
+	ctx context.Context, node *graph.Node, ds *ast.Resource, funcSchema *schema.Function,
+	evalCtx *eval.Context,
+) (cty.Value, []resource.URN, error) {
 	hclCtx := evalCtx.HCLContext()
 
 	var allDeps []resource.URN
@@ -1671,7 +1782,7 @@ func (e *Engine) processDataSourceInContext(
 			return val, diags
 		})
 	if diags.HasErrors() {
-		return diags
+		return cty.NilVal, nil, diags
 	}
 
 	invokeReq := InvokeRequest{
@@ -1727,27 +1838,15 @@ func (e *Engine) processDataSourceInContext(
 
 	outputs, err := e.invokeFunction(ctx, invokeReq)
 	if err != nil {
-		return fmt.Errorf("invoking data source: %w", err)
+		return cty.NilVal, nil, fmt.Errorf("invoking data source: %w", err)
 	}
 
 	ctyOutputs, err := transform.FunctionOutputToCty(outputs, funcSchema, e.dryRun)
 	if err != nil {
-		return fmt.Errorf("converting function outputs to HCL types: %w", err)
+		return cty.NilVal, nil, fmt.Errorf("converting function outputs to HCL types: %w", err)
 	}
 
-	// Store outputs for future references.
-	// The node key is "<prefix>data.<type>.<name>"; strip the prefix and "data." to get "<type>.<name>".
-	dsKey := node.Key
-	if node.ModuleInfo != nil {
-		dsKey = strings.TrimPrefix(dsKey, node.ModuleInfo.Prefix)
-	}
-	dsKey = strings.TrimPrefix(dsKey, "data.")
-	evalCtx.SetDataSource(dsKey, ctyOutputs)
-
-	// Store dependencies for this data source.
-	e.dataSourceDependencies.Set(dsKey, allDeps)
-
-	return nil
+	return ctyOutputs, allDeps, nil
 }
 
 // processCall processes a call block (method invocation on a resource).


### PR DESCRIPTION
This expands Pulumi HCL to support `for_each` in `data` blocks, mirroring TF HCL. This works both on eject and conversion from PCL's inline invokes within `for_each` blocks.

Fixes https://github.com/pulumi/pulumi-converter-terraform/issues/417