### PR TITLE
Keep the local name for directly assigned invokes

### DIFF
--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -726,6 +726,62 @@ func TestCustomInvokeHoistedWithCount(t *testing.T) {
 	}, values)
 }
 
+// TestCustomInvokeAssignedToLocalKeepsName verifies when an invoke is the direct value of
+// a top-level local variable (`name = invoke(...)`), the hoisted data block should reuse
+// the local's name (`data "<token>" "name"`) rather than the auto-generated
+// `invoke_N`. References to the local then rewrite to `data.<token>.<name>.<output>`.
+func TestCustomInvokeAssignedToLocalKeepsName(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	pclSource := `myConfig = invoke("test:index:echo", {
+    input = "hello"
+})
+
+output result {
+    value = myConfig.result
+}
+`
+
+	monitor := &testutil.MockResourceMonitor{
+		InvokeHandler: func(_ context.Context, req hclrun.InvokeRequest) (*hclrun.InvokeResponse, error) {
+			input, _ := req.Args.GetOk("input")
+			return &hclrun.InvokeResponse{
+				Return: property.NewMap(map[string]property.Value{
+					"result": property.New(input.AsString() + "+"),
+				}),
+			}, nil
+		},
+	}
+
+	mock := testConvertedPCLWithComponent(t, pclSource, nil, monitor, testSchema)
+
+	require.Len(t, mock.InvokedFunctions, 1)
+	assert.Equal(t, "test:index:echo", mock.InvokedFunctions[0].Token)
+
+	result, ok := mock.StackOutputs.GetOk("result")
+	require.True(t, ok, "expected 'result' stack output")
+	assert.Equal(t, property.New("hello+"), result)
+}
+
 // TestCustomInvokeHoistedInListComprehension checks that a custom provider
 // invoke that appears inside a PCL list comprehension is hoisted into a data
 // block whose `for_each` matches the comprehension's collection, and that the

--- a/cmd/pulumi-language-hcl/testdata/TestCustomInvokeAssignedToLocalKeepsName/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestCustomInvokeAssignedToLocalKeepsName/main.hcl
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+data "test_echo" "myConfig" {
+  input = "hello"
+}
+
+output "result" {
+  value = data.test_echo.myConfig.result
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-options-depends-on/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-options-depends-on/main.hcl
@@ -7,7 +7,7 @@ terraform {
   }
 }
 
-data "simple-invoke_myinvoke" "invoke_0" {
+data "simple-invoke_myinvoke" "data" {
   value      = "hello"
   depends_on = [simple-invoke_stringresource.first]
 }
@@ -18,8 +18,8 @@ resource "simple-invoke_stringresource" "first" {
   text = "first hello"
 }
 resource "simple-invoke_stringresource" "second" {
-  text = data.simple-invoke_myinvoke.invoke_0.result
+  text = data.simple-invoke_myinvoke.data.result
 }
 output "hello" {
-  value = data.simple-invoke_myinvoke.invoke_0.result
+  value = data.simple-invoke_myinvoke.data.result
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-options/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-options/main.hcl
@@ -7,7 +7,7 @@ terraform {
   }
 }
 
-data "simple-invoke_myinvoke" "invoke_0" {
+data "simple-invoke_myinvoke" "data" {
   value               = "hello"
   provider            = pulumi_providers_simple-invoke.explicitProvider
   parent              = pulumi_providers_simple-invoke.explicitProvider
@@ -18,5 +18,5 @@ data "simple-invoke_myinvoke" "invoke_0" {
 resource "pulumi_providers_simple-invoke" "explicitProvider" {
 }
 output "hello" {
-  value = data.simple-invoke_myinvoke.invoke_0.result
+  value = data.simple-invoke_myinvoke.data.result
 }

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -566,6 +566,23 @@ func (g *generator) collectInvokes(node pcl.Node) {
 	case *pcl.OutputVariable:
 		g.collectInvokesInExpr(n.Value, nil, srcFile)
 	case *pcl.LocalVariable:
+		// When a local variable's value is directly an invoke that gets
+		// promoted to a data source, name the data source after the local
+		// variable (e.g. `local x = invoke(...)` becomes
+		// `data "<token>" "x"`) instead of the auto-generated `invoke_N`.
+		if call, ok := n.Definition.Value.(*model.FunctionCallExpression); ok && call.Name == pcl.Invoke {
+			if _, inlinable := inlinableStdFunc(call); !inlinable {
+				for _, arg := range call.Args {
+					g.collectInvokesInExpr(arg, nil, srcFile)
+				}
+				g.invokeDataSources = append(g.invokeDataSources, spilledDataSource{
+					expr:       call,
+					name:       n.LogicalName(),
+					sourceFile: srcFile,
+				})
+				return
+			}
+		}
 		g.collectInvokesInExpr(n.Definition.Value, nil, srcFile)
 	}
 }


### PR DESCRIPTION
When PCL contains an invoke that is a direct assignment, preserve the name:

`name = invoke("<token>", { args... })` now translates to:

```hcl
data "<token>" name { args... }
```

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/92