### PR TITLE
Remove the read timeout, since it doesn't exist in Pulumi

### DIFF
--- a/pkg/hcl/ast/resource.go
+++ b/pkg/hcl/ast/resource.go
@@ -31,8 +31,6 @@ import (
 type Timeouts struct {
 	// Create is the timeout for create operations.
 	Create hcl.Expression
-	// Read is the timeout for read operations.
-	Read hcl.Expression
 	// Update is the timeout for update operations.
 	Update hcl.Expression
 	// Delete is the timeout for delete operations.

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -916,10 +916,6 @@ func (p *Parser) parseTimeoutsBlock(block *hcl.Block) (*ast.Timeouts, hcl.Diagno
 		timeouts.Create = attr.Expr
 	}
 
-	if attr, ok := content.Attributes["read"]; ok {
-		timeouts.Read = attr.Expr
-	}
-
 	if attr, ok := content.Attributes["update"]; ok {
 		timeouts.Update = attr.Expr
 	}

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -231,7 +231,6 @@ var preconditionSchema = &hcl.BodySchema{
 var timeoutsSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "create"},
-		{Name: "read"},
 		{Name: "update"},
 		{Name: "delete"},
 	},


### PR DESCRIPTION
The tracking issue in Pulumi to add such support is https://github.com/pulumi/pulumi/issues/15636. In the mean time, we should pull functionality that isn't hooked up.