### PR TITLE
Preserve comments when converting PCL <-> HCL

### DIFF
--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-can/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-can/main.pp
@@ -19,6 +19,8 @@ output "outputTryFailure" {
   value = can(aSecretMap["b"])
 }
 
+# A dynamically typed value, whose field accesses will not be type errors (since the type is not known to the type
+# checker), but may fail dynamically, and can thus be used as test inputs to can.
 config "anObject" {
 }
 
@@ -40,6 +42,7 @@ output "outputDynamicTryFailure" {
   value = can(aSecretObject.b)
 }
 
+# Check that explicit null values can be returned
 output "plainTryNull" {
   value = can(anObject.opt)
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-list/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-list/main.pp
@@ -27,6 +27,7 @@ output "splitOutput" {
   value = split("-", aString)
 }
 
+# Wrap in list to avoid unsafe-null-output (see l1-builtin-try/main.pp).
 output "singleOrNoneOutput" {
   value = [singleOrNone(singleOrNoneList)]
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-to-json/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-to-json/main.pp
@@ -33,6 +33,7 @@ output "objectOutput" {
   })
 }
 
+# Nested object using config values
 nestedObject = {
   "anObject" = {
     "name"  = aString

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-try/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-builtin-try/main.pp
@@ -19,6 +19,8 @@ output "outputTryFailure" {
   value = try(aSecretMap["b"], "fallback")
 }
 
+# A dynamically typed value, whose field accesses will not be type errors (since the type is not known to the type
+# checker), but may fail dynamically, and can thus be used as test inputs to try.
 config "anObject" {
 }
 
@@ -40,6 +42,9 @@ output "outputDynamicTryFailure" {
   value = try(aSecretObject.b, "fallback")
 }
 
+# Check that explicit null values can be returned.
+# It's not safe to return a null value directly (see l1-output-null 
+# and https://github.com/pulumi/pulumi/issues/19015) so wrap these in a list.
 output "plainTryNull" {
   value = [try(anObject.opt, "fallback")]
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-elide-index/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-elide-index/main.pp
@@ -1,3 +1,5 @@
+// Test that "pkg:typ" type tokens are accepted in PCL and are correctly expanded out. We also have an L2 test around
+// this but it's worth checking with the pulumi schema as it would be too easy for codegen to special case it differently.
 resource "myStash" "pulumi:index:Stash" {
   input = "test"
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-keyword-overlap/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-keyword-overlap/main.pp
@@ -1,3 +1,4 @@
+# Keywords in various languages should be renamed and work.
 class = "class_output_string"
 
 export = "export_output_string"

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-output-map/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-output-map/main.pp
@@ -16,6 +16,7 @@ output "numbers" {
   }
 }
 
+// Test that keys don't get renamed
 output "keys" {
   value = {
     "my.key" = 1

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-output-null/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-output-null/main.pp
@@ -1,3 +1,8 @@
+// "null" and "map" are currently commented out due to
+// https://github.com/pulumi/pulumi/issues/19015.
+//output "null" {
+//    value = null
+//}
 output "array" {
   value = [null]
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-proxy-index/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-proxy-index/main.pp
@@ -1,3 +1,4 @@
+# We use `secret` to lift plain values to output space, then check we can index into them
 config "anObject" "object({property=string})" {
 }
 

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-explicit-parameterized-provider/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-explicit-parameterized-provider/main.pp
@@ -12,12 +12,14 @@ resource "prov" "pulumi:providers:goodbye" {
   text = "World"
 }
 
+// The resource name is based on the parameter value
 resource "res" "goodbye:index:Goodbye" {
   options {
     provider = prov
   }
 }
 
+// The resource name is based on the parameter value and the provider config
 output "parameterValue" {
   value = res.parameterValue
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-invoke-dependencies/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-invoke-dependencies/main.pp
@@ -2,6 +2,8 @@ resource "first" "simple:index:Resource" {
   value = false
 }
 
+// assert that resource second depends on resource first
+// because it uses .secret from the invoke which depends on first
 resource "second" "simple:index:Resource" {
   value = invoke("simple-invoke:index:secretInvoke", {
     value          = "hello"

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-invoke-secrets/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-invoke-secrets/main.pp
@@ -2,6 +2,7 @@ resource "res" "simple:index:Resource" {
   value = true
 }
 
+// inputs are plain and the invoke response is plain
 output "nonSecret" {
   value = invoke("simple-invoke:index:secretInvoke", {
     value          = "hello"
@@ -9,6 +10,8 @@ output "nonSecret" {
   }).response
 }
 
+// referencing value from resource
+// invoke response is secret => whole output is secret
 output "firstSecret" {
   value = invoke("simple-invoke:index:secretInvoke", {
     value          = "hello"
@@ -16,6 +19,7 @@ output "firstSecret" {
   }).response
 }
 
+// inputs are secret, invoke response is plain => whole output is secret
 output "secondSecret" {
   value = invoke("simple-invoke:index:secretInvoke", {
     value          = secret("goodbye")

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-logical-name/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-logical-name/main.pp
@@ -12,6 +12,9 @@ output "bB-Beta_beta.💜⁉" {
   value         = aA-Alpha_alpha____.value
 }
 
+// New format for output logical name because outputs don't have separate logical names. Even nodejs which just
+// does "export" normally for outputs needs that export _to be_ the output name and so if the "logical name"
+// isn't a valid nodejs export we have to output it differently.
 output "dD-Delta_delta.🔥⁉" {
   __logicalName = "dD-Delta_delta.🔥⁉"
   value         = aA-Alpha_alpha____.value

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-module-format/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-module-format/main.pp
@@ -1,39 +1,48 @@
+// This tests that PCL allows both fully specified type tokens, and tokens that only specify the module and
+// member name.
+// First use the fully specified token to invoke and create a resource.
 resource "res1" "module-format:mod_Resource:Resource" {
   text = invoke("module-format:mod_concatWorld:concatWorld", {
     value = "hello"
   }).result
 }
 
+// Next use just the module name as defined by the module format
 resource "res2" "module-format:mod_Resource:Resource" {
   text = invoke("module-format:mod_concatWorld:concatWorld", {
     value = "goodbye"
   }).result
 }
 
+// First use the fully specified token to invoke and create a resource.
 resource "res3" "module-format:mod/nested_Resource:Resource" {
   text = invoke("module-format:mod/nested_concatWorld:concatWorld", {
     value = "hello"
   }).result
 }
 
+// Next use just the module name as defined by the module format
 resource "res4" "module-format:mod/nested_Resource:Resource" {
   text = invoke("module-format:mod/nested_concatWorld:concatWorld", {
     value = "goodbye"
   }).result
 }
 
+// First use the fully specified token to invoke and create a resource in the index module.
 resource "res5" "module-format:index_Resource:Resource" {
   text = invoke("module-format:index_concatWorld:concatWorld", {
     value = "bonjour"
   }).result
 }
 
+// Next use just the module name as defined by the module format
 resource "res6" "module-format:index_Resource:Resource" {
   text = invoke("module-format:index_concatWorld:concatWorld", {
     value = "youkoso"
   }).result
 }
 
+// Next use the short, 2 component, form because this is the index module
 resource "res7" "module-format:index_Resource:Resource" {
   text = invoke("module-format:index_concatWorld:concatWorld", {
     value = "guten tag"

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-parameterized-invoke/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-parameterized-invoke/main.pp
@@ -8,6 +8,7 @@ package "subpackage" {
   }
 }
 
+// The invoke name is based on the parameter value
 output "parameterValue" {
   value = invoke("subpackage:index:doHelloWorld", {
     input = "goodbye"

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-parameterized-resource-twice/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-parameterized-resource-twice/main.pp
@@ -18,12 +18,14 @@ package "hipackage" {
   }
 }
 
+// The resource name is based on the parameter value
 resource "example1" "hipackage:index:HelloWorld" {
 }
 
 resource "exampleComponent1" "hipackage:index:HelloWorldComponent" {
 }
 
+// The resource name is based on the parameter value
 resource "example2" "byepackage:index:GoodbyeWorld" {
 }
 

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-parameterized-resource/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-parameterized-resource/main.pp
@@ -8,6 +8,7 @@ package "subpackage" {
   }
 }
 
+// The resource name is based on the parameter value
 resource "example" "subpackage:index:HelloWorld" {
 }
 

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-provider-grpc-config-schema-secret/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-provider-grpc-config-schema-secret/main.pp
@@ -1,3 +1,4 @@
+# This provider covers scenarios where configuration properties are marked as secret in the schema.
 resource "config_grpc_provider" "pulumi:providers:config-grpc" {
   secretString1     = "SECRET"
   secretInt1        = 16

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-provider-grpc-config-secret/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-provider-grpc-config-secret/main.pp
@@ -1,3 +1,4 @@
+# This provider covers scenarios where user passes secret values to the provider.
 resource "config_grpc_provider" "pulumi:providers:config-grpc" {
   string1 = invoke("config-grpc:index:toSecret", {
     string1 = "SECRET"
@@ -17,12 +18,16 @@ resource "config_grpc_provider" "pulumi:providers:config-grpc" {
   listString2 = ["VALUE", invoke("config-grpc:index:toSecret", {
     string1 = "SECRET"
   }).string1]
+  # TODO[pulumi/pulumi#17535] this currently breaks Go compilation unfortunately.
+  # mapString1 = invoke("config-grpc:index:toSecret", {mapString1 = { key1 = "SECRET", key2 = "SECRET2" }}).mapString1
   mapString2 = {
     "key1" = "value1"
     "key2" = invoke("config-grpc:index:toSecret", {
       string1 = "SECRET"
     }).string1
   }
+  # TODO[pulumi/pulumi#17535] this breaks Go compilation as well.
+  # os1 = invoke("config-grpc:index:toSecret", {objString1 = { x = "SECRET" }}).objString1
   objString2 = {
     x = invoke("config-grpc:index:toSecret", {
       string1 = "SECRET"

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-provider-grpc-config/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-provider-grpc-config/main.pp
@@ -1,6 +1,8 @@
+# Cover interesting schema shapes.
 resource "config_grpc_provider" "pulumi:providers:config-grpc" {
-  string1     = ""
-  string2     = "x"
+  string1 = ""
+  string2 = "x"
+  # Test a JSON-like string to see if it trips up JSON detectors.
   string3     = "{}"
   int1        = 0
   int2        = 42

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-proxy-index/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-proxy-index/main.pp
@@ -1,3 +1,5 @@
+# Check we can index into properties of objects returned in outputs, this is similar to ref-ref but 
+# we index into the outputs
 resource "res" "ref-ref:index:Resource" {
   data = {
     innerData = {

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-config/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-config/main.pp
@@ -5,6 +5,7 @@ resource "prov" "pulumi:providers:config" {
   }
 }
 
+// Note this isn't _using_ the explicit provider, it's just grabbing a value from it.
 resource "res" "config:index:Resource" {
   text = prov.version
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-elide-unknowns/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-elide-unknowns/main.pp
@@ -1,3 +1,5 @@
+// This test checks that when a provider doesn't return properties for fields it considers unknown the runtime
+// can still access that field as an output.
 resource "prov" "pulumi:providers:output" {
   elideUnknowns = true
 }
@@ -16,6 +18,7 @@ resource "complex" "output:index:ComplexResource" {
   }
 }
 
+// Try and use the unknown output as an input to another resource to check that it doesn't cause any issues.
 resource "res" "simple:index:Resource" {
   value = unknown.output == "hello"
 }
@@ -32,6 +35,7 @@ resource "resObject" "simple:index:Resource" {
   value = complex.outputObject.output == "hello"
 }
 
+// And try to use it has an output
 output "out" {
   value = unknown.output
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-keyword-overlap/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-keyword-overlap/main.pp
@@ -14,6 +14,10 @@ resource "import" "simple:index:Resource" {
   value = true
 }
 
+# TODO(pulumi/pulumi#18246): Pcl should support scoping based on resource type just like HCL does in TF so we can uncomment this.
+# output "import" {
+#   value = Resource["import"]
+# }
 resource "object" "simple:index:Resource" {
   value = true
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-alias/0/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-alias/0/main.pp
@@ -1,3 +1,4 @@
+// Make a simple resource to use as a parent
 resource "parent" "simple:index:Resource" {
   value = true
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-delete-before-replace/0/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-delete-before-replace/0/main.pp
@@ -1,3 +1,5 @@
+// Stage 0: Initial resource creation
+// Resource with deleteBeforeReplace option
 resource "withOption" "simple:index:Resource" {
   value = true
   options {
@@ -6,6 +8,7 @@ resource "withOption" "simple:index:Resource" {
   }
 }
 
+// Resource without deleteBeforeReplace (default create-before-delete behavior)
 resource "withoutOption" "simple:index:Resource" {
   value = true
   options {

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-delete-before-replace/1/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-delete-before-replace/1/main.pp
@@ -1,13 +1,16 @@
+// Stage 1: Change properties to trigger replacements
+// Resource with deleteBeforeReplace option - should delete before creating
 resource "withOption" "simple:index:Resource" {
-  value = false
+  value = false // Changed to trigger replacement
   options {
     replaceOnChanges    = [value]
     deleteBeforeReplace = true
   }
 }
 
+// Resource without deleteBeforeReplace - should create before deleting (default)
 resource "withoutOption" "simple:index:Resource" {
-  value = false
+  value = false // Changed to trigger replacement
   options {
     replaceOnChanges = [value]
   }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-replace-on-changes/0/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-replace-on-changes/0/main.pp
@@ -1,3 +1,5 @@
+// Stage 0: Initial resource creation
+// Scenario 1: Schema-based replaceOnChanges on replaceProp
 resource "schemaReplace" "replaceonchanges:index:ResourceA" {
   value       = true
   replaceProp = true
@@ -6,6 +8,7 @@ resource "schemaReplace" "replaceonchanges:index:ResourceA" {
   }
 }
 
+// Scenario 2: Option-based replaceOnChanges on value
 resource "optionReplace" "replaceonchanges:index:ResourceB" {
   value = true
   options {
@@ -13,6 +16,7 @@ resource "optionReplace" "replaceonchanges:index:ResourceB" {
   }
 }
 
+// Scenario 3: Both schema and option - will change value
 resource "bothReplaceValue" "replaceonchanges:index:ResourceA" {
   value       = true
   replaceProp = true
@@ -21,6 +25,7 @@ resource "bothReplaceValue" "replaceonchanges:index:ResourceA" {
   }
 }
 
+// Scenario 4: Both schema and option - will change replaceProp
 resource "bothReplaceProp" "replaceonchanges:index:ResourceA" {
   value       = true
   replaceProp = true
@@ -29,10 +34,12 @@ resource "bothReplaceProp" "replaceonchanges:index:ResourceA" {
   }
 }
 
+// Scenario 5: No replaceOnChanges - baseline update
 resource "regularUpdate" "replaceonchanges:index:ResourceB" {
   value = true
 }
 
+// Scenario 6: replaceOnChanges set but no change
 resource "noChange" "replaceonchanges:index:ResourceB" {
   value = true
   options {
@@ -40,6 +47,7 @@ resource "noChange" "replaceonchanges:index:ResourceB" {
   }
 }
 
+// Scenario 7: replaceOnChanges on value, but only replaceProp changes
 resource "wrongPropChange" "replaceonchanges:index:ResourceA" {
   value       = true
   replaceProp = true
@@ -48,6 +56,7 @@ resource "wrongPropChange" "replaceonchanges:index:ResourceA" {
   }
 }
 
+// Scenario 8: Multiple properties in replaceOnChanges array
 resource "multiplePropReplace" "replaceonchanges:index:ResourceA" {
   value       = true
   replaceProp = true

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-replace-on-changes/1/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-replace-on-changes/1/main.pp
@@ -1,56 +1,65 @@
+// Stage 1: Change properties to trigger replacements
+// Scenario 1: Change replaceProp → REPLACE (schema triggers)
 resource "schemaReplace" "replaceonchanges:index:ResourceA" {
   value       = true
-  replaceProp = false
+  replaceProp = false // Changed from true
   options {
     replaceOnChanges = [replaceProp]
   }
 }
 
+// Scenario 2: Change value → REPLACE (option triggers)
 resource "optionReplace" "replaceonchanges:index:ResourceB" {
-  value = false
+  value = false // Changed from true
   options {
     replaceOnChanges = [value]
   }
 }
 
+// Scenario 3: Change value → REPLACE (option on value triggers)
 resource "bothReplaceValue" "replaceonchanges:index:ResourceA" {
-  value       = false
-  replaceProp = true
+  value       = false // Changed from true
+  replaceProp = true // Unchanged
   options {
     replaceOnChanges = [replaceProp, value]
   }
 }
 
+// Scenario 4: Change replaceProp → REPLACE (schema on replaceProp triggers)
 resource "bothReplaceProp" "replaceonchanges:index:ResourceA" {
-  value       = true
-  replaceProp = false
+  value       = true // Unchanged
+  replaceProp = false // Changed from true
   options {
     replaceOnChanges = [replaceProp, value]
   }
 }
 
+// Scenario 5: Change value → UPDATE (no replaceOnChanges)
 resource "regularUpdate" "replaceonchanges:index:ResourceB" {
-  value = false
+  value = false // Changed from true
 }
 
+// Scenario 6: No change → SAME (no operation)
 resource "noChange" "replaceonchanges:index:ResourceB" {
-  value = true
+  value = true // Unchanged
   options {
     replaceOnChanges = [value]
   }
 }
 
+// Scenario 7: Change replaceProp (not value) → UPDATE (marked property unchanged)
 resource "wrongPropChange" "replaceonchanges:index:ResourceA" {
-  value       = true
-  replaceProp = false
+  value       = true // Unchanged (this is marked for replacement)
+  replaceProp = false // Changed from true (this is NOT marked for replacement by option)
   options {
     replaceOnChanges = [replaceProp, value]
   }
 }
 
+// Scenario 8: Change value → REPLACE (multiple properties marked)
 resource "multiplePropReplace" "replaceonchanges:index:ResourceA" {
-  value       = false
-  replaceProp = true
+  value       = false // Changed from true
+  replaceProp = true // Unchanged
   options {
     replaceOnChanges = [replaceProp, value]
   }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-version-sdk/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-option-version-sdk/main.pp
@@ -1,3 +1,5 @@
+# Check that withV2 is generated against the v2 SDK and not against the V26 SDK,
+# and that the version resource option is elided.
 resource "withV2" "simple:index:Resource" {
   value = true
   options {

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-order/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-order/main.pp
@@ -6,6 +6,8 @@ resource "res1" "simple:index:Resource" {
   value = true
 }
 
+// This test asserts that PCL declaration order does not need to match usage order. That is a resource can be declared
+// lower in the file than it is first referenced.
 output "out" {
   value = res2.value
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-provider-inheritance/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-provider-inheritance/main.pp
@@ -8,6 +8,7 @@ resource "parent1" "simple:index:Resource" {
   }
 }
 
+// This should inherit the explicit provider from parent1
 resource "child1" "simple:index:Resource" {
   value = true
   options {
@@ -24,6 +25,7 @@ resource "parent2" "primitive:index:Resource" {
   booleanMap  = {}
 }
 
+// This _should not_ inherit the provider from parent2 as it is a default provider.
 resource "child2" "simple:index:Resource" {
   value = true
   options {
@@ -31,6 +33,7 @@ resource "child2" "simple:index:Resource" {
   }
 }
 
+// This _should not_ inherit the provider from parent1 as its from the wrong package.
 resource "child3" "primitive:index:Resource" {
   boolean     = false
   float       = 0

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-snake-names/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-snake-names/main.pp
@@ -1,3 +1,4 @@
+// Resource inputs are correctly translated
 resource "first" "snake_names:cool_module:some_resource" {
   the_input = true
   nested = {
@@ -5,6 +6,7 @@ resource "first" "snake_names:cool_module:some_resource" {
   }
 }
 
+// Datasource outputs are correctly translated
 resource "third" "snake_names:cool_module:another_resource" {
   the_input = invoke("snake_names:cool_module:some_data", {
     the_input = first.the_output["someKey"][0].nested_output

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-union/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-union/main.pp
@@ -14,14 +14,17 @@ resource "mapMapUnionExample" "union:index:Example" {
   }
 }
 
+// List<Union<String, Enum>> pattern
 resource "stringEnumUnionListExample" "union:index:Example" {
   stringEnumUnionListProperty = ["Listen", "Send", "NotAnEnumValue"]
 }
 
+// Safe enum: literal string matching an enum value
 resource "safeEnumExample" "union:index:Example" {
   typedEnumProperty = "Block"
 }
 
+// Output enum: output from another resource used as enum input
 resource "enumOutputExample" "union:index:EnumOutput" {
   name = "example"
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-deferred-outputs/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-deferred-outputs/main.pp
@@ -1,3 +1,4 @@
+# first & second are simple mutually dependent components
 component "first" "./first" {
   input = second.untainted
 }
@@ -6,7 +7,11 @@ component "second" "./second" {
   input = first.untainted
 }
 
+# another & many are also mutually dependent components, but many tests that the mutual dependency works through
+# `range`.
 component "another" "./first" {
+  # We do the join + for + == dance because we want to force a value that depends on the contents of the list, not
+  # just it's length (which may be known at preview time).
   input = join("", [for _, v in many : v.untainted ? "a" : "b"]) == "xyz"
 }
 

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-for-resource/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-for-resource/main.pp
@@ -2,6 +2,7 @@ resource "source" "nestedobject:index:Container" {
   inputs = ["a", "b", "c"]
 }
 
+# for over list<object> output
 resource "receiver" "nestedobject:index:Receiver" {
   details = [for __key, __value in source.details : {
     key   = __value.key
@@ -9,10 +10,12 @@ resource "receiver" "nestedobject:index:Receiver" {
   }]
 }
 
+# for over list<string> output
 resource "fromSimple" "nestedobject:index:Container" {
   inputs = [for _, detail in source.details : detail.value]
 }
 
+# for producing a map
 resource "mapped" "nestedobject:index:MapContainer" {
   tags = {for _, detail in source.details : detail.key => detail.value}
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-resource-output-traversal/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-resource-output-traversal/main.pp
@@ -9,6 +9,7 @@ resource "mapContainer" "nestedobject:index:MapContainer" {
   }
 }
 
+# A resource that ranges over a computed list
 resource "listOutput" "nestedobject:index:Target" {
   name = range.value.value
   options {
@@ -16,6 +17,7 @@ resource "listOutput" "nestedobject:index:Target" {
   }
 }
 
+# A resource that ranges over a computed map
 resource "mapOutput" "nestedobject:index:Target" {
   name = "${range.key}=>${range.value}"
   options {

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/provider-alias-component/0/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/provider-alias-component/0/main.pp
@@ -2,6 +2,7 @@ resource "res" "conformance-component:index:Simple" {
   value = true
 }
 
+// Make a simple resource so that plugin detection works.
 resource "simpleResource" "simple:index:Resource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/provider-alias-component/1/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/provider-alias-component/1/main.pp
@@ -1,7 +1,9 @@
+// Make a simple resource to use as a parent
 resource "parent" "simple:index:Resource" {
   value = true
 }
 
+// parent "res" to a new parent and alias it so it doesn't recreate.
 resource "res" "conformance-component:index:Simple" {
   value = true
   options {
@@ -12,6 +14,7 @@ resource "res" "conformance-component:index:Simple" {
   }
 }
 
+// Make a simple resource so that plugin detection works.
 resource "simpleResource" "simple:index:Resource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/provider-ignore-changes-component/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/provider-ignore-changes-component/main.pp
@@ -9,6 +9,7 @@ resource "withoutIgnoreChanges" "conformance-component:index:Simple" {
   value = true
 }
 
+// Make a simple resource so that plugin detection works.
 resource "simpleResource" "simple:index:Resource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/provider-resource-component/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/provider-resource-component/main.pp
@@ -2,6 +2,7 @@ resource "res" "conformance-component:index:Simple" {
   value = true
 }
 
+// Make a simple resource so that plugin detection works.
 resource "simpleResource" "simple:index:Resource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-can/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-can/main.hcl
@@ -16,6 +16,8 @@ output "outputTrySuccess" {
 output "outputTryFailure" {
   value = can(local.aSecretMap["b"])
 }
+# A dynamically typed value, whose field accesses will not be type errors (since the type is not known to the type
+# checker), but may fail dynamically, and can thus be used as test inputs to can.
 variable "anObject" {
 }
 output "dynamicTrySuccess" {
@@ -33,6 +35,7 @@ output "outputDynamicTrySuccess" {
 output "outputDynamicTryFailure" {
   value = can(local.aSecretObject.b)
 }
+# Check that explicit null values can be returned
 output "plainTryNull" {
   value = can(var.anObject.opt)
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-list/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-list/main.hcl
@@ -22,6 +22,7 @@ output "lengthOutput" {
 output "splitOutput" {
   value = split("-", var.aString)
 }
+# Wrap in list to avoid unsafe-null-output (see l1-builtin-try/main.pp).
 output "singleOrNoneOutput" {
   value = [one(var.singleOrNoneList)]
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-to-json/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-to-json/main.hcl
@@ -28,6 +28,7 @@ output "objectOutput" {
     "count" = 1
   })
 }
+# Nested object using config values
 locals {
   nestedObject = {
     "anObject" = {

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-try/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-try/main.hcl
@@ -16,6 +16,8 @@ output "outputTrySuccess" {
 output "outputTryFailure" {
   value = try(local.aSecretMap["b"], "fallback")
 }
+# A dynamically typed value, whose field accesses will not be type errors (since the type is not known to the type
+# checker), but may fail dynamically, and can thus be used as test inputs to try.
 variable "anObject" {
 }
 output "dynamicTrySuccess" {
@@ -33,6 +35,9 @@ output "outputDynamicTrySuccess" {
 output "outputDynamicTryFailure" {
   value = try(local.aSecretObject.b, "fallback")
 }
+# Check that explicit null values can be returned.
+# It's not safe to return a null value directly (see l1-output-null 
+# and https://github.com/pulumi/pulumi/issues/19015) so wrap these in a list.
 output "plainTryNull" {
   value = [try(var.anObject.opt, "fallback")]
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-elide-index/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-elide-index/main.hcl
@@ -1,3 +1,5 @@
+// Test that "pkg:typ" type tokens are accepted in PCL and are correctly expanded out. We also have an L2 test around
+// this but it's worth checking with the pulumi schema as it would be too easy for codegen to special case it differently.
 resource "pulumi_stash" "myStash" {
   input = "test"
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-keyword-overlap/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-keyword-overlap/main.hcl
@@ -1,3 +1,4 @@
+# Keywords in various languages should be renamed and work.
 locals {
   class = "class_output_string"
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-output-map/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-output-map/main.hcl
@@ -13,6 +13,7 @@ output "numbers" {
     "2" = 2
   }
 }
+// Test that keys don't get renamed
 output "keys" {
   value = {
     "my.key" = 1

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-output-null/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-output-null/main.hcl
@@ -1,3 +1,8 @@
+// "null" and "map" are currently commented out due to
+// https://github.com/pulumi/pulumi/issues/19015.
+//output "null" {
+//    value = null
+//}
 output "array" {
   value = [null]
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-proxy-index/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-proxy-index/main.hcl
@@ -1,3 +1,4 @@
+# We use `secret` to lift plain values to output space, then check we can index into them
 variable "anObject" {
   type = object({property=string})
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-explicit-parameterized-provider/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-explicit-parameterized-provider/main.hcl
@@ -10,9 +10,11 @@ terraform {
 resource "pulumi_providers_goodbye" "prov" {
   text = "World"
 }
+// The resource name is based on the parameter value
 resource "goodbye_goodbye" "res" {
   provider = pulumi_providers_goodbye.prov
 }
+// The resource name is based on the parameter value and the provider config
 output "parameterValue" {
   value = goodbye_goodbye.res.parameter_value
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-dependencies/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-dependencies/main.hcl
@@ -19,6 +19,8 @@ data "simple-invoke_secretinvoke" "invoke_0" {
 resource "simple_resource" "first" {
   value = false
 }
+// assert that resource second depends on resource first
+// because it uses .secret from the invoke which depends on first
 resource "simple_resource" "second" {
   value = data.simple-invoke_secretinvoke.invoke_0.secret
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-secrets/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-secrets/main.hcl
@@ -27,12 +27,16 @@ data "simple-invoke_secretinvoke" "invoke_2" {
 resource "simple_resource" "res" {
   value = true
 }
+// inputs are plain and the invoke response is plain
 output "nonSecret" {
   value = data.simple-invoke_secretinvoke.invoke_0.response
 }
+// referencing value from resource
+// invoke response is secret => whole output is secret
 output "firstSecret" {
   value = data.simple-invoke_secretinvoke.invoke_1.response
 }
+// inputs are secret, invoke response is plain => whole output is secret
 output "secondSecret" {
   value = data.simple-invoke_secretinvoke.invoke_2.response
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-logical-name/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-logical-name/main.hcl
@@ -16,6 +16,9 @@ variable "cC-Charlie_charlie.😃⁉️" {
 output "bB-Beta_beta.💜⁉" {
   value = simple_resource["aA-Alpha_alpha.🤯⁉️"].value
 }
+// New format for output logical name because outputs don't have separate logical names. Even nodejs which just
+// does "export" normally for outputs needs that export _to be_ the output name and so if the "logical name"
+// isn't a valid nodejs export we have to output it differently.
 output "dD-Delta_delta.🔥⁉" {
   value = simple_resource["aA-Alpha_alpha.🤯⁉️"].value
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-module-format/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-module-format/main.hcl
@@ -51,24 +51,33 @@ call "res7" "call" {
   input = "xxx"
 }
 
+// This tests that PCL allows both fully specified type tokens, and tokens that only specify the module and
+// member name.
+// First use the fully specified token to invoke and create a resource.
 resource "module-format_mod_resource" "res1" {
   text = data.module-format_mod_concatworld.invoke_0.result
 }
+// Next use just the module name as defined by the module format
 resource "module-format_mod_resource" "res2" {
   text = data.module-format_mod_concatworld.invoke_1.result
 }
+// First use the fully specified token to invoke and create a resource.
 resource "module-format_mod_nested_resource" "res3" {
   text = data.module-format_mod_nested_concatworld.invoke_2.result
 }
+// Next use just the module name as defined by the module format
 resource "module-format_mod_nested_resource" "res4" {
   text = data.module-format_mod_nested_concatworld.invoke_3.result
 }
+// First use the fully specified token to invoke and create a resource in the index module.
 resource "module-format_resource" "res5" {
   text = data.module-format_concatworld.invoke_4.result
 }
+// Next use just the module name as defined by the module format
 resource "module-format_resource" "res6" {
   text = data.module-format_concatworld.invoke_5.result
 }
+// Next use the short, 2 component, form because this is the index module
 resource "module-format_resource" "res7" {
   text = data.module-format_concatworld.invoke_6.result
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-invoke/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-invoke/main.hcl
@@ -11,6 +11,7 @@ data "subpackage_dohelloworld" "invoke_0" {
   input = "goodbye"
 }
 
+// The invoke name is based on the parameter value
 output "parameterValue" {
   value = data.subpackage_dohelloworld.invoke_0.output
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-resource-twice/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-resource-twice/main.hcl
@@ -11,10 +11,12 @@ terraform {
   }
 }
 
+// The resource name is based on the parameter value
 resource "hipackage_helloworld" "example1" {
 }
 resource "hipackage_helloworldcomponent" "exampleComponent1" {
 }
+// The resource name is based on the parameter value
 resource "byepackage_goodbyeworld" "example2" {
 }
 resource "byepackage_goodbyeworldcomponent" "exampleComponent2" {

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-resource/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-resource/main.hcl
@@ -7,6 +7,7 @@ terraform {
   }
 }
 
+// The resource name is based on the parameter value
 resource "subpackage_helloworld" "example" {
 }
 resource "subpackage_helloworldcomponent" "exampleComponent" {

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config-schema-secret/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config-schema-secret/main.hcl
@@ -7,6 +7,7 @@ terraform {
   }
 }
 
+# This provider covers scenarios where configuration properties are marked as secret in the schema.
 resource "pulumi_providers_config-grpc" "config_grpc_provider" {
   secret_string1      = "SECRET"
   secret_int1         = 16

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config-secret/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config-secret/main.hcl
@@ -32,6 +32,7 @@ data "config-grpc_tosecret" "invoke_7" {
   string1 = "SECRET"
 }
 
+# This provider covers scenarios where user passes secret values to the provider.
 resource "pulumi_providers_config-grpc" "config_grpc_provider" {
   string1      = data.config-grpc_tosecret.invoke_0.string1
   int1         = data.config-grpc_tosecret.invoke_1.int1
@@ -39,10 +40,14 @@ resource "pulumi_providers_config-grpc" "config_grpc_provider" {
   bool1        = data.config-grpc_tosecret.invoke_3.bool1
   list_string1 = data.config-grpc_tosecret.invoke_4.list_string1
   list_string2 = ["VALUE", data.config-grpc_tosecret.invoke_5.string1]
+  # TODO[pulumi/pulumi#17535] this currently breaks Go compilation unfortunately.
+  # mapString1 = invoke("config-grpc:index:toSecret", {mapString1 = { key1 = "SECRET", key2 = "SECRET2" }}).mapString1
   map_string2 = {
     "key1" = "value1"
     "key2" = data.config-grpc_tosecret.invoke_6.string1
   }
+  # TODO[pulumi/pulumi#17535] this breaks Go compilation as well.
+  # os1 = invoke("config-grpc:index:toSecret", {objString1 = { x = "SECRET" }}).objString1
   obj_string2 = {
     x = data.config-grpc_tosecret.invoke_7.string1
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config/main.hcl
@@ -7,9 +7,11 @@ terraform {
   }
 }
 
+# Cover interesting schema shapes.
 resource "pulumi_providers_config-grpc" "config_grpc_provider" {
-  string1      = ""
-  string2      = "x"
+  string1 = ""
+  string2 = "x"
+  # Test a JSON-like string to see if it trips up JSON detectors.
   string3      = "{}"
   int1         = 0
   int2         = 42

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-proxy-index/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-proxy-index/main.hcl
@@ -7,6 +7,8 @@ terraform {
   }
 }
 
+# Check we can index into properties of objects returned in outputs, this is similar to ref-ref but 
+# we index into the outputs
 resource "ref-ref_resource" "res" {
   data = {
     inner_data = {

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-config/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-config/main.hcl
@@ -11,6 +11,7 @@ resource "pulumi_providers_config" "prov" {
   name                = "my config"
   plugin_download_url = "not the same as the pulumi resource option"
 }
+// Note this isn't _using_ the explicit provider, it's just grabbing a value from it.
 resource "config_resource" "res" {
   text = pulumi_providers_config.prov.version
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-elide-unknowns/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-elide-unknowns/main.hcl
@@ -11,6 +11,8 @@ terraform {
   }
 }
 
+// This test checks that when a provider doesn't return properties for fields it considers unknown the runtime
+// can still access that field as an output.
 resource "pulumi_providers_output" "prov" {
   elide_unknowns = true
 }
@@ -22,6 +24,7 @@ resource "output_complexresource" "complex" {
   provider = pulumi_providers_output.prov
   value    = 1
 }
+// Try and use the unknown output as an input to another resource to check that it doesn't cause any issues.
 resource "simple_resource" "res" {
   value = output_resource.unknown.output == "hello"
 }
@@ -34,6 +37,7 @@ resource "simple_resource" "resMap" {
 resource "simple_resource" "resObject" {
   value = output_complexresource.complex.output_object.output == "hello"
 }
+// And try to use it has an output
 output "out" {
   value = output_resource.unknown.output
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-keyword-overlap/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-keyword-overlap/main.hcl
@@ -19,6 +19,10 @@ resource "simple_resource" "mod" {
 resource "simple_resource" "import" {
   value = true
 }
+# TODO(pulumi/pulumi#18246): Pcl should support scoping based on resource type just like HCL does in TF so we can uncomment this.
+# output "import" {
+#   value = Resource["import"]
+# }
 resource "simple_resource" "object" {
   value = true
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-alias/0/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-alias/0/main.hcl
@@ -11,6 +11,7 @@ terraform {
   }
 }
 
+// Make a simple resource to use as a parent
 resource "simple_resource" "parent" {
   value = true
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-delete-before-replace/0/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-delete-before-replace/0/main.hcl
@@ -7,6 +7,8 @@ terraform {
   }
 }
 
+// Stage 0: Initial resource creation
+// Resource with deleteBeforeReplace option
 resource "simple_resource" "withOption" {
   replace_on_changes = ["value"]
   lifecycle {
@@ -14,6 +16,7 @@ resource "simple_resource" "withOption" {
   }
   value = true
 }
+// Resource without deleteBeforeReplace (default create-before-delete behavior)
 resource "simple_resource" "withoutOption" {
   replace_on_changes = ["value"]
   value              = true

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-delete-before-replace/1/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-delete-before-replace/1/main.hcl
@@ -7,14 +7,17 @@ terraform {
   }
 }
 
+// Stage 1: Change properties to trigger replacements
+// Resource with deleteBeforeReplace option - should delete before creating
 resource "simple_resource" "withOption" {
   replace_on_changes = ["value"]
   lifecycle {
     create_before_destroy = !true
   }
-  value = false
+  value = false // Changed to trigger replacement
 }
+// Resource without deleteBeforeReplace - should create before deleting (default)
 resource "simple_resource" "withoutOption" {
   replace_on_changes = ["value"]
-  value              = false
+  value              = false // Changed to trigger replacement
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-replace-on-changes/0/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-replace-on-changes/0/main.hcl
@@ -7,37 +7,46 @@ terraform {
   }
 }
 
+// Stage 0: Initial resource creation
+// Scenario 1: Schema-based replaceOnChanges on replaceProp
 resource "replaceonchanges_resourcea" "schemaReplace" {
   replace_on_changes = ["replaceProp"]
   value              = true
   replace_prop       = true
 }
+// Scenario 2: Option-based replaceOnChanges on value
 resource "replaceonchanges_resourceb" "optionReplace" {
   replace_on_changes = ["value"]
   value              = true
 }
+// Scenario 3: Both schema and option - will change value
 resource "replaceonchanges_resourcea" "bothReplaceValue" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
+// Scenario 4: Both schema and option - will change replaceProp
 resource "replaceonchanges_resourcea" "bothReplaceProp" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
+// Scenario 5: No replaceOnChanges - baseline update
 resource "replaceonchanges_resourceb" "regularUpdate" {
   value = true
 }
+// Scenario 6: replaceOnChanges set but no change
 resource "replaceonchanges_resourceb" "noChange" {
   replace_on_changes = ["value"]
   value              = true
 }
+// Scenario 7: replaceOnChanges on value, but only replaceProp changes
 resource "replaceonchanges_resourcea" "wrongPropChange" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
+// Scenario 8: Multiple properties in replaceOnChanges array
 resource "replaceonchanges_resourcea" "multiplePropReplace" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-replace-on-changes/1/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-replace-on-changes/1/main.hcl
@@ -7,39 +7,48 @@ terraform {
   }
 }
 
+// Stage 1: Change properties to trigger replacements
+// Scenario 1: Change replaceProp → REPLACE (schema triggers)
 resource "replaceonchanges_resourcea" "schemaReplace" {
   replace_on_changes = ["replaceProp"]
   value              = true
-  replace_prop       = false
+  replace_prop       = false // Changed from true
 }
+// Scenario 2: Change value → REPLACE (option triggers)
 resource "replaceonchanges_resourceb" "optionReplace" {
   replace_on_changes = ["value"]
-  value              = false
+  value              = false // Changed from true
 }
+// Scenario 3: Change value → REPLACE (option on value triggers)
 resource "replaceonchanges_resourcea" "bothReplaceValue" {
   replace_on_changes = ["replaceProp", "value"]
-  value              = false
-  replace_prop       = true
+  value              = false // Changed from true
+  replace_prop       = true // Unchanged
 }
+// Scenario 4: Change replaceProp → REPLACE (schema on replaceProp triggers)
 resource "replaceonchanges_resourcea" "bothReplaceProp" {
   replace_on_changes = ["replaceProp", "value"]
-  value              = true
-  replace_prop       = false
+  value              = true // Unchanged
+  replace_prop       = false // Changed from true
 }
+// Scenario 5: Change value → UPDATE (no replaceOnChanges)
 resource "replaceonchanges_resourceb" "regularUpdate" {
-  value = false
+  value = false // Changed from true
 }
+// Scenario 6: No change → SAME (no operation)
 resource "replaceonchanges_resourceb" "noChange" {
   replace_on_changes = ["value"]
-  value              = true
+  value              = true // Unchanged
 }
+// Scenario 7: Change replaceProp (not value) → UPDATE (marked property unchanged)
 resource "replaceonchanges_resourcea" "wrongPropChange" {
   replace_on_changes = ["replaceProp", "value"]
-  value              = true
-  replace_prop       = false
+  value              = true // Unchanged (this is marked for replacement)
+  replace_prop       = false // Changed from true (this is NOT marked for replacement by option)
 }
+// Scenario 8: Change value → REPLACE (multiple properties marked)
 resource "replaceonchanges_resourcea" "multiplePropReplace" {
   replace_on_changes = ["replaceProp", "value"]
-  value              = false
-  replace_prop       = true
+  value              = false // Changed from true
+  replace_prop       = true // Unchanged
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-version-sdk/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-version-sdk/main.hcl
@@ -7,6 +7,8 @@ terraform {
   }
 }
 
+# Check that withV2 is generated against the v2 SDK and not against the V26 SDK,
+# and that the version resource option is elided.
 resource "simple_resource" "withV2" {
   version = "2.0.0"
   value   = true

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-order/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-order/main.hcl
@@ -13,6 +13,8 @@ resource "simple_resource" "res2" {
 resource "simple_resource" "res1" {
   value = true
 }
+// This test asserts that PCL declaration order does not need to match usage order. That is a resource can be declared
+// lower in the file than it is first referenced.
 output "out" {
   value = simple_resource.res2.value
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-provider-inheritance/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-provider-inheritance/main.hcl
@@ -17,6 +17,7 @@ resource "simple_resource" "parent1" {
   provider = pulumi_providers_simple.provider
   value    = true
 }
+// This should inherit the explicit provider from parent1
 resource "simple_resource" "child1" {
   parent = simple_resource.parent1
   value  = true
@@ -29,10 +30,12 @@ resource "primitive_resource" "parent2" {
   number_array = []
   boolean_map  = {}
 }
+// This _should not_ inherit the provider from parent2 as it is a default provider.
 resource "simple_resource" "child2" {
   parent = primitive_resource.parent2
   value  = true
 }
+// This _should not_ inherit the provider from parent1 as its from the wrong package.
 resource "primitive_resource" "child3" {
   parent       = simple_resource.parent1
   boolean      = false

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-snake-names/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-snake-names/main.hcl
@@ -14,12 +14,14 @@ data "snake_names_cool_module_some_data" "invoke_0" {
   }
 }
 
+// Resource inputs are correctly translated
 resource "snake_names_cool_module_some_resource" "first" {
   the_input = true
   nested = {
     nested_value = "nested"
   }
 }
+// Datasource outputs are correctly translated
 resource "snake_names_cool_module_another_resource" "third" {
   the_input = data.snake_names_cool_module_some_data.invoke_0.nested_output[0]["key"].value
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-union/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-union/main.hcl
@@ -20,12 +20,15 @@ resource "union_example" "mapMapUnionExample" {
     }
   }
 }
+// List<Union<String, Enum>> pattern
 resource "union_example" "stringEnumUnionListExample" {
   string_enum_union_list_property = ["Listen", "Send", "NotAnEnumValue"]
 }
+// Safe enum: literal string matching an enum value
 resource "union_example" "safeEnumExample" {
   typed_enum_property = "Block"
 }
+// Output enum: output from another resource used as enum input
 resource "union_enumoutput" "enumOutputExample" {
   name = "example"
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/main.hcl
@@ -7,6 +7,7 @@ terraform {
   }
 }
 
+# first & second are simple mutually dependent components
 module "first" {
   source = "./first"
   input  = module.second.untainted
@@ -15,9 +16,13 @@ module "second" {
   source = "./second"
   input  = module.first.untainted
 }
+# another & many are also mutually dependent components, but many tests that the mutual dependency works through
+# `range`.
 module "another" {
   source = "./first"
-  input  = join("", [for _, v in module.many : v.untainted ? "a" : "b"]) == "xyz"
+  # We do the join + for + == dance because we want to force a value that depends on the contents of the list, not
+  # just it's length (which may be known at preview time).
+  input = join("", [for _, v in module.many : v.untainted ? "a" : "b"]) == "xyz"
 }
 module "many" {
   source = "./second"

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-for-resource/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-for-resource/main.hcl
@@ -10,6 +10,7 @@ terraform {
 resource "nestedobject_container" "source" {
   inputs = ["a", "b", "c"]
 }
+# for over list<object> output
 resource "nestedobject_receiver" "receiver" {
   dynamic "details" {
     for_each = nestedobject_container.source.details
@@ -19,9 +20,11 @@ resource "nestedobject_receiver" "receiver" {
     }
   }
 }
+# for over list<string> output
 resource "nestedobject_container" "fromSimple" {
   inputs = [for _, detail in nestedobject_container.source.details : detail.value]
 }
+# for producing a map
 resource "nestedobject_mapcontainer" "mapped" {
   tags = {for _, detail in nestedobject_container.source.details : detail.key => detail.value}
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-range-resource-output-traversal/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-range-resource-output-traversal/main.hcl
@@ -16,10 +16,12 @@ resource "nestedobject_mapcontainer" "mapContainer" {
     "k2" = "delta"
   }
 }
+# A resource that ranges over a computed list
 resource "nestedobject_target" "listOutput" {
   for_each = {  for  __key,  __value  in  nestedobject_container.container.details  :  tostring(__key)  =>  __value  }
   name     = each.value.value
 }
+# A resource that ranges over a computed map
 resource "nestedobject_target" "mapOutput" {
   for_each = nestedobject_mapcontainer.mapContainer.tags
   name     ="${each.key}=>${each.value}"

--- a/cmd/pulumi-language-hcl/testdata/projects/provider-alias-component/0/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/provider-alias-component/0/main.hcl
@@ -14,6 +14,7 @@ terraform {
 resource "conformance-component_simple" "res" {
   value = true
 }
+// Make a simple resource so that plugin detection works.
 resource "simple_resource" "simpleResource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/provider-alias-component/1/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/provider-alias-component/1/main.hcl
@@ -11,9 +11,11 @@ terraform {
   }
 }
 
+// Make a simple resource to use as a parent
 resource "simple_resource" "parent" {
   value = true
 }
+// parent "res" to a new parent and alias it so it doesn't recreate.
 resource "conformance-component_simple" "res" {
   parent = simple_resource.parent
   aliases = [{
@@ -21,6 +23,7 @@ resource "conformance-component_simple" "res" {
   }]
   value = true
 }
+// Make a simple resource so that plugin detection works.
 resource "simple_resource" "simpleResource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/provider-ignore-changes-component/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/provider-ignore-changes-component/main.hcl
@@ -20,6 +20,7 @@ resource "conformance-component_simple" "withIgnoreChanges" {
 resource "conformance-component_simple" "withoutIgnoreChanges" {
   value = true
 }
+// Make a simple resource so that plugin detection works.
 resource "simple_resource" "simpleResource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/provider-resource-component/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/provider-resource-component/main.hcl
@@ -14,6 +14,7 @@ terraform {
 resource "conformance-component_simple" "res" {
   value = true
 }
+// Make a simple resource so that plugin detection works.
 resource "simple_resource" "simpleResource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-can/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-can/main.hcl
@@ -16,6 +16,8 @@ output "outputTrySuccess" {
 output "outputTryFailure" {
   value = can(local.aSecretMap["b"])
 }
+# A dynamically typed value, whose field accesses will not be type errors (since the type is not known to the type
+# checker), but may fail dynamically, and can thus be used as test inputs to can.
 variable "anObject" {
 }
 output "dynamicTrySuccess" {
@@ -33,6 +35,7 @@ output "outputDynamicTrySuccess" {
 output "outputDynamicTryFailure" {
   value = can(local.aSecretObject.b)
 }
+# Check that explicit null values can be returned
 output "plainTryNull" {
   value = can(var.anObject.opt)
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-list/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-list/main.hcl
@@ -22,6 +22,7 @@ output "lengthOutput" {
 output "splitOutput" {
   value = split("-", var.aString)
 }
+# Wrap in list to avoid unsafe-null-output (see l1-builtin-try/main.pp).
 output "singleOrNoneOutput" {
   value = [one(var.singleOrNoneList)]
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-to-json/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-to-json/main.hcl
@@ -28,6 +28,7 @@ output "objectOutput" {
     "count" = 1
   })
 }
+# Nested object using config values
 locals {
   nestedObject = {
     "anObject" = {

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-try/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-try/main.hcl
@@ -16,6 +16,8 @@ output "outputTrySuccess" {
 output "outputTryFailure" {
   value = try(local.aSecretMap["b"], "fallback")
 }
+# A dynamically typed value, whose field accesses will not be type errors (since the type is not known to the type
+# checker), but may fail dynamically, and can thus be used as test inputs to try.
 variable "anObject" {
 }
 output "dynamicTrySuccess" {
@@ -33,6 +35,9 @@ output "outputDynamicTrySuccess" {
 output "outputDynamicTryFailure" {
   value = try(local.aSecretObject.b, "fallback")
 }
+# Check that explicit null values can be returned.
+# It's not safe to return a null value directly (see l1-output-null 
+# and https://github.com/pulumi/pulumi/issues/19015) so wrap these in a list.
 output "plainTryNull" {
   value = [try(var.anObject.opt, "fallback")]
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-elide-index/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-elide-index/main.hcl
@@ -1,3 +1,5 @@
+// Test that "pkg:typ" type tokens are accepted in PCL and are correctly expanded out. We also have an L2 test around
+// this but it's worth checking with the pulumi schema as it would be too easy for codegen to special case it differently.
 resource "pulumi_stash" "myStash" {
   input = "test"
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-keyword-overlap/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-keyword-overlap/main.hcl
@@ -1,3 +1,4 @@
+# Keywords in various languages should be renamed and work.
 locals {
   class = "class_output_string"
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-output-map/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-output-map/main.hcl
@@ -13,6 +13,7 @@ output "numbers" {
     "2" = 2
   }
 }
+// Test that keys don't get renamed
 output "keys" {
   value = {
     "my.key" = 1

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-output-null/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-output-null/main.hcl
@@ -1,3 +1,8 @@
+// "null" and "map" are currently commented out due to
+// https://github.com/pulumi/pulumi/issues/19015.
+//output "null" {
+//    value = null
+//}
 output "array" {
   value = [null]
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-proxy-index/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-proxy-index/main.hcl
@@ -1,3 +1,4 @@
+# We use `secret` to lift plain values to output space, then check we can index into them
 variable "anObject" {
   type = object({property=string})
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-explicit-parameterized-provider/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-explicit-parameterized-provider/main.hcl
@@ -10,9 +10,11 @@ terraform {
 resource "pulumi_providers_goodbye" "prov" {
   text = "World"
 }
+// The resource name is based on the parameter value
 resource "goodbye_goodbye" "res" {
   provider = pulumi_providers_goodbye.prov
 }
+// The resource name is based on the parameter value and the provider config
 output "parameterValue" {
   value = goodbye_goodbye.res.parameter_value
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-dependencies/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-dependencies/main.hcl
@@ -19,6 +19,8 @@ data "simple-invoke_secretinvoke" "invoke_0" {
 resource "simple_resource" "first" {
   value = false
 }
+// assert that resource second depends on resource first
+// because it uses .secret from the invoke which depends on first
 resource "simple_resource" "second" {
   value = data.simple-invoke_secretinvoke.invoke_0.secret
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-secrets/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-secrets/main.hcl
@@ -27,12 +27,16 @@ data "simple-invoke_secretinvoke" "invoke_2" {
 resource "simple_resource" "res" {
   value = true
 }
+// inputs are plain and the invoke response is plain
 output "nonSecret" {
   value = data.simple-invoke_secretinvoke.invoke_0.response
 }
+// referencing value from resource
+// invoke response is secret => whole output is secret
 output "firstSecret" {
   value = data.simple-invoke_secretinvoke.invoke_1.response
 }
+// inputs are secret, invoke response is plain => whole output is secret
 output "secondSecret" {
   value = data.simple-invoke_secretinvoke.invoke_2.response
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-logical-name/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-logical-name/main.hcl
@@ -16,6 +16,9 @@ variable "cC-Charlie_charlie.😃⁉️" {
 output "bB-Beta_beta.💜⁉" {
   value = simple_resource["aA-Alpha_alpha.🤯⁉️"].value
 }
+// New format for output logical name because outputs don't have separate logical names. Even nodejs which just
+// does "export" normally for outputs needs that export _to be_ the output name and so if the "logical name"
+// isn't a valid nodejs export we have to output it differently.
 output "dD-Delta_delta.🔥⁉" {
   value = simple_resource["aA-Alpha_alpha.🤯⁉️"].value
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-module-format/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-module-format/main.hcl
@@ -51,24 +51,33 @@ call "res7" "call" {
   input = "xxx"
 }
 
+// This tests that PCL allows both fully specified type tokens, and tokens that only specify the module and
+// member name.
+// First use the fully specified token to invoke and create a resource.
 resource "module-format_mod_resource" "res1" {
   text = data.module-format_mod_concatworld.invoke_0.result
 }
+// Next use just the module name as defined by the module format
 resource "module-format_mod_resource" "res2" {
   text = data.module-format_mod_concatworld.invoke_1.result
 }
+// First use the fully specified token to invoke and create a resource.
 resource "module-format_mod_nested_resource" "res3" {
   text = data.module-format_mod_nested_concatworld.invoke_2.result
 }
+// Next use just the module name as defined by the module format
 resource "module-format_mod_nested_resource" "res4" {
   text = data.module-format_mod_nested_concatworld.invoke_3.result
 }
+// First use the fully specified token to invoke and create a resource in the index module.
 resource "module-format_resource" "res5" {
   text = data.module-format_concatworld.invoke_4.result
 }
+// Next use just the module name as defined by the module format
 resource "module-format_resource" "res6" {
   text = data.module-format_concatworld.invoke_5.result
 }
+// Next use the short, 2 component, form because this is the index module
 resource "module-format_resource" "res7" {
   text = data.module-format_concatworld.invoke_6.result
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-invoke/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-invoke/main.hcl
@@ -11,6 +11,7 @@ data "subpackage_dohelloworld" "invoke_0" {
   input = "goodbye"
 }
 
+// The invoke name is based on the parameter value
 output "parameterValue" {
   value = data.subpackage_dohelloworld.invoke_0.output
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-resource-twice/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-resource-twice/main.hcl
@@ -11,10 +11,12 @@ terraform {
   }
 }
 
+// The resource name is based on the parameter value
 resource "hipackage_helloworld" "example1" {
 }
 resource "hipackage_helloworldcomponent" "exampleComponent1" {
 }
+// The resource name is based on the parameter value
 resource "byepackage_goodbyeworld" "example2" {
 }
 resource "byepackage_goodbyeworldcomponent" "exampleComponent2" {

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-resource/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-resource/main.hcl
@@ -7,6 +7,7 @@ terraform {
   }
 }
 
+// The resource name is based on the parameter value
 resource "subpackage_helloworld" "example" {
 }
 resource "subpackage_helloworldcomponent" "exampleComponent" {

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config-schema-secret/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config-schema-secret/main.hcl
@@ -7,6 +7,7 @@ terraform {
   }
 }
 
+# This provider covers scenarios where configuration properties are marked as secret in the schema.
 resource "pulumi_providers_config-grpc" "config_grpc_provider" {
   secret_string1      = "SECRET"
   secret_int1         = 16

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config-secret/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config-secret/main.hcl
@@ -32,6 +32,7 @@ data "config-grpc_tosecret" "invoke_7" {
   string1 = "SECRET"
 }
 
+# This provider covers scenarios where user passes secret values to the provider.
 resource "pulumi_providers_config-grpc" "config_grpc_provider" {
   string1      = data.config-grpc_tosecret.invoke_0.string1
   int1         = data.config-grpc_tosecret.invoke_1.int1
@@ -39,10 +40,14 @@ resource "pulumi_providers_config-grpc" "config_grpc_provider" {
   bool1        = data.config-grpc_tosecret.invoke_3.bool1
   list_string1 = data.config-grpc_tosecret.invoke_4.list_string1
   list_string2 = ["VALUE", data.config-grpc_tosecret.invoke_5.string1]
+  # TODO[pulumi/pulumi#17535] this currently breaks Go compilation unfortunately.
+  # mapString1 = invoke("config-grpc:index:toSecret", {mapString1 = { key1 = "SECRET", key2 = "SECRET2" }}).mapString1
   map_string2 = {
     "key1" = "value1"
     "key2" = data.config-grpc_tosecret.invoke_6.string1
   }
+  # TODO[pulumi/pulumi#17535] this breaks Go compilation as well.
+  # os1 = invoke("config-grpc:index:toSecret", {objString1 = { x = "SECRET" }}).objString1
   obj_string2 = {
     x = data.config-grpc_tosecret.invoke_7.string1
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config/main.hcl
@@ -7,9 +7,11 @@ terraform {
   }
 }
 
+# Cover interesting schema shapes.
 resource "pulumi_providers_config-grpc" "config_grpc_provider" {
-  string1      = ""
-  string2      = "x"
+  string1 = ""
+  string2 = "x"
+  # Test a JSON-like string to see if it trips up JSON detectors.
   string3      = "{}"
   int1         = 0
   int2         = 42

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-proxy-index/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-proxy-index/main.hcl
@@ -7,6 +7,8 @@ terraform {
   }
 }
 
+# Check we can index into properties of objects returned in outputs, this is similar to ref-ref but 
+# we index into the outputs
 resource "ref-ref_resource" "res" {
   data = {
     inner_data = {

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-config/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-config/main.hcl
@@ -11,6 +11,7 @@ resource "pulumi_providers_config" "prov" {
   plugin_download_url = "not the same as the pulumi resource option"
   name                = "my config"
 }
+// Note this isn't _using_ the explicit provider, it's just grabbing a value from it.
 resource "config_resource" "res" {
   text = pulumi_providers_config.prov.version
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-elide-unknowns/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-elide-unknowns/main.hcl
@@ -11,6 +11,8 @@ terraform {
   }
 }
 
+// This test checks that when a provider doesn't return properties for fields it considers unknown the runtime
+// can still access that field as an output.
 resource "pulumi_providers_output" "prov" {
   elide_unknowns = true
 }
@@ -22,6 +24,7 @@ resource "output_complexresource" "complex" {
   provider = pulumi_providers_output.prov
   value    = 1
 }
+// Try and use the unknown output as an input to another resource to check that it doesn't cause any issues.
 resource "simple_resource" "res" {
   value = output_resource.unknown.output == "hello"
 }
@@ -34,6 +37,7 @@ resource "simple_resource" "resMap" {
 resource "simple_resource" "resObject" {
   value = output_complexresource.complex.output_object.output == "hello"
 }
+// And try to use it has an output
 output "out" {
   value = output_resource.unknown.output
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-keyword-overlap/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-keyword-overlap/main.hcl
@@ -19,6 +19,10 @@ resource "simple_resource" "mod" {
 resource "simple_resource" "import" {
   value = true
 }
+# TODO(pulumi/pulumi#18246): Pcl should support scoping based on resource type just like HCL does in TF so we can uncomment this.
+# output "import" {
+#   value = Resource["import"]
+# }
 resource "simple_resource" "object" {
   value = true
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-alias/0/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-alias/0/main.hcl
@@ -11,6 +11,7 @@ terraform {
   }
 }
 
+// Make a simple resource to use as a parent
 resource "simple_resource" "parent" {
   value = true
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-delete-before-replace/0/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-delete-before-replace/0/main.hcl
@@ -7,6 +7,8 @@ terraform {
   }
 }
 
+// Stage 0: Initial resource creation
+// Resource with deleteBeforeReplace option
 resource "simple_resource" "withOption" {
   replace_on_changes = ["value"]
   lifecycle {
@@ -14,6 +16,7 @@ resource "simple_resource" "withOption" {
   }
   value = true
 }
+// Resource without deleteBeforeReplace (default create-before-delete behavior)
 resource "simple_resource" "withoutOption" {
   replace_on_changes = ["value"]
   value              = true

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-delete-before-replace/1/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-delete-before-replace/1/main.hcl
@@ -7,14 +7,17 @@ terraform {
   }
 }
 
+// Stage 1: Change properties to trigger replacements
+// Resource with deleteBeforeReplace option - should delete before creating
 resource "simple_resource" "withOption" {
   replace_on_changes = ["value"]
   lifecycle {
     create_before_destroy = !true
   }
-  value = false
+  value = false // Changed to trigger replacement
 }
+// Resource without deleteBeforeReplace - should create before deleting (default)
 resource "simple_resource" "withoutOption" {
   replace_on_changes = ["value"]
-  value              = false
+  value              = false // Changed to trigger replacement
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-replace-on-changes/0/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-replace-on-changes/0/main.hcl
@@ -7,37 +7,46 @@ terraform {
   }
 }
 
+// Stage 0: Initial resource creation
+// Scenario 1: Schema-based replaceOnChanges on replaceProp
 resource "replaceonchanges_resourcea" "schemaReplace" {
   replace_on_changes = ["replaceProp"]
   value              = true
   replace_prop       = true
 }
+// Scenario 2: Option-based replaceOnChanges on value
 resource "replaceonchanges_resourceb" "optionReplace" {
   replace_on_changes = ["value"]
   value              = true
 }
+// Scenario 3: Both schema and option - will change value
 resource "replaceonchanges_resourcea" "bothReplaceValue" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
+// Scenario 4: Both schema and option - will change replaceProp
 resource "replaceonchanges_resourcea" "bothReplaceProp" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
+// Scenario 5: No replaceOnChanges - baseline update
 resource "replaceonchanges_resourceb" "regularUpdate" {
   value = true
 }
+// Scenario 6: replaceOnChanges set but no change
 resource "replaceonchanges_resourceb" "noChange" {
   replace_on_changes = ["value"]
   value              = true
 }
+// Scenario 7: replaceOnChanges on value, but only replaceProp changes
 resource "replaceonchanges_resourcea" "wrongPropChange" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
+// Scenario 8: Multiple properties in replaceOnChanges array
 resource "replaceonchanges_resourcea" "multiplePropReplace" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-replace-on-changes/1/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-replace-on-changes/1/main.hcl
@@ -7,39 +7,48 @@ terraform {
   }
 }
 
+// Stage 1: Change properties to trigger replacements
+// Scenario 1: Change replaceProp → REPLACE (schema triggers)
 resource "replaceonchanges_resourcea" "schemaReplace" {
   replace_on_changes = ["replaceProp"]
   value              = true
-  replace_prop       = false
+  replace_prop       = false // Changed from true
 }
+// Scenario 2: Change value → REPLACE (option triggers)
 resource "replaceonchanges_resourceb" "optionReplace" {
   replace_on_changes = ["value"]
-  value              = false
+  value              = false // Changed from true
 }
+// Scenario 3: Change value → REPLACE (option on value triggers)
 resource "replaceonchanges_resourcea" "bothReplaceValue" {
   replace_on_changes = ["replaceProp", "value"]
-  value              = false
-  replace_prop       = true
+  value              = false // Changed from true
+  replace_prop       = true // Unchanged
 }
+// Scenario 4: Change replaceProp → REPLACE (schema on replaceProp triggers)
 resource "replaceonchanges_resourcea" "bothReplaceProp" {
   replace_on_changes = ["replaceProp", "value"]
-  value              = true
-  replace_prop       = false
+  value              = true // Unchanged
+  replace_prop       = false // Changed from true
 }
+// Scenario 5: Change value → UPDATE (no replaceOnChanges)
 resource "replaceonchanges_resourceb" "regularUpdate" {
-  value = false
+  value = false // Changed from true
 }
+// Scenario 6: No change → SAME (no operation)
 resource "replaceonchanges_resourceb" "noChange" {
   replace_on_changes = ["value"]
-  value              = true
+  value              = true // Unchanged
 }
+// Scenario 7: Change replaceProp (not value) → UPDATE (marked property unchanged)
 resource "replaceonchanges_resourcea" "wrongPropChange" {
   replace_on_changes = ["replaceProp", "value"]
-  value              = true
-  replace_prop       = false
+  value              = true // Unchanged (this is marked for replacement)
+  replace_prop       = false // Changed from true (this is NOT marked for replacement by option)
 }
+// Scenario 8: Change value → REPLACE (multiple properties marked)
 resource "replaceonchanges_resourcea" "multiplePropReplace" {
   replace_on_changes = ["replaceProp", "value"]
-  value              = false
-  replace_prop       = true
+  value              = false // Changed from true
+  replace_prop       = true // Unchanged
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-version-sdk/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-version-sdk/main.hcl
@@ -7,6 +7,8 @@ terraform {
   }
 }
 
+# Check that withV2 is generated against the v2 SDK and not against the V26 SDK,
+# and that the version resource option is elided.
 resource "simple_resource" "withV2" {
   version = "2.0.0"
   value   = true

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-order/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-order/main.hcl
@@ -13,6 +13,8 @@ resource "simple_resource" "res2" {
 resource "simple_resource" "res1" {
   value = true
 }
+// This test asserts that PCL declaration order does not need to match usage order. That is a resource can be declared
+// lower in the file than it is first referenced.
 output "out" {
   value = simple_resource.res2.value
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-provider-inheritance/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-provider-inheritance/main.hcl
@@ -17,6 +17,7 @@ resource "simple_resource" "parent1" {
   provider = pulumi_providers_simple.provider
   value    = true
 }
+// This should inherit the explicit provider from parent1
 resource "simple_resource" "child1" {
   parent = simple_resource.parent1
   value  = true
@@ -29,10 +30,12 @@ resource "primitive_resource" "parent2" {
   number_array = []
   boolean_map  = {}
 }
+// This _should not_ inherit the provider from parent2 as it is a default provider.
 resource "simple_resource" "child2" {
   parent = primitive_resource.parent2
   value  = true
 }
+// This _should not_ inherit the provider from parent1 as its from the wrong package.
 resource "primitive_resource" "child3" {
   parent       = simple_resource.parent1
   boolean      = false

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-snake-names/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-snake-names/main.hcl
@@ -14,12 +14,14 @@ data "snake_names_cool_module_some_data" "invoke_0" {
   }
 }
 
+// Resource inputs are correctly translated
 resource "snake_names_cool_module_some_resource" "first" {
   the_input = true
   nested = {
     nested_value = "nested"
   }
 }
+// Datasource outputs are correctly translated
 resource "snake_names_cool_module_another_resource" "third" {
   the_input = data.snake_names_cool_module_some_data.invoke_0.nested_output[0]["key"].value
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-union/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-union/main.hcl
@@ -20,12 +20,15 @@ resource "union_example" "mapMapUnionExample" {
     }
   }
 }
+// List<Union<String, Enum>> pattern
 resource "union_example" "stringEnumUnionListExample" {
   string_enum_union_list_property = ["Listen", "Send", "NotAnEnumValue"]
 }
+// Safe enum: literal string matching an enum value
 resource "union_example" "safeEnumExample" {
   typed_enum_property = "Block"
 }
+// Output enum: output from another resource used as enum input
 resource "union_enumoutput" "enumOutputExample" {
   name = "example"
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/main.hcl
@@ -7,6 +7,7 @@ terraform {
   }
 }
 
+# first & second are simple mutually dependent components
 module "first" {
   source = "./first"
   input  = module.second.untainted
@@ -15,9 +16,13 @@ module "second" {
   source = "./second"
   input  = module.first.untainted
 }
+# another & many are also mutually dependent components, but many tests that the mutual dependency works through
+# `range`.
 module "another" {
   source = "./first"
-  input  = join("", [for _, v in module.many : v.untainted ? "a" : "b"]) == "xyz"
+  # We do the join + for + == dance because we want to force a value that depends on the contents of the list, not
+  # just it's length (which may be known at preview time).
+  input = join("", [for _, v in module.many : v.untainted ? "a" : "b"]) == "xyz"
 }
 module "many" {
   source = "./second"

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-for-resource/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-for-resource/main.hcl
@@ -10,6 +10,7 @@ terraform {
 resource "nestedobject_container" "source" {
   inputs = ["a", "b", "c"]
 }
+# for over list<object> output
 resource "nestedobject_receiver" "receiver" {
   dynamic "details" {
     for_each = nestedobject_container.source.details
@@ -19,9 +20,11 @@ resource "nestedobject_receiver" "receiver" {
     }
   }
 }
+# for over list<string> output
 resource "nestedobject_container" "fromSimple" {
   inputs = [for _, detail in nestedobject_container.source.details : detail.value]
 }
+# for producing a map
 resource "nestedobject_mapcontainer" "mapped" {
   tags = {for _, detail in nestedobject_container.source.details : detail.key => detail.value}
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-resource-output-traversal/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-resource-output-traversal/main.hcl
@@ -16,10 +16,12 @@ resource "nestedobject_mapcontainer" "mapContainer" {
     "k2" = "delta"
   }
 }
+# A resource that ranges over a computed list
 resource "nestedobject_target" "listOutput" {
   for_each = {  for  __key,  __value  in  nestedobject_container.container.details  :  tostring(__key)  =>  __value  }
   name     = each.value.value
 }
+# A resource that ranges over a computed map
 resource "nestedobject_target" "mapOutput" {
   for_each = nestedobject_mapcontainer.mapContainer.tags
   name     ="${each.key}=>${each.value}"

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/provider-alias-component/0/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/provider-alias-component/0/main.hcl
@@ -14,6 +14,7 @@ terraform {
 resource "conformance-component_simple" "res" {
   value = true
 }
+// Make a simple resource so that plugin detection works.
 resource "simple_resource" "simpleResource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/provider-alias-component/1/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/provider-alias-component/1/main.hcl
@@ -11,9 +11,11 @@ terraform {
   }
 }
 
+// Make a simple resource to use as a parent
 resource "simple_resource" "parent" {
   value = true
 }
+// parent "res" to a new parent and alias it so it doesn't recreate.
 resource "conformance-component_simple" "res" {
   parent = simple_resource.parent
   aliases = [{
@@ -21,6 +23,7 @@ resource "conformance-component_simple" "res" {
   }]
   value = true
 }
+// Make a simple resource so that plugin detection works.
 resource "simple_resource" "simpleResource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/provider-ignore-changes-component/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/provider-ignore-changes-component/main.hcl
@@ -20,6 +20,7 @@ resource "conformance-component_simple" "withIgnoreChanges" {
 resource "conformance-component_simple" "withoutIgnoreChanges" {
   value = true
 }
+// Make a simple resource so that plugin detection works.
 resource "simple_resource" "simpleResource" {
   value = false
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/provider-resource-component/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/provider-resource-component/main.hcl
@@ -14,6 +14,7 @@ terraform {
 resource "conformance-component_simple" "res" {
   value = true
 }
+// Make a simple resource so that plugin detection works.
 resource "simple_resource" "simpleResource" {
   value = false
 }

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/comments"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
@@ -43,7 +44,8 @@ func GenerateProgram(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, 
 
 	// Create a generator context to track invoke data sources and call blocks
 	gen := &generator{
-		program: program,
+		program:  program,
+		comments: buildProgramComments(program),
 	}
 
 	genRequiredProviders(body, program)
@@ -76,6 +78,7 @@ func GenerateProgram(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, 
 
 	// Second pass: generate resources, outputs, etc.
 	for _, node := range program.Nodes {
+		gen.emitLeadingComments(body, node.SyntaxNode())
 		switch n := node.(type) {
 		case *pcl.Resource:
 			d := gen.genResource(body, n)
@@ -146,6 +149,47 @@ type generator struct {
 	// data block hoisted from an invoke inside a for-comprehension. References
 	// to its KeyVariable / ValueVariable are rewritten to each.key / each.value.
 	forDataBlock *model.ForExpression
+	// comments maps source filenames to leading-comment maps built from the
+	// PCL source files of this program.
+	comments map[string]*comments.Map
+}
+
+// buildProgramComments parses the source of every PCL file in the program and
+// returns a per-filename map of leading comments. `package` blocks are
+// excluded as anchors so any comments preceding them flow to the next emitted
+// node.
+func buildProgramComments(program *pcl.Program) map[string]*comments.Map {
+	out := map[string]*comments.Map{}
+	for name, content := range program.Source() {
+		src := []byte(content)
+		file, fdiags := hclsyntax.ParseConfig(src, name, hcl.Pos{Byte: 0, Line: 1, Column: 1})
+		if fdiags.HasErrors() || file == nil {
+			continue
+		}
+		body, ok := file.Body.(*hclsyntax.Body)
+		if !ok {
+			continue
+		}
+		out[name] = comments.Build(src, name, body, "package")
+	}
+	return out
+}
+
+// emitLeadingComments writes any source comments that precede node into body.
+// node must be the SyntaxNode() of a bound PCL element; the binder guarantees
+// it has a real syntax pointer.
+func (g *generator) emitLeadingComments(body *hclwrite.Body, node hclsyntax.Node) {
+	rng := node.Range()
+	g.comments[rng.Filename].Emit(body, rng.Start.Byte)
+}
+
+// withTrailing returns valueTokens with the same-line trailing comment for
+// the attribute identified by node (if any) appended. The combined tokens are
+// suitable for hclwrite.Body.SetAttributeRaw, which keeps the comment on the
+// same line as the value.
+func (g *generator) withTrailing(valueTokens hclwrite.Tokens, node hclsyntax.Node) hclwrite.Tokens {
+	rng := node.Range()
+	return g.comments[rng.Filename].AppendTrailing(valueTokens, rng.Start.Byte)
 }
 
 type spilledDataSource struct {
@@ -717,11 +761,12 @@ func (g *generator) genResource(body *hclwrite.Body, r *pcl.Resource) hcl.Diagno
 	for _, attr := range r.Inputs {
 		inputType := findPropertyType(inputs, attr.Name)
 		hclName := transform.SnakeCaseFromPulumiCase(attr.Name)
+		g.emitLeadingComments(block.Body(), attr.SyntaxNode())
 		if objType, ok := transform.AsHCLBlockType(inputType); ok {
 			d := g.genBlocks(block.Body(), hclName, attr.Value, objType)
 			diags = append(diags, d...)
 		} else {
-			d := g.genExpression(block.Body(), hclName, attr.Value, inputType)
+			d := g.genAttributeWithTrailing(block.Body(), hclName, attr.Value, inputType, attr.SyntaxNode())
 			diags = append(diags, d...)
 		}
 	}
@@ -1261,7 +1306,8 @@ func (g *generator) genModule(body *hclwrite.Body, c *pcl.Component) hcl.Diagnos
 	}
 
 	for _, attr := range c.Inputs {
-		d := g.genExpression(block.Body(), attr.Name, attr.Value, schema.AnyType)
+		g.emitLeadingComments(block.Body(), attr.SyntaxNode())
+		d := g.genAttributeWithTrailing(block.Body(), attr.Name, attr.Value, schema.AnyType, attr.SyntaxNode())
 		diags = append(diags, d...)
 	}
 	return diags
@@ -1356,6 +1402,20 @@ func (g *generator) genExpression(body *hclwrite.Body, name string, expr model.E
 		return diags
 	}
 	body.SetAttributeRaw(name, tokens)
+	return diags
+}
+
+// genAttributeWithTrailing is genExpression that also appends any same-line
+// trailing comment on the source attribute identified by node, so the comment
+// stays on the same line as the value in the output.
+func (g *generator) genAttributeWithTrailing(
+	body *hclwrite.Body, name string, expr model.Expression, typ schema.Type, node hclsyntax.Node,
+) hcl.Diagnostics {
+	tokens, diags := g.exprTokens(expr, typ)
+	if diags.HasErrors() {
+		return diags
+	}
+	body.SetAttributeRaw(name, g.withTrailing(tokens, node))
 	return diags
 }
 

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/comments"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
@@ -201,6 +202,22 @@ type fileTransformer struct {
 	// "each.* in an inlined invoke" from "each.* at the top level of a
 	// ranged block's own body".
 	inlineDepth int
+	// comments holds leading comments lexed from the source file, keyed by
+	// the source start byte of the syntactic element that should carry them.
+	comments *comments.Map
+}
+
+// emitLeadingComments writes any source comments that immediately precede the
+// element at the given source start byte to body.
+func (ft *fileTransformer) emitLeadingComments(body *hclwrite.Body, startByte int) {
+	ft.comments.Emit(body, startByte)
+}
+
+// withTrailing returns valueTokens with the same-line trailing comment for the
+// attribute at startByte (if any) appended, ready to be passed to
+// hclwrite.Body.SetAttributeRaw so the comment stays on the same line.
+func (ft *fileTransformer) withTrailing(valueTokens hclwrite.Tokens, startByte int) hclwrite.Tokens {
+	return ft.comments.AppendTrailing(valueTokens, startByte)
 }
 
 // comprehensionCtx records the variable names of a PCL for-expression so
@@ -424,12 +441,14 @@ func transformHCLFileToPCL(
 	if resultDiags.HasErrors() {
 		return resultDiags, nil
 	}
+	ft.comments = comments.Build(src, filename, body, "terraform", "data", "call")
 
 	for _, alias := range sortedKeys(paramInfos) {
 		emitPackageBlock(out, alias, paramInfos[alias])
 	}
 
 	for _, block := range body.Blocks {
+		ft.emitLeadingComments(out, block.Range().Start.Byte)
 		switch block.Type {
 
 		case "terraform":
@@ -463,13 +482,17 @@ func transformHCLFileToPCL(
 				if attr.Name == "type" {
 					continue
 				}
-				blk.Body().SetAttributeRaw(attr.Name, ft.transformExpr(attr.Expr))
+				start := attr.Range().Start.Byte
+				ft.emitLeadingComments(blk.Body(), start)
+				blk.Body().SetAttributeRaw(attr.Name, ft.withTrailing(ft.transformExpr(attr.Expr), start))
 			}
 			out.AppendNewline()
 
 		case "locals":
 			for _, attr := range sortedAttributes(block.Body.Attributes) {
-				out.SetAttributeRaw(attr.Name, ft.transformExpr(attr.Expr))
+				start := attr.Range().Start.Byte
+				ft.emitLeadingComments(out, start)
+				out.SetAttributeRaw(attr.Name, ft.withTrailing(ft.transformExpr(attr.Expr), start))
 				out.AppendNewline()
 			}
 
@@ -483,7 +506,9 @@ func transformHCLFileToPCL(
 				blk.Body().SetAttributeRaw("__logicalName", hclwrite.TokensForValue(cty.StringVal(name)))
 			}
 			for _, attr := range sortedAttributes(block.Body.Attributes) {
-				blk.Body().SetAttributeRaw(attr.Name, ft.transformExpr(attr.Expr))
+				start := attr.Range().Start.Byte
+				ft.emitLeadingComments(blk.Body(), start)
+				blk.Body().SetAttributeRaw(attr.Name, ft.withTrailing(ft.transformExpr(attr.Expr), start))
 			}
 			out.AppendNewline()
 
@@ -535,7 +560,9 @@ func transformHCLFileToPCL(
 				case "depends_on", "providers", "version":
 					continue
 				}
-				blk.Body().SetAttributeRaw(attr.Name, ft.transformExpr(attr.Expr))
+				start := attr.Range().Start.Byte
+				ft.emitLeadingComments(blk.Body(), start)
+				blk.Body().SetAttributeRaw(attr.Name, ft.withTrailing(ft.transformExpr(attr.Expr), start))
 			}
 			if rangeExpr != nil {
 				optBlk := blk.Body().AppendNewBlock("options", nil)
@@ -582,7 +609,9 @@ func transformHCLFileToPCL(
 					continue
 				}
 				name, _ := transform.PulumiCaseFromSnakeCase(attr.Name, res.InputProperties)
-				blk.Body().SetAttributeRaw(name, ft.transformExpr(attr.Expr))
+				start := attr.Range().Start.Byte
+				ft.emitLeadingComments(blk.Body(), start)
+				blk.Body().SetAttributeRaw(name, ft.withTrailing(ft.transformExpr(attr.Expr), start))
 			}
 
 			// Collect resource options from attributes and sub-blocks.
@@ -666,7 +695,9 @@ func transformHCLFileToPCL(
 			blk := out.AppendNewBlock("pulumi", nil)
 			for _, attr := range sortedAttributes(block.Body.Attributes) {
 				name, _ := transform.PulumiCaseFromSnakeCase(attr.Name, nil)
-				blk.Body().SetAttributeRaw(name, ft.transformExpr(attr.Expr))
+				start := attr.Range().Start.Byte
+				ft.emitLeadingComments(blk.Body(), start)
+				blk.Body().SetAttributeRaw(name, ft.withTrailing(ft.transformExpr(attr.Expr), start))
 			}
 			out.AppendNewline()
 
@@ -682,7 +713,9 @@ func transformHCLFileToPCL(
 
 	// Top-level attributes (uncommon in HCL input, but pass through with transforms).
 	for _, attr := range sortedAttributes(body.Attributes) {
-		out.SetAttributeRaw(attr.Name, ft.transformExpr(attr.Expr))
+		start := attr.Range().Start.Byte
+		ft.emitLeadingComments(out, start)
+		out.SetAttributeRaw(attr.Name, ft.withTrailing(ft.transformExpr(attr.Expr), start))
 		out.AppendNewline()
 	}
 

--- a/pkg/hcl/comments/comments.go
+++ b/pkg/hcl/comments/comments.go
@@ -1,0 +1,250 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package comments associates source comments with the syntactic element that immediately
+// follows them, so callers writing fresh [hclwrite] output can preserve comments from the
+// original source.
+package comments
+
+import (
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+// Map associates source comments with the syntactic element they belong to.
+//
+// A comment is treated as "trailing" when it begins on the same line as the
+// end of an element in its enclosing body (e.g. `value = "x" // note`); such
+// comments are keyed by that element's start byte so they can be emitted
+// immediately after the element's value tokens.
+//
+// Otherwise the comment is "leading": it is assigned to the next direct
+// sibling — attribute or sub-block — by finding the smallest element start
+// byte in the enclosing body that is >= the comment's end byte. Comments
+// with no following sibling in their scope are dropped, so they do not leak
+// across block boundaries.
+type Map struct {
+	byElementStart  map[int]hclwrite.Tokens
+	trailingByOwner map[int]hclwrite.Tokens
+}
+
+// Build lexes src and returns a Map that assigns each source comment to the
+// element in body that immediately follows it.
+//
+// Block types listed in skipBlockTypes are not treated as anchors: comments
+// preceding such a block (or appearing inside it) flow past it to the next
+// non-skipped sibling. This is useful when the caller does not emit those
+// blocks in its output (for example, the converter skips `terraform`,
+// `data`, and `call` blocks; codegen skips `package` blocks).
+type bodyScope struct {
+	body          *hclsyntax.Body
+	startByte     int         // inclusive byte where this scope begins
+	endByte       int         // exclusive byte where this scope ends
+	starts        []int       // direct-child element start bytes (sorted)
+	ends          map[int]int // start byte → end byte, for direct children
+	endsByEndLine map[int]int // end line → element start byte, for direct children
+}
+
+func Build(src []byte, filename string, body *hclsyntax.Body, skipBlockTypes ...string) *Map {
+	m := &Map{
+		byElementStart:  map[int]hclwrite.Tokens{},
+		trailingByOwner: map[int]hclwrite.Tokens{},
+	}
+
+	tokens, diags := hclsyntax.LexConfig(src, filename, hcl.Pos{Byte: 0, Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return m
+	}
+
+	skip := make(map[string]bool, len(skipBlockTypes))
+	for _, t := range skipBlockTypes {
+		skip[t] = true
+	}
+
+	var scopes []bodyScope
+	collectScopes(body, skip, &scopes)
+	for i := range scopes {
+		sort.Ints(scopes[i].starts)
+	}
+	// The root body's SrcRange can start past leading trivia (block comments
+	// at the start of a file), but we want comments anywhere in the source to
+	// associate with elements in the root scope. Extend the root scope to
+	// cover the full source extent.
+	if len(scopes) > 0 {
+		scopes[0].startByte = 0
+		scopes[0].endByte = len(src)
+	}
+
+	for _, t := range tokens {
+		if t.Type != hclsyntax.TokenComment {
+			continue
+		}
+		scope := innermostScope(scopes, t.Range.Start.Byte)
+		if scope == nil {
+			continue
+		}
+		// Trailing line comment: starts on the same line as a direct child's end.
+		if owner, ok := scope.endsByEndLine[t.Range.Start.Line]; ok &&
+			t.Range.Start.Byte >= scope.ends[owner] {
+			m.trailingByOwner[owner] = append(m.trailingByOwner[owner], trailingCommentTokenFor(t))
+			continue
+		}
+		idx := sort.SearchInts(scope.starts, t.Range.End.Byte)
+		if idx >= len(scope.starts) {
+			// No following sibling in this scope; drop the comment.
+			continue
+		}
+		key := scope.starts[idx]
+		m.byElementStart[key] = append(m.byElementStart[key], commentTokenFor(t))
+	}
+
+	return m
+}
+
+// Leading returns the leading comments associated with the element starting at
+// the given source byte and removes them from the map so each comment is
+// emitted at most once.
+func (m *Map) Leading(startByte int) hclwrite.Tokens {
+	if m == nil {
+		return nil
+	}
+	tokens := m.byElementStart[startByte]
+	if len(tokens) == 0 {
+		return nil
+	}
+	delete(m.byElementStart, startByte)
+	return tokens
+}
+
+// Emit appends the leading comments for the element at startByte to body.
+func (m *Map) Emit(body *hclwrite.Body, startByte int) {
+	tokens := m.Leading(startByte)
+	if len(tokens) == 0 {
+		return
+	}
+	body.AppendUnstructuredTokens(tokens)
+}
+
+// Trailing returns the same-line trailing comments associated with the element
+// starting at the given source byte and removes them so each is emitted at
+// most once. Callers should append the returned tokens to the attribute's
+// value tokens before passing them to hclwrite.Body.SetAttributeRaw, so the
+// comment ends up on the same line as the value rather than after the
+// attribute's auto-emitted newline.
+func (m *Map) Trailing(startByte int) hclwrite.Tokens {
+	if m == nil {
+		return nil
+	}
+	tokens := m.trailingByOwner[startByte]
+	if len(tokens) == 0 {
+		return nil
+	}
+	delete(m.trailingByOwner, startByte)
+	return tokens
+}
+
+// AppendTrailing returns valueTokens with the trailing comment for the element
+// at startByte (if any) appended. The result is suitable for
+// hclwrite.Body.SetAttributeRaw so the comment lands on the same line as the
+// value.
+func (m *Map) AppendTrailing(valueTokens hclwrite.Tokens, startByte int) hclwrite.Tokens {
+	trailing := m.Trailing(startByte)
+	if len(trailing) == 0 {
+		return valueTokens
+	}
+	return append(valueTokens, trailing...)
+}
+
+// commentTokenFor converts a lexed hclsyntax comment token into an hclwrite
+// token. Line comments (`//` and `#`) include a trailing newline already;
+// block comments (`/* ... */`) do not, so we add one to keep the next element
+// on its own line.
+func commentTokenFor(t hclsyntax.Token) *hclwrite.Token {
+	bytes := t.Bytes
+	if len(bytes) == 0 || bytes[len(bytes)-1] != '\n' {
+		buf := make([]byte, len(bytes)+1)
+		copy(buf, bytes)
+		buf[len(buf)-1] = '\n'
+		bytes = buf
+	}
+	return &hclwrite.Token{Type: hclsyntax.TokenComment, Bytes: bytes}
+}
+
+// trailingCommentTokenFor builds a trailing-comment token to follow an
+// attribute's value tokens. SpacesBefore=1 keeps a single space between the
+// value and the comment (e.g. `value = "x" // note`). Any trailing newline on
+// the lexed comment is stripped because SetAttributeRaw will emit its own
+// terminating newline; leaving the lexer's `\n` in place would produce a
+// stray blank line below the attribute.
+func trailingCommentTokenFor(t hclsyntax.Token) *hclwrite.Token {
+	bytes := t.Bytes
+	for len(bytes) > 0 && bytes[len(bytes)-1] == '\n' {
+		bytes = bytes[:len(bytes)-1]
+	}
+	return &hclwrite.Token{
+		Type:         hclsyntax.TokenComment,
+		Bytes:        append([]byte(nil), bytes...),
+		SpacesBefore: 1,
+	}
+}
+
+// collectScopes walks body recursively and records each body and its direct
+// attribute/block start bytes. Skipped block types are not recorded as anchors
+// in their parent scope, but their bodies are still walked so that comments
+// inside them associate with siblings inside the skipped block (or are
+// dropped) rather than leaking out to the surrounding scope.
+func collectScopes(body *hclsyntax.Body, skip map[string]bool, scopes *[]bodyScope) {
+	scope := bodyScope{
+		body:          body,
+		startByte:     body.SrcRange.Start.Byte,
+		endByte:       body.SrcRange.End.Byte,
+		ends:          map[int]int{},
+		endsByEndLine: map[int]int{},
+	}
+	addChild := func(rng hcl.Range) {
+		scope.starts = append(scope.starts, rng.Start.Byte)
+		scope.ends[rng.Start.Byte] = rng.End.Byte
+		scope.endsByEndLine[rng.End.Line] = rng.Start.Byte
+	}
+	for _, attr := range body.Attributes {
+		addChild(attr.Range())
+	}
+	for _, block := range body.Blocks {
+		if skip[block.Type] {
+			continue
+		}
+		addChild(block.Range())
+	}
+	*scopes = append(*scopes, scope)
+	for _, block := range body.Blocks {
+		collectScopes(block.Body, skip, scopes)
+	}
+}
+
+// innermostScope returns the bodyScope whose extent contains the given byte
+// offset and is the deepest such scope, or nil if no scope contains it.
+func innermostScope(scopes []bodyScope, byte int) *bodyScope {
+	var best *bodyScope
+	for i := range scopes {
+		if byte >= scopes[i].startByte && byte < scopes[i].endByte {
+			if best == nil || scopes[i].startByte > best.startByte {
+				best = &scopes[i]
+			}
+		}
+	}
+	return best
+}

--- a/pkg/hcl/comments/comments_test.go
+++ b/pkg/hcl/comments/comments_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package comments
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parse parses src as HCL and returns its body. Fails the test on errors.
+func parse(t *testing.T, src string) *hclsyntax.Body {
+	t.Helper()
+	file, diags := hclsyntax.ParseConfig([]byte(src), "test.hcl", hcl.Pos{Byte: 0, Line: 1, Column: 1})
+	require.False(t, diags.HasErrors(), "parse: %v", diags)
+	return file.Body.(*hclsyntax.Body)
+}
+
+// buildAndEmit builds a Map from src and writes the leading + trailing comments
+// for each top-level attribute (in source order) of body into a fresh hclwrite
+// file, returning the rendered bytes.
+func buildAndEmit(t *testing.T, src string, skip ...string) string {
+	t.Helper()
+	body := parse(t, src)
+	m := Build([]byte(src), "test.hcl", body, skip...)
+
+	out := hclwrite.NewEmptyFile()
+	for _, attr := range body.Attributes {
+		start := attr.Range().Start.Byte
+		m.Emit(out.Body(), start)
+		out.Body().SetAttributeRaw(attr.Name, m.AppendTrailing(
+			hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte("PLACEHOLDER")}},
+			start,
+		))
+	}
+	return string(out.Bytes())
+}
+
+func TestBuild_LeadingAttachedToNextSibling(t *testing.T) {
+	t.Parallel()
+
+	src := "// preamble\nfoo = 1\n"
+	got := buildAndEmit(t, src)
+	assert.Equal(t, "// preamble\nfoo = PLACEHOLDER\n", got)
+}
+
+func TestBuild_TrailingStaysOnSameLine(t *testing.T) {
+	t.Parallel()
+
+	src := "foo = 1 // note\n"
+	got := buildAndEmit(t, src)
+	assert.Equal(t, "foo = PLACEHOLDER // note\n", got)
+}
+
+func TestBuild_BlockCommentTrailingNewlineAdded(t *testing.T) {
+	t.Parallel()
+
+	// Block comments have no trailing newline in the lexer; commentTokenFor
+	// should add one so the next element starts on its own line.
+	src := "/* preamble */\nfoo = 1\n"
+	got := buildAndEmit(t, src)
+	assert.Equal(t, "/* preamble */\nfoo = PLACEHOLDER\n", got)
+}
+
+func TestBuild_DroppedWhenNoFollowingSibling(t *testing.T) {
+	t.Parallel()
+
+	// The comment has no following sibling, so it must not leak; the output
+	// has no comment at all.
+	src := "foo = 1\n// trailing-of-file\n"
+	got := buildAndEmit(t, src)
+	assert.Equal(t, "foo = PLACEHOLDER\n", got)
+}
+
+func TestBuild_ScopedToEnclosingBlock(t *testing.T) {
+	t.Parallel()
+
+	// A trailing comment inside a block must not leak to the next sibling
+	// outside the block.
+	src := "block {\n  inner = 1 // note\n}\nouter = 2\n"
+	body := parse(t, src)
+	m := Build([]byte(src), "test.hcl", body)
+
+	// The outer attribute should have NO leading comment associated with it.
+	outerStart := body.Attributes["outer"].Range().Start.Byte
+	assert.Empty(t, m.Leading(outerStart))
+	assert.Empty(t, m.Trailing(outerStart))
+
+	// The inner attribute's trailing comment is preserved.
+	innerStart := body.Blocks[0].Body.Attributes["inner"].Range().Start.Byte
+	trailing := m.Trailing(innerStart)
+	require.Len(t, trailing, 1)
+	assert.Equal(t, "// note", string(trailing[0].Bytes))
+}
+
+func TestBuild_SkipBlockTypesFlowsCommentsPast(t *testing.T) {
+	t.Parallel()
+
+	// "skipme" is excluded as an anchor in its parent scope, so the leading
+	// comment lands on the next non-skipped sibling instead.
+	src := "// preamble\nskipme {}\nfoo = 1\n"
+	body := parse(t, src)
+	m := Build([]byte(src), "test.hcl", body, "skipme")
+
+	out := hclwrite.NewEmptyFile()
+	m.Emit(out.Body(), body.Attributes["foo"].Range().Start.Byte)
+	out.Body().SetAttributeRaw("foo", hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte("PLACEHOLDER")},
+	})
+	assert.Equal(t, "// preamble\nfoo = PLACEHOLDER\n", string(out.Bytes()))
+}
+
+func TestBuild_LexErrorReturnsEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	// An unterminated string makes hclsyntax.LexConfig produce diagnostics;
+	// Build should bail out early and return an empty Map without panicking.
+	body := &hclsyntax.Body{
+		SrcRange: hcl.Range{
+			Filename: "test.hcl",
+			Start:    hcl.Pos{Byte: 0, Line: 1, Column: 1},
+			End:      hcl.Pos{Byte: 0, Line: 1, Column: 1},
+		},
+	}
+	m := Build([]byte("\""), "test.hcl", body)
+	require.NotNil(t, m)
+	assert.Empty(t, m.Leading(0))
+	assert.Empty(t, m.Trailing(0))
+}
+
+func TestNilMap_IsSafe(t *testing.T) {
+	t.Parallel()
+
+	// All public accessors must tolerate a nil receiver so callers can use
+	// (*Map)(nil) freely.
+	var m *Map
+	assert.Nil(t, m.Leading(0))
+	assert.Nil(t, m.Trailing(0))
+	assert.Equal(t, hclwrite.Tokens(nil), m.AppendTrailing(nil, 0))
+
+	out := hclwrite.NewEmptyFile()
+	m.Emit(out.Body(), 0)
+	assert.Empty(t, string(out.Bytes()))
+}
+
+func TestEmit_NoOpWhenNoComments(t *testing.T) {
+	t.Parallel()
+
+	body := parse(t, "foo = 1\n")
+	m := Build([]byte("foo = 1\n"), "test.hcl", body)
+
+	out := hclwrite.NewEmptyFile()
+	m.Emit(out.Body(), body.Attributes["foo"].Range().Start.Byte)
+	assert.Empty(t, string(out.Bytes()))
+}
+
+func TestAppendTrailing_NoCommentReturnsInput(t *testing.T) {
+	t.Parallel()
+
+	body := parse(t, "foo = 1\n")
+	m := Build([]byte("foo = 1\n"), "test.hcl", body)
+
+	in := hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte("X")}}
+	got := m.AppendTrailing(in, body.Attributes["foo"].Range().Start.Byte)
+	assert.Equal(t, in, got)
+}
+
+func TestLeadingAndTrailing_EmittedOnce(t *testing.T) {
+	t.Parallel()
+
+	body := parse(t, "// lead\nfoo = 1 // tail\n")
+	m := Build([]byte("// lead\nfoo = 1 // tail\n"), "test.hcl", body)
+
+	start := body.Attributes["foo"].Range().Start.Byte
+	require.Len(t, m.Leading(start), 1)
+	require.Len(t, m.Trailing(start), 1)
+	// Second call must return nil — comments are removed once emitted.
+	assert.Empty(t, m.Leading(start))
+	assert.Empty(t, m.Trailing(start))
+}


### PR DESCRIPTION
Preserve comments when converting to HCL or ejecting from HCL to PCL.

Fixes #89 