### PR TITLE
Don't include `AdditionalKeys` when converting into `Pulumi.yaml`

### DIFF
--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-project-root-main/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-project-root-main/Pulumi.yaml
@@ -1,3 +1,3 @@
-main: subdir
 name: l1-builtin-project-root-main
 runtime: hcl
+main: subdir

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-main/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-main/Pulumi.yaml
@@ -1,3 +1,3 @@
-main: subdir
 name: l1-main
 runtime: hcl
+main: subdir

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-asset-archive/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-asset-archive/Pulumi.yaml
@@ -1,3 +1,3 @@
-main: subdir
 name: l2-resource-asset-archive
 runtime: hcl
+main: subdir

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-project-root-main/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-project-root-main/Pulumi.yaml
@@ -1,3 +1,3 @@
-main: subdir
 name: l1-builtin-project-root-main
 runtime: hcl
+main: subdir

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-main/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-main/Pulumi.yaml
@@ -1,3 +1,3 @@
-main: subdir
 name: l1-main
 runtime: hcl
+main: subdir

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-asset-archive/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-asset-archive/Pulumi.yaml
@@ -1,3 +1,3 @@
-main: subdir
 name: l2-resource-asset-archive
 runtime: hcl
+main: subdir

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -715,12 +715,7 @@ func (g *generator) genResource(body *hclwrite.Body, r *pcl.Resource) hcl.Diagno
 	}
 
 	for _, attr := range r.Inputs {
-		var inputType schema.Type
-		for _, prop := range inputs {
-			if attr.Name == prop.Name {
-				inputType = prop.Type
-			}
-		}
+		inputType := findPropertyType(inputs, attr.Name)
 		hclName := transform.SnakeCaseFromPulumiCase(attr.Name)
 		if objType, ok := transform.AsHCLBlockType(inputType); ok {
 			d := g.genBlocks(block.Body(), hclName, attr.Value, objType)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	pulumiencoding "github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -49,7 +50,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"gopkg.in/yaml.v3"
 )
 
 // LanguageHost implements the LanguageRuntimeServer gRPC interface.
@@ -58,6 +58,9 @@ type LanguageHost struct {
 	engine  pulumirpc.EngineClient
 	closers []io.Closer
 }
+
+// Ensure LanguageHost implements the interface.
+var _ pulumirpc.LanguageRuntimeServer = (*LanguageHost)(nil)
 
 // NewLanguageHost creates a new HCL language host.
 //
@@ -560,23 +563,38 @@ func (host *LanguageHost) GenerateProject(
 		binderOpts = append(binderOpts, pcl.NonStrictBindOptions()...)
 	}
 
-	// When the project specifies a "main" subdirectory, the PCL source files
-	// may live under that subdirectory (e.g. during round-trip testing where
-	// ConvertProgram preserves the directory structure). Check whether the
-	// subdirectory exists under SourceDirectory and, if so, bind from there.
-	sourceDir := req.SourceDirectory
-	var project map[string]any
+	var project workspace.Project
 	if err := json.Unmarshal([]byte(req.Project), &project); err != nil {
-		return nil, fmt.Errorf("parsing project JSON: %w", err)
-	}
-	if main, ok := project["main"].(string); ok && main != "" {
-		mainDir := filepath.Join(sourceDir, main)
-		if info, err := os.Stat(mainDir); err == nil && info.IsDir() {
-			sourceDir = mainDir
-		}
+		return nil, err
 	}
 
-	program, bindDiags, err := pcl.BindDirectory(sourceDir, nil, binderOpts...)
+	project.Runtime = workspace.NewProjectRuntimeInfo("hcl", nil)
+
+	projectBytes, err := pulumiencoding.YAML.Marshal(project)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(req.TargetDirectory, 0o755); err != nil {
+		return nil, fmt.Errorf("create target directory: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(req.TargetDirectory, "Pulumi.yaml"), projectBytes, 0o600); err != nil {
+		return nil, fmt.Errorf("write Pulumi.yaml: %w", err)
+	}
+
+	// Determine where to write program files. When the project specifies a
+	// "main" subdirectory, generated code goes into that subdirectory.
+	programDir := req.TargetDirectory
+	if project.Main != "" {
+		programDir = filepath.Join(req.TargetDirectory, project.Main)
+		if err := os.MkdirAll(programDir, 0755); err != nil {
+			return nil, fmt.Errorf("creating main directory: %w", err)
+		}
+
+	}
+
+	program, bindDiags, err := pcl.BindDirectory(req.SourceDirectory, nil, binderOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("binding directory: %w", err)
 	}
@@ -591,16 +609,6 @@ func (host *LanguageHost) GenerateProject(
 		return nil, fmt.Errorf("generating program: %w", err)
 	}
 
-	// Determine where to write program files. When the project specifies a
-	// "main" subdirectory, generated code goes into that subdirectory.
-	programDir := req.TargetDirectory
-	if main, ok := project["main"].(string); ok && main != "" {
-		programDir = filepath.Join(req.TargetDirectory, main)
-		if err := os.MkdirAll(programDir, 0755); err != nil {
-			return nil, fmt.Errorf("creating main directory: %w", err)
-		}
-	}
-
 	for name, content := range files {
 		path := filepath.Join(programDir, name)
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
@@ -609,10 +617,6 @@ func (host *LanguageHost) GenerateProject(
 		if err := os.WriteFile(path, content, 0644); err != nil {
 			return nil, fmt.Errorf("writing %s: %w", name, err)
 		}
-	}
-
-	if err := writePulumiYaml(req.TargetDirectory, req.Project); err != nil {
-		return nil, fmt.Errorf("writing Pulumi.yaml: %w", err)
 	}
 
 	// For each parameterized local dependency, store the hcl.sdk.json so that
@@ -747,8 +751,8 @@ func (host *LanguageHost) Link(
 	return &pulumirpc.LinkResponse{}, nil
 }
 
-// Ensure LanguageHost implements the interface.
-var _ pulumirpc.LanguageRuntimeServer = (*LanguageHost)(nil)
+// Ensure resourceMonitorAdapter implements the interface.
+var _ run.ResourceMonitor = (*resourceMonitorAdapter)(nil)
 
 // resourceMonitorAdapter adapts the Pulumi gRPC resource monitor to our interface.
 type resourceMonitorAdapter struct {
@@ -1019,31 +1023,6 @@ func (*resourceMonitorAdapter) pluginOptions() plugin.MarshalOptions {
 		KeepSecrets:   true,
 		KeepResources: true,
 	}
-}
-
-// Ensure resourceMonitorAdapter implements the interface.
-var _ run.ResourceMonitor = (*resourceMonitorAdapter)(nil)
-
-// writePulumiYaml writes the Pulumi.yaml file with runtime set to hcl.
-func writePulumiYaml(dir string, projectJSON string) error {
-	var project map[string]any
-	if err := json.Unmarshal([]byte(projectJSON), &project); err != nil {
-		return fmt.Errorf("parsing project JSON: %w", err)
-	}
-
-	project["runtime"] = "hcl"
-
-	yamlContent, err := yaml.Marshal(project)
-	if err != nil {
-		return fmt.Errorf("marshaling project to YAML: %w", err)
-	}
-
-	path := filepath.Join(dir, "Pulumi.yaml")
-	if err := os.WriteFile(path, yamlContent, 0644); err != nil {
-		return fmt.Errorf("writing Pulumi.yaml: %w", err)
-	}
-
-	return nil
 }
 
 // formatTimeoutSeconds converts a timeout in seconds to a duration string.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that we correctly inline additional keys.
+func TestGenerateProjectInlinesAdditionalKeys(t *testing.T) {
+	t.Parallel()
+
+	test := func(t *testing.T, projectJSON, expectedYAML string) {
+
+		sourceDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "main.pp"),
+			[]byte("output hello {\n    value = \"world\"\n}\n"), 0o600))
+
+		targetDir := t.TempDir()
+
+		host := &LanguageHost{}
+		_, err := host.GenerateProject(t.Context(), &pulumirpc.GenerateProjectRequest{
+			SourceDirectory: sourceDir,
+			TargetDirectory: targetDir,
+			Project:         projectJSON,
+			LoaderTarget:    "127.0.0.1:1",
+		})
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(filepath.Join(targetDir, "Pulumi.yaml"))
+		require.NoError(t, err)
+
+		require.Equal(t, expectedYAML, string(data))
+	}
+
+	t.Run("no additional keys", func(t *testing.T) {
+		t.Parallel()
+
+		json := `{
+        "name": "test",
+        "description": "test project"
+    }`
+
+		yaml := `name: test
+runtime: hcl
+description: test project
+`
+
+		test(t, json, yaml)
+	})
+
+	t.Run("with additional keys", func(t *testing.T) {
+		t.Parallel()
+
+		json := `{
+        "name": "test",
+        "description": "test project",
+	"AdditionalKeys": { "fizz": "buzz" }
+    }`
+
+		yaml := `name: test
+runtime: hcl
+description: test project
+fizz: buzz
+`
+
+		test(t, json, yaml)
+	})
+}


### PR DESCRIPTION
This PR changes how converting into `Pulumi.yaml` renders. By converting from JSON to YAML through `workspace.Project` instead of `map[string]any`, we respect the `inline` modifier present on `workspace.Project.AdditionalKeys`:

	// Handle additional keys, albeit in a way that will remove comments and trivia.
	AdditionalKeys map[string]any `yaml:",inline"`