### PR TITLE
Fix `"l3-component-nested"`

### DIFF
--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -137,7 +137,6 @@ var expectedFailures = map[string]string{
 	"l3-component-primitive-conversions": "primitive type coercion (e.g. string→bool) not yet supported by HCL runtime",
 	"l2-id-type":                         "ID-as-string coercion across primitive types not yet supported by HCL runtime",
 	"l2-resource-option-hooks":           "PCL pcl.Hook nodes not yet supported by HCL codegen",
-	"l3-component-nested":                "nested component URN naming convention does not match conformance expectation",
 }
 
 // expectedEjectFailures lists tests whose eject (HCL→PCL conversion) step is

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-nested/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-nested/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-nested
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-nested/innerComponent/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-nested/innerComponent/main.pp
@@ -1,0 +1,12 @@
+resource "res" "simple:index:Resource" {
+  value = !input
+}
+
+config "input" "bool" {
+  description = "An input passed to the inner component"
+}
+
+output "output" {
+  value = res.value
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-nested/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-nested/main.pp
@@ -1,0 +1,8 @@
+component "outerComponent" "./outerComponent" {
+  input = true
+}
+
+output "result" {
+  value = outerComponent.output
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-nested/outerComponent/innerComponent/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-nested/outerComponent/innerComponent/main.pp
@@ -1,0 +1,12 @@
+resource "res" "simple:index:Resource" {
+  value = !input
+}
+
+config "input" "bool" {
+  description = "An input passed to the inner component"
+}
+
+output "output" {
+  value = res.value
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-nested/outerComponent/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-nested/outerComponent/main.pp
@@ -1,0 +1,12 @@
+config "input" "bool" {
+  description = "An input passed to the outer component"
+}
+
+component "innerComponent" "./innerComponent" {
+  input = !input
+}
+
+output "output" {
+  value = innerComponent.output
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-nested
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/innerComponent/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/innerComponent/main.hcl
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "res" {
+  value = ! var.input
+}
+variable "input" {
+  type        = bool
+  description = "An input passed to the inner component"
+}
+output "output" {
+  value = simple_resource.res.value
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/main.hcl
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+module "outerComponent" {
+  source = "./outerComponent"
+  input  = true
+}
+output "result" {
+  value = module.outerComponent.output
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/outerComponent/innerComponent/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/outerComponent/innerComponent/main.hcl
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "res" {
+  value = ! var.input
+}
+variable "input" {
+  type        = bool
+  description = "An input passed to the inner component"
+}
+output "output" {
+  value = simple_resource.res.value
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/outerComponent/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/outerComponent/main.hcl
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+variable "input" {
+  type        = bool
+  description = "An input passed to the outer component"
+}
+module "innerComponent" {
+  source = "./innerComponent"
+  input  = ! var.input
+}
+output "output" {
+  value = module.innerComponent.output
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-nested
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/innerComponent/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/innerComponent/main.hcl
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "res" {
+  value = ! var.input
+}
+variable "input" {
+  type        = bool
+  description = "An input passed to the inner component"
+}
+output "output" {
+  value = simple_resource.res.value
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/main.hcl
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+module "outerComponent" {
+  source = "./outerComponent"
+  input  = true
+}
+output "result" {
+  value = module.outerComponent.output
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/outerComponent/innerComponent/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/outerComponent/innerComponent/main.hcl
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "res" {
+  value = ! var.input
+}
+variable "input" {
+  type        = bool
+  description = "An input passed to the inner component"
+}
+output "output" {
+  value = simple_resource.res.value
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/outerComponent/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/outerComponent/main.hcl
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+variable "input" {
+  type        = bool
+  description = "An input passed to the outer component"
+}
+module "innerComponent" {
+  source = "./innerComponent"
+  input  = ! var.input
+}
+output "output" {
+  value = module.innerComponent.output
+}

--- a/pkg/hcl/eval/evaluator.go
+++ b/pkg/hcl/eval/evaluator.go
@@ -120,6 +120,28 @@ func (e *Evaluator) EvaluateBody(body hcl.Body) (map[string]cty.Value, hcl.Diagn
 	return result, diags
 }
 
+// SensitiveMark is the cty value mark applied to sensitive values.
+const SensitiveMark = "sensitive"
+
+// SensitiveArgumentDiagnostic returns the diagnostic Terraform emits when
+// a sensitive value is supplied as a meta-argument such as `count` or
+// `for_each`. argName is the meta-argument's name (e.g. "count" or
+// "for_each"). The shape of the diagnostic intentionally mirrors
+// Terraform's so users coming from Terraform see a familiar message.
+func SensitiveArgumentDiagnostic(argName string, expr hcl.Expression) *hcl.Diagnostic {
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  fmt.Sprintf("Invalid %s argument", argName),
+		Detail: fmt.Sprintf(
+			"Sensitive values, or values derived from sensitive values, "+
+				"cannot be used as %s arguments. If used, the sensitive value "+
+				"could be exposed as a resource instance key. If you want to use "+
+				"the value anyway, wrap it in nonsensitive(...).",
+			argName),
+		Subject: expr.Range().Ptr(),
+	}
+}
+
 // EvaluateCount evaluates a count expression and returns (count, isBool, diags).
 // isBool is true when the expression evaluated to a boolean (true→1, false→0),
 // which suppresses the numeric index suffix on resource names.
@@ -132,6 +154,10 @@ func (e *Evaluator) EvaluateCount(expr hcl.Expression) (int, bool, hcl.Diagnosti
 	val, diags := e.Evaluate(expr)
 	if diags.HasErrors() {
 		return 0, false, diags
+	}
+
+	if val.HasMark(SensitiveMark) {
+		return 0, false, hcl.Diagnostics{SensitiveArgumentDiagnostic("count", expr)}
 	}
 
 	if val.Type() == cty.Bool {
@@ -176,6 +202,10 @@ func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, 
 	val, diags := e.Evaluate(expr)
 	if diags.HasErrors() {
 		return nil, diags
+	}
+
+	if val.HasMark(SensitiveMark) {
+		return nil, hcl.Diagnostics{SensitiveArgumentDiagnostic("for_each", expr)}
 	}
 
 	if val.IsNull() {

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -28,17 +28,43 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 	"github.com/pulumi/pulumi/pkg/v3/util/pdag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // ModuleInfo holds metadata for nodes that are part of an inlined module.
 type ModuleInfo struct {
-	Prefix       string      // e.g., "module.first." — prefixed to all internal keys
-	ModuleName   string      // e.g., "first"
-	Module       *ast.Module // the module block from the parent config
-	SourcePath   string      // resolved source path (for component type name)
-	ParentPrefix string      // "" for root-level modules, "module.outer." for nested
+	// Path identifies this module call within the nesting tree.
+	// Its leaf step is bare (no count/for_each disambiguator) — runtime
+	// instances of count/for_each-expanded calls live separately.
+	Path modulepath.Path
+
+	Module     *ast.Module // the module block from the parent config
+	SourcePath string      // resolved source path (for component type name)
+}
+
+// ModuleName returns the block label of this module call (e.g. "first").
+func (m *ModuleInfo) ModuleName() string {
+	_, last, ok := m.Path.Parent()
+	if !ok {
+		return ""
+	}
+	return last.Name()
+}
+
+// Prefix returns the string prefix used to disambiguate node keys
+// belonging to this module from the rest of the graph.
+func (m *ModuleInfo) Prefix() string { return m.Path.PrefixString() }
+
+// ParentPrefix returns the string prefix of the enclosing module, or "" if
+// this module is at the root of the configuration.
+func (m *ModuleInfo) ParentPrefix() string {
+	parent, _, ok := m.Path.Parent()
+	if !ok {
+		return ""
+	}
+	return parent.PrefixString()
 }
 
 // LoadedModule represents a loaded and parsed module (used by ModuleLoader).
@@ -297,7 +323,7 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Inline module contents into the graph for fine-grained dependency tracking.
 	for name, module := range config.Modules {
-		if err := g.inlineModule(name, module, "", moduleLoader, workDir); err != nil {
+		if err := g.inlineModule(name, module, modulepath.Root(), moduleLoader, workDir); err != nil {
 			return nil, fmt.Errorf("inlining module %s: %w", name, err)
 		}
 	}
@@ -575,9 +601,10 @@ func (g *Graph) Validate() []error {
 	return errors
 }
 
-// inlineModule loads a module and inlines its contents into the graph with a prefix.
+// inlineModule loads a module and inlines its contents into the graph
+// rooted at parentPath.
 func (g *Graph) inlineModule(
-	name string, mod *ast.Module, parentPrefix string,
+	name string, mod *ast.Module, parentPath modulepath.Path,
 	moduleLoader ModuleLoader, workDir string,
 ) error {
 	loaded, err := moduleLoader.LoadModule(mod.Source, workDir)
@@ -585,13 +612,13 @@ func (g *Graph) inlineModule(
 		return fmt.Errorf("loading module %s: %w", name, err)
 	}
 
-	prefix := parentPrefix + "module." + name + "."
+	path := parentPath.Append(modulepath.NewStep(name))
+	prefix := path.PrefixString()
+	parentPrefix := parentPath.PrefixString()
 	modInfo := &ModuleInfo{
-		Prefix:       prefix,
-		ModuleName:   name,
-		Module:       mod,
-		SourcePath:   loaded.SourcePath,
-		ParentPrefix: parentPrefix,
+		Path:       path,
+		Module:     mod,
+		SourcePath: loaded.SourcePath,
 	}
 
 	// Init node: depends on count/for_each/depends_on from parent scope.
@@ -697,7 +724,9 @@ func (g *Graph) inlineModule(
 		}
 	}
 
-	// Completion node: depends on all outputs + init.
+	// Completion node: depends on all outputs + init. The completion key
+	// is the module call's identifier (without the trailing "."), so that
+	// expressions like `module.<name>` in the parent scope resolve to it.
 	completionKey := parentPrefix + "module." + name
 	completionDeps := []pdag.Node{initIdx}
 	for outputName := range loaded.Config.Outputs {
@@ -719,7 +748,7 @@ func (g *Graph) inlineModule(
 
 	// Nested modules
 	for nestedName, nestedMod := range loaded.Config.Modules {
-		if err := g.inlineModule(nestedName, nestedMod, prefix, moduleLoader, loaded.SourcePath); err != nil {
+		if err := g.inlineModule(nestedName, nestedMod, path, moduleLoader, loaded.SourcePath); err != nil {
 			return fmt.Errorf("inlining nested module %s: %w", nestedName, err)
 		}
 	}

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -662,24 +662,28 @@ func (g *Graph) inlineModule(
 
 	// Locals
 	for localName, local := range loaded.Config.Locals {
+		deps := g.exprDeps(local.Value, prefix)
+		deps = append(deps, initIdx)
 		if err := g.AddNode(&Node{
 			Key:        prefix + "local." + localName,
 			Type:       NodeTypeLocal,
 			Local:      local,
 			ModuleInfo: modInfo,
-		}, g.exprDeps(local.Value, prefix)); err != nil {
+		}, deps); err != nil {
 			return err
 		}
 	}
 
 	// Providers
 	for key, provider := range loaded.Config.Providers {
+		deps := g.providerDeps(provider, prefix)
+		deps = append(deps, initIdx)
 		if err := g.AddNode(&Node{
 			Key:        prefix + key,
 			Type:       NodeTypeProvider,
 			Provider:   provider,
 			ModuleInfo: modInfo,
-		}, g.providerDeps(provider, prefix)); err != nil {
+		}, deps); err != nil {
 			return err
 		}
 	}
@@ -714,12 +718,14 @@ func (g *Graph) inlineModule(
 
 	// Outputs
 	for outputName, output := range loaded.Config.Outputs {
+		deps := g.exprDeps(output.Value, prefix)
+		deps = append(deps, initIdx)
 		if err := g.AddNode(&Node{
 			Key:        prefix + "output." + outputName,
 			Type:       NodeTypeOutput,
 			Output:     output,
 			ModuleInfo: modInfo,
-		}, g.exprDeps(output.Value, prefix)); err != nil {
+		}, deps); err != nil {
 			return err
 		}
 	}

--- a/pkg/hcl/modulepath/modulepath.go
+++ b/pkg/hcl/modulepath/modulepath.go
@@ -1,0 +1,380 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package modulepath identifies a particular module instance in the
+// nesting tree of an HCL configuration.
+//
+// A [Path] is composed of [Step]s, one per module call traversed from the
+// root config down to the instance in question. The empty path is the
+// root configuration. A [Step] carries the module call's block label plus
+// the optional disambiguator (count index or for_each key) that identifies
+// which instance of that call we mean.
+//
+// The internal byte layout of a Path is an implementation detail and is
+// explicitly NOT a stable encoding: do not persist values of this type or
+// rely on the bytes returned by any private method to round-trip across
+// process boundaries. The package's value comes from giving callers a
+// comparable, hashable handle that supports unambiguous derivation of
+// Pulumi logical names regardless of label content.
+package modulepath
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// stepKind tags the disambiguator carried by a [Step].
+type stepKind uint8
+
+const (
+	stepKindBare    stepKind = 0
+	stepKindIndex   stepKind = 1
+	stepKindForEach stepKind = 2
+)
+
+// Step is one element of a [Path]: a module call's block label plus the
+// optional count index or for_each key that selects a particular instance
+// of that call.
+//
+// Construct values via [NewStep], [NewIndexedStep], or [NewKeyedStep].
+type Step struct {
+	name string
+	kind stepKind
+	idx  uint64
+	key  string
+}
+
+// NewStep returns a Step for a module call with no count or for_each
+// expansion.
+func NewStep(name string) Step {
+	return Step{name: name, kind: stepKindBare}
+}
+
+// NewIndexedStep returns a Step for a particular instance of a count-expanded
+// module call. index must be non-negative.
+func NewIndexedStep(name string, index int) Step {
+	if index < 0 {
+		panic(fmt.Sprintf("modulepath: index must be non-negative, got %d", index))
+	}
+	return Step{name: name, kind: stepKindIndex, idx: uint64(index)}
+}
+
+// NewKeyedStep returns a Step for a particular instance of a for_each-expanded
+// module call.
+func NewKeyedStep(name string, key string) Step {
+	return Step{name: name, kind: stepKindForEach, key: key}
+}
+
+// Name returns the block label of this step (e.g. "vpc", "vpc.primary").
+func (s Step) Name() string { return s.name }
+
+// Index returns the count index of this step. ok is false if the step is
+// not from a count expansion.
+func (s Step) Index() (index int, ok bool) {
+	if s.kind != stepKindIndex {
+		return 0, false
+	}
+	return int(s.idx), true //nolint:gosec // constructed via NewIndexedStep, fits int
+}
+
+// Key returns the for_each key of this step. ok is false if the step is not
+// from a for_each expansion.
+func (s Step) Key() (key string, ok bool) {
+	if s.kind != stepKindForEach {
+		return "", false
+	}
+	return s.key, true
+}
+
+// LogicalName returns the Pulumi logical name component for this single
+// step:
+//
+//   - "<name>"          if the step has no count/for_each.
+//   - "<name>-<index>"  for count instances.
+//   - "<name>-<key>"    for for_each instances.
+func (s Step) LogicalName() string {
+	switch s.kind {
+	case stepKindIndex:
+		return s.name + "-" + strconv.FormatUint(s.idx, 10)
+	case stepKindForEach:
+		return s.name + "-" + s.key
+	default:
+		return s.name
+	}
+}
+
+// String returns a diagnostic representation of this step using
+// Terraform-style addressing (module["name"], module["name"][0],
+// module["name"]["key"]).
+//
+// Don't parse this. Use the typed accessors instead.
+func (s Step) String() string {
+	switch s.kind {
+	case stepKindIndex:
+		return fmt.Sprintf("module[%q][%d]", s.name, s.idx)
+	case stepKindForEach:
+		return fmt.Sprintf("module[%q][%q]", s.name, s.key)
+	default:
+		return fmt.Sprintf("module[%q]", s.name)
+	}
+}
+
+// Path identifies a particular module instance in the nesting tree
+// rooted at the top-level config.
+//
+// The zero value [Path] is the root (no enclosing module). Paths are
+// comparable in Go, hashable as map keys, and immutable.
+//
+// The internal representation is a length-prefixed binary string, an
+// implementation detail. Do not depend on it: there is no marshal API
+// because there is no stable on-disk format. Use [Path.String] for
+// human-readable diagnostics; use the typed methods for everything else.
+type Path struct {
+	repr string
+}
+
+// Root returns the empty Path (the root configuration).
+func Root() Path { return Path{} }
+
+// Len returns the number of steps in p.
+func (p Path) Len() int {
+	n := 0
+	for range p.Steps {
+		n++
+	}
+	return n
+}
+
+// IsRoot reports whether p has zero steps.
+func (p Path) IsRoot() bool { return p == Path{} }
+
+// Append returns a new Path with s added to the end. p is not mutated.
+func (p Path) Append(s Step) Path {
+	var b strings.Builder
+	b.Grow(len(p.repr) + estimateStepSize(s))
+	b.WriteString(p.repr)
+	encodeStep(&b, s)
+	return Path{repr: b.String()}
+}
+
+// Parent returns the path with the last step removed plus that last step.
+// ok is false if p is the root.
+func (p Path) Parent() (parent Path, last Step, ok bool) {
+	if p.repr == "" {
+		return Path{}, Step{}, false
+	}
+	bytes := []byte(p.repr)
+	lastStart := 0
+	cursor := 0
+	var lastStep Step
+	for cursor < len(bytes) {
+		lastStart = cursor
+		next, s := decodeStep(bytes, cursor)
+		lastStep = s
+		cursor = next
+	}
+	return Path{repr: string(bytes[:lastStart])}, lastStep, true
+}
+
+// Steps yields the steps of p in order. Designed for `for s := range p.Steps`.
+func (p Path) Steps(yield func(Step) bool) {
+	bytes := []byte(p.repr)
+	cursor := 0
+	for cursor < len(bytes) {
+		next, s := decodeStep(bytes, cursor)
+		if !yield(s) {
+			return
+		}
+		cursor = next
+	}
+}
+
+// LogicalName returns the canonical Pulumi resource name for this path
+// (joining each step's [Step.LogicalName] with "-").
+//
+//	Root                              -> ""
+//	["outer"]                         -> "outer"
+//	["outer", "inner"]                -> "outer-inner"
+//	["outer"[0], "inner"]             -> "outer-0-inner"
+//	["outer"["a"], "inner"]           -> "outer-a-inner"
+//
+// Note that names containing "-" are not escaped: a logical name produced
+// by this function is a one-way derivation, not a round-trippable encoding
+// of the path.
+func (p Path) LogicalName() string {
+	var b strings.Builder
+	first := true
+	for s := range p.Steps {
+		if !first {
+			b.WriteByte('-')
+		}
+		b.WriteString(s.LogicalName())
+		first = false
+	}
+	return b.String()
+}
+
+// String returns a diagnostic representation joining each step with ".".
+//
+// Don't parse this. Use [Path.Steps] or the typed accessors instead.
+func (p Path) String() string {
+	if p.IsRoot() {
+		return ""
+	}
+	parts := make([]string, 0, p.Len())
+	for s := range p.Steps {
+		parts = append(parts, s.String())
+	}
+	return strings.Join(parts, ".")
+}
+
+// PrefixString returns a string suitable for prefixing bare element
+// identifiers (e.g. "var.foo", "aws_instance.web") to form a globally
+// unique identifier within an HCL configuration.
+//
+// The empty path returns "". Non-root paths return a string of the form
+// "module.<name>.module.<name>." so callers may concatenate directly:
+//
+//	p.PrefixString() + "var.foo"
+//
+// This format intentionally matches the dependency reference syntax used
+// by HCL itself (e.g. `module.<name>.<output>`), so a graph-time
+// dependency lookup performed by string concatenation matches the keys
+// stored when the prefixed nodes are added.
+//
+// Note that this is NOT a collision-free encoding: a label of the form
+// "a.module.b" would prefix-collide with the path ["a", "b"]. HCL
+// traversal syntax cannot reference such pathological labels in any case,
+// so the collision is benign in practice. Use the path itself
+// ([Path] equality / map-key) rather than this string when collision
+// safety is required.
+func (p Path) PrefixString() string {
+	if p.IsRoot() {
+		return ""
+	}
+	var b strings.Builder
+	for s := range p.Steps {
+		b.WriteString("module.")
+		b.WriteString(s.Name())
+		switch s.kind {
+		case stepKindIndex:
+			fmt.Fprintf(&b, "[%d]", s.idx)
+		case stepKindForEach:
+			fmt.Fprintf(&b, "[%q]", s.key)
+		}
+		b.WriteByte('.')
+	}
+	return b.String()
+}
+
+// NodeKey returns an opaque, collision-free string formed by combining p
+// with localID. It is suitable as a unique identifier for an element
+// (resource, local, output, ...) inside the module instance described by p.
+//
+// The returned bytes are not human-readable and not stable across process
+// boundaries. Use this only as an in-memory map key.
+func (p Path) NodeKey(localID string) string {
+	var b strings.Builder
+	b.Grow(len(p.repr) + 2 + len(localID))
+	b.WriteString(p.repr)
+	writeUint16(&b, len(localID))
+	b.WriteString(localID)
+	return b.String()
+}
+
+// --- internal encoding ---
+
+// encodeStep writes a single step into b using a length-prefixed layout:
+//
+//	u16 BE  name length
+//	bytes   name
+//	u8      kind tag
+//	if kind == stepKindIndex:   u64 BE index
+//	if kind == stepKindForEach: u16 BE key length, key bytes
+func encodeStep(b *strings.Builder, s Step) {
+	writeUint16(b, len(s.name))
+	b.WriteString(s.name)
+	b.WriteByte(byte(s.kind))
+	switch s.kind {
+	case stepKindIndex:
+		var buf [8]byte
+		binary.BigEndian.PutUint64(buf[:], s.idx)
+		b.Write(buf[:])
+	case stepKindForEach:
+		writeUint16(b, len(s.key))
+		b.WriteString(s.key)
+	}
+}
+
+// decodeStep returns the cursor position after the step starting at start
+// and the decoded Step. It panics if the bytes are malformed; callers must
+// only feed it bytes produced by encodeStep.
+func decodeStep(bytes []byte, start int) (int, Step) {
+	mustHave(bytes, start, 2)
+	nameLen := int(binary.BigEndian.Uint16(bytes[start : start+2]))
+	start += 2
+	mustHave(bytes, start, nameLen)
+	name := string(bytes[start : start+nameLen])
+	start += nameLen
+	mustHave(bytes, start, 1)
+	kind := stepKind(bytes[start])
+	start++
+	switch kind {
+	case stepKindBare:
+		return start, Step{name: name, kind: kind}
+	case stepKindIndex:
+		mustHave(bytes, start, 8)
+		idx := binary.BigEndian.Uint64(bytes[start : start+8])
+		start += 8
+		return start, Step{name: name, kind: kind, idx: idx}
+	case stepKindForEach:
+		mustHave(bytes, start, 2)
+		keyLen := int(binary.BigEndian.Uint16(bytes[start : start+2]))
+		start += 2
+		mustHave(bytes, start, keyLen)
+		key := string(bytes[start : start+keyLen])
+		start += keyLen
+		return start, Step{name: name, kind: kind, key: key}
+	default:
+		panic(fmt.Sprintf("modulepath: corrupt path repr (unknown kind %d)", kind))
+	}
+}
+
+func writeUint16(b *strings.Builder, n int) {
+	if n < 0 || n > 0xFFFF {
+		panic(fmt.Sprintf("modulepath: value %d does not fit in uint16", n))
+	}
+	var buf [2]byte
+	binary.BigEndian.PutUint16(buf[:], uint16(n)) //nolint:gosec // checked above
+	b.Write(buf[:])
+}
+
+func estimateStepSize(s Step) int {
+	size := 2 + len(s.name) + 1
+	switch s.kind {
+	case stepKindIndex:
+		size += 8
+	case stepKindForEach:
+		size += 2 + len(s.key)
+	}
+	return size
+}
+
+func mustHave(bytes []byte, start, n int) {
+	if start+n > len(bytes) {
+		panic("modulepath: corrupt path repr (truncated)")
+	}
+}

--- a/pkg/hcl/modulepath/modulepath_test.go
+++ b/pkg/hcl/modulepath/modulepath_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modulepath_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoot(t *testing.T) {
+	t.Parallel()
+
+	r := modulepath.Root()
+	assert.True(t, r.IsRoot())
+	assert.Equal(t, 0, r.Len())
+	assert.Equal(t, "", r.LogicalName())
+	assert.Equal(t, "", r.String())
+}
+
+func TestStep_LogicalName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		step modulepath.Step
+		want string
+	}{
+		{"bare", modulepath.NewStep("vpc"), "vpc"},
+		{"bare-with-dot", modulepath.NewStep("vpc.primary"), "vpc.primary"},
+		{"index-zero", modulepath.NewIndexedStep("vpc", 0), "vpc-0"},
+		{"index-large", modulepath.NewIndexedStep("vpc", 17), "vpc-17"},
+		{"each-string", modulepath.NewKeyedStep("vpc", "prod"), "vpc-prod"},
+		{"each-empty", modulepath.NewKeyedStep("vpc", ""), "vpc-"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.step.LogicalName())
+		})
+	}
+}
+
+func TestStep_Accessors(t *testing.T) {
+	t.Parallel()
+
+	bare := modulepath.NewStep("a")
+	assert.Equal(t, "a", bare.Name())
+	_, ok := bare.Index()
+	assert.False(t, ok)
+	_, ok = bare.Key()
+	assert.False(t, ok)
+
+	idx := modulepath.NewIndexedStep("a", 3)
+	got, ok := idx.Index()
+	assert.True(t, ok)
+	assert.Equal(t, 3, got)
+
+	key := modulepath.NewKeyedStep("a", "k")
+	gotKey, ok := key.Key()
+	assert.True(t, ok)
+	assert.Equal(t, "k", gotKey)
+}
+
+func TestNewIndexedStep_NegativePanics(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() { modulepath.NewIndexedStep("a", -1) })
+}
+
+func TestPath_Append(t *testing.T) {
+	t.Parallel()
+
+	p := modulepath.Root().Append(modulepath.NewStep("a")).Append(modulepath.NewStep("b"))
+	assert.Equal(t, 2, p.Len())
+	assert.False(t, p.IsRoot())
+	assert.Equal(t, "a-b", p.LogicalName())
+}
+
+func TestPath_AppendDoesNotMutate(t *testing.T) {
+	t.Parallel()
+
+	p1 := modulepath.Root().Append(modulepath.NewStep("a"))
+	p2 := p1.Append(modulepath.NewStep("b"))
+	// p1 must still be just "a".
+	assert.Equal(t, "a", p1.LogicalName())
+	assert.Equal(t, "a-b", p2.LogicalName())
+}
+
+func TestPath_LogicalName_RoundTripsDottedLabels(t *testing.T) {
+	t.Parallel()
+
+	// The whole point of this package: dots in labels survive intact.
+	p := modulepath.Root().
+		Append(modulepath.NewStep("vpc.primary")).
+		Append(modulepath.NewStep("inner"))
+	assert.Equal(t, "vpc.primary-inner", p.LogicalName())
+}
+
+func TestPath_LogicalName_MixedExpansions(t *testing.T) {
+	t.Parallel()
+
+	p := modulepath.Root().
+		Append(modulepath.NewIndexedStep("outer", 2)).
+		Append(modulepath.NewKeyedStep("inner", "prod"))
+	assert.Equal(t, "outer-2-inner-prod", p.LogicalName())
+}
+
+func TestPath_Parent(t *testing.T) {
+	t.Parallel()
+
+	root := modulepath.Root()
+	_, _, ok := root.Parent()
+	assert.False(t, ok)
+
+	a := root.Append(modulepath.NewStep("a"))
+	parent, last, ok := a.Parent()
+	assert.True(t, ok)
+	assert.True(t, parent.IsRoot())
+	assert.Equal(t, "a", last.Name())
+
+	ab := a.Append(modulepath.NewIndexedStep("b", 5))
+	parent, last, ok = ab.Parent()
+	assert.True(t, ok)
+	assert.Equal(t, "a", parent.LogicalName())
+	idx, hasIdx := last.Index()
+	assert.True(t, hasIdx)
+	assert.Equal(t, 5, idx)
+}
+
+func TestPath_Steps(t *testing.T) {
+	t.Parallel()
+
+	p := modulepath.Root().
+		Append(modulepath.NewStep("a")).
+		Append(modulepath.NewIndexedStep("b", 7)).
+		Append(modulepath.NewKeyedStep("c", "k"))
+
+	var got []string
+	for s := range p.Steps {
+		got = append(got, s.LogicalName())
+	}
+	assert.Equal(t, []string{"a", "b-7", "c-k"}, got)
+}
+
+func TestPath_Steps_EarlyExit(t *testing.T) {
+	t.Parallel()
+
+	p := modulepath.Root().
+		Append(modulepath.NewStep("a")).
+		Append(modulepath.NewStep("b")).
+		Append(modulepath.NewStep("c"))
+
+	var got []string
+	for s := range p.Steps {
+		got = append(got, s.Name())
+		if s.Name() == "b" {
+			break
+		}
+	}
+	assert.Equal(t, []string{"a", "b"}, got)
+}
+
+func TestPath_Comparable(t *testing.T) {
+	t.Parallel()
+
+	p1 := modulepath.Root().Append(modulepath.NewStep("a"))
+	p2 := modulepath.Root().Append(modulepath.NewStep("a"))
+	p3 := modulepath.Root().Append(modulepath.NewStep("b"))
+
+	assert.True(t, p1 == p2, "equal paths must be == comparable")
+	assert.False(t, p1 == p3)
+}
+
+func TestPath_UsableAsMapKey(t *testing.T) {
+	t.Parallel()
+
+	p1 := modulepath.Root().Append(modulepath.NewStep("a"))
+	p2 := modulepath.Root().Append(modulepath.NewStep("a"))
+	p3 := modulepath.Root().Append(modulepath.NewStep("b"))
+
+	m := map[modulepath.Path]string{p1: "first"}
+	got, ok := m[p2]
+	assert.True(t, ok)
+	assert.Equal(t, "first", got)
+	_, ok = m[p3]
+	assert.False(t, ok)
+}
+
+func TestPath_NoCollisionAcrossDottedLabels(t *testing.T) {
+	t.Parallel()
+
+	// "a.b" / "c" must not collide with "a" / "b.c" — the bug we set out
+	// to fix. With length-prefixed encoding, these produce distinct paths.
+	p1 := modulepath.Root().
+		Append(modulepath.NewStep("a.b")).
+		Append(modulepath.NewStep("c"))
+	p2 := modulepath.Root().
+		Append(modulepath.NewStep("a")).
+		Append(modulepath.NewStep("b.c"))
+
+	assert.False(t, p1 == p2)
+	assert.Equal(t, "a.b-c", p1.LogicalName())
+	assert.Equal(t, "a-b.c", p2.LogicalName())
+}
+
+func TestPath_NodeKey_DistinguishesPaths(t *testing.T) {
+	t.Parallel()
+
+	p1 := modulepath.Root().Append(modulepath.NewStep("a"))
+	p2 := modulepath.Root().Append(modulepath.NewStep("b"))
+	assert.NotEqual(t, p1.NodeKey("res"), p2.NodeKey("res"))
+}
+
+func TestPath_NodeKey_DistinguishesLocalIDs(t *testing.T) {
+	t.Parallel()
+
+	p := modulepath.Root().Append(modulepath.NewStep("a"))
+	assert.NotEqual(t, p.NodeKey("res1"), p.NodeKey("res2"))
+}
+
+func TestPath_NodeKey_NoBoundaryCollision(t *testing.T) {
+	t.Parallel()
+
+	// Without length prefixing, a label "ax" + local "b" would collide with
+	// label "a" + local "xb". With the length-prefixed encoding we use, they
+	// must differ.
+	p1 := modulepath.Root().Append(modulepath.NewStep("ax"))
+	p2 := modulepath.Root().Append(modulepath.NewStep("a"))
+	assert.NotEqual(t, p1.NodeKey("b"), p2.NodeKey("xb"))
+}
+
+func TestPath_PrefixString(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "", modulepath.Root().PrefixString())
+
+	p := modulepath.Root().Append(modulepath.NewStep("a"))
+	got := p.PrefixString()
+	// Must end with "." so concatenation works.
+	assert.True(t, strings.HasSuffix(got, "."))
+
+	// Must contain the label content for diagnostics, but the exact
+	// format is part of the API contract: it's a quoted bracketed form.
+	assert.Contains(t, got, "a")
+}
+
+func TestPath_PrefixString_DistinguishesDottedLabels(t *testing.T) {
+	t.Parallel()
+
+	// "a.b" / "c" must produce a different prefix than "a" / "b.c".
+	p1 := modulepath.Root().
+		Append(modulepath.NewStep("a.b")).
+		Append(modulepath.NewStep("c"))
+	p2 := modulepath.Root().
+		Append(modulepath.NewStep("a")).
+		Append(modulepath.NewStep("b.c"))
+	assert.NotEqual(t, p1.PrefixString(), p2.PrefixString())
+}
+
+func TestPath_String_Diagnostic(t *testing.T) {
+	t.Parallel()
+
+	p := modulepath.Root().
+		Append(modulepath.NewStep("vpc.primary")).
+		Append(modulepath.NewIndexedStep("inner", 3))
+	// String is for humans only — exact format may evolve, but it should
+	// contain both labels and the index.
+	got := p.String()
+	assert.Contains(t, got, "vpc.primary")
+	assert.Contains(t, got, "inner")
+	assert.Contains(t, got, "3")
+}
+
+func TestPath_LargeIndex(t *testing.T) {
+	t.Parallel()
+
+	// Indices may exceed 64; the encoding allocates a full uint64 so this is fine.
+	p := modulepath.Root().Append(modulepath.NewIndexedStep("a", 1<<20))
+	idx, ok := first(p.Steps).Index()
+	assert.True(t, ok)
+	assert.Equal(t, 1<<20, idx)
+}
+
+// first returns the first value yielded by an iter.Seq[T]-like function.
+// Used to keep tests succinct.
+func first[T any](seq func(yield func(T) bool)) T {
+	var out T
+	for v := range seq {
+		out = v
+		break
+	}
+	return out
+}
+
+func TestPath_StepsAreOrderPreserving(t *testing.T) {
+	t.Parallel()
+
+	steps := []modulepath.Step{
+		modulepath.NewStep("a"),
+		modulepath.NewIndexedStep("b", 1),
+		modulepath.NewKeyedStep("c", "x"),
+		modulepath.NewStep("d"),
+	}
+	p := modulepath.Root()
+	for _, s := range steps {
+		p = p.Append(s)
+	}
+
+	var got []string
+	for s := range p.Steps {
+		got = append(got, s.LogicalName())
+	}
+	want := make([]string, 0, len(steps))
+	for _, s := range steps {
+		want = append(want, s.LogicalName())
+	}
+	assert.True(t, slices.Equal(want, got), "expected %v, got %v", want, got)
+}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2262,6 +2262,9 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating module count: %s", diags.Error())
 		}
+		if countVal.HasMark(eval.SensitiveMark) {
+			return hcl.Diagnostics{eval.SensitiveArgumentDiagnostic("count", mod.Count)}
+		}
 		if !countVal.Type().Equals(cty.Number) {
 			return fmt.Errorf("module count must be a number")
 		}
@@ -2296,6 +2299,9 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 	forEachVal, diags := mod.ForEach.Value(parentEvalCtx.HCLContext())
 	if diags.HasErrors() {
 		return fmt.Errorf("evaluating module for_each: %s", diags.Error())
+	}
+	if forEachVal.HasMark(eval.SensitiveMark) {
+		return hcl.Diagnostics{eval.SensitiveArgumentDiagnostic("for_each", mod.ForEach)}
 	}
 	if !forEachVal.CanIterateElements() {
 		return fmt.Errorf("module for_each must be a set or map")

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/graph"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
@@ -168,7 +169,10 @@ type CallResponse struct {
 
 // moduleInstance represents a single runtime instance of an inlined module.
 type moduleInstance struct {
-	Key     string               // e.g., "module.first" or "module.first[0]"
+	// Path identifies this instance within the module nesting tree. The
+	// leaf [modulepath.Step] carries the count index or for_each key, if
+	// any. Path.LogicalName() is the canonical Pulumi component name.
+	Path    modulepath.Path
 	EvalCtx *eval.Context        // per-instance evaluation context
 	URN     string               // component URN
 	Index   *int                 // count index (nil if not using count)
@@ -176,6 +180,24 @@ type moduleInstance struct {
 	EachVal *cty.Value           // for_each value (nil if not using for_each)
 	mu      sync.Mutex           // protects Outputs
 	Outputs map[string]cty.Value // collected output values
+}
+
+// instancePath builds the path for one instance of a module call, replacing
+// the leaf step with one that carries the runtime disambiguator (count
+// index or for_each key, if any).
+func instancePath(modInfo *graph.ModuleInfo, index *int, eachKey *cty.Value) modulepath.Path {
+	parent, leaf, ok := modInfo.Path.Parent()
+	if !ok {
+		return modInfo.Path
+	}
+	switch {
+	case index != nil:
+		return parent.Append(modulepath.NewIndexedStep(leaf.Name(), *index))
+	case eachKey != nil:
+		return parent.Append(modulepath.NewKeyedStep(leaf.Name(), eachKey.AsString()))
+	default:
+		return modInfo.Path
+	}
 }
 
 // inheritableOpts holds the resource options that child resources can inherit from their parent.
@@ -637,7 +659,7 @@ func (e *Engine) processLocal(ctx context.Context, node *graph.Node) error {
 
 	if node.ModuleInfo != nil {
 		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			localName := strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix+"local.")
+			localName := strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix()+"local.")
 			val, diags := local.Value.Value(inst.EvalCtx.HCLContext())
 			if diags.HasErrors() {
 				return fmt.Errorf("evaluating local value %s: %s", localName, diags.Error())
@@ -707,7 +729,7 @@ func (e *Engine) registerProviderInContext(
 		logicalName = provider.Name
 	}
 	if modInst != nil {
-		modInstanceName := extractResourceName(modInst.Key)
+		modInstanceName := modInst.Path.LogicalName()
 		logicalName = modInstanceName + "-" + logicalName
 	}
 
@@ -737,7 +759,7 @@ func (e *Engine) registerProviderInContext(
 
 	if node.ModuleInfo != nil {
 		// Strip prefix for module-internal references
-		bareKey := strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix)
+		bareKey := strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix())
 		evalCtx.SetResource(bareKey, cty.ObjectVal(outputObj))
 	} else {
 		evalCtx.SetResource(node.Key, cty.ObjectVal(outputObj))
@@ -870,7 +892,7 @@ func (e *Engine) registerResourceInstanceInContext(
 			for _, dep := range eval.ExtractDependencies(expr) {
 				fullDep := dep
 				if node.ModuleInfo != nil {
-					fullDep = node.ModuleInfo.Prefix + dep
+					fullDep = node.ModuleInfo.Prefix() + dep
 				}
 				if resOutputs, ok := e.resourceOutputs.Get(fullDep); ok {
 					if urnVal := resOutputs.GetAttr("urn"); urnVal.Type() == cty.String {
@@ -970,17 +992,17 @@ func (e *Engine) registerResourceInstanceInContext(
 	if instance.Index != nil {
 		baseKey := instance.OriginalKey
 		if node.ModuleInfo != nil {
-			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix)
+			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
 		}
 		evalCtx.SetCountResource(baseKey, *instance.Index, cty.ObjectVal(outputObj))
 	} else if instance.EachKey != nil {
 		baseKey := instance.OriginalKey
 		if node.ModuleInfo != nil {
-			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix)
+			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
 		}
 		evalCtx.SetEachResource(baseKey, instance.EachKey.AsString(), cty.ObjectVal(outputObj))
 	} else if node.ModuleInfo != nil {
-		bareKey := strings.TrimPrefix(instance.Key, node.ModuleInfo.Prefix)
+		bareKey := strings.TrimPrefix(instance.Key, node.ModuleInfo.Prefix())
 		evalCtx.SetResource(bareKey, cty.ObjectVal(outputObj))
 	} else {
 		evalCtx.SetResource(instance.Key, cty.ObjectVal(outputObj))
@@ -1014,7 +1036,7 @@ func (e *Engine) buildResourceOptionsInContext(
 
 	resPrefix := ""
 	if modInfo != nil {
-		resPrefix = modInfo.Prefix
+		resPrefix = modInfo.Prefix()
 	}
 
 	for _, dep := range res.DependsOn {
@@ -1468,18 +1490,8 @@ func ExtractSemverFromConstraint(constraint string) string {
 func extractResourceName(key string) string {
 	baseKey, index, eachKey := graph.ParseInstanceKey(key)
 
-	// For module calls (possibly nested) the key looks like
-	// "module.outer.module.inner" — join the module names with hyphens to
-	// produce "outer-inner". For ordinary resources ("type.name") just strip
-	// the leading "type." prefix.
-	if strings.HasPrefix(baseKey, "module.") {
-		parts := strings.Split(baseKey, ".")
-		names := make([]string, 0, len(parts)/2)
-		for i := 0; i+1 < len(parts) && parts[i] == "module"; i += 2 {
-			names = append(names, parts[i+1])
-		}
-		baseKey = strings.Join(names, "-")
-	} else if _, after, ok := strings.Cut(baseKey, "."); ok {
+	// Strip the "type." prefix from the base key to get the logical name.
+	if _, after, ok := strings.Cut(baseKey, "."); ok {
 		baseKey = after
 	}
 
@@ -1504,11 +1516,11 @@ func (*Engine) extractModuleResourceName(
 	}
 
 	// Strip the module prefix to get the bare resource key (e.g., "simple_resource.name").
-	bareKey := strings.TrimPrefix(instanceKey, modInfo.Prefix)
+	bareKey := strings.TrimPrefix(instanceKey, modInfo.Prefix())
 	bareResourceName := extractResourceName(bareKey)
 
 	// Extract the module instance name (e.g., "many" or "many[0]").
-	modInstanceName := extractResourceName(modInst.Key)
+	modInstanceName := modInst.Path.LogicalName()
 
 	return modInstanceName + "-" + bareResourceName
 }
@@ -1648,7 +1660,7 @@ func (e *Engine) processDataSourceInContext(
 
 	dsKey := node.Key
 	if node.ModuleInfo != nil {
-		dsKey = strings.TrimPrefix(dsKey, node.ModuleInfo.Prefix)
+		dsKey = strings.TrimPrefix(dsKey, node.ModuleInfo.Prefix())
 	}
 	dsKey = strings.TrimPrefix(dsKey, "data.")
 
@@ -1780,7 +1792,7 @@ func (e *Engine) invokeDataSourceOnce(
 			for _, dep := range eval.ExtractDependencies(expr) {
 				fullDep := dep
 				if node.ModuleInfo != nil {
-					fullDep = node.ModuleInfo.Prefix + dep
+					fullDep = node.ModuleInfo.Prefix() + dep
 				}
 				if resOutputs, ok := e.resourceOutputs.Get(fullDep); ok {
 					if urnVal := resOutputs.GetAttr("urn"); urnVal.Type() == cty.String {
@@ -1841,7 +1853,7 @@ func (e *Engine) invokeDataSourceOnce(
 		}
 		fullDepKey := depKey
 		if node.ModuleInfo != nil {
-			fullDepKey = node.ModuleInfo.Prefix + depKey
+			fullDepKey = node.ModuleInfo.Prefix() + depKey
 		}
 		if outputs, ok := e.resourceOutputs.Get(fullDepKey); ok {
 			urnVal := outputs.GetAttr("urn")
@@ -2097,11 +2109,11 @@ func (a *moduleLoaderAdapter) LoadModule(source, workDir string) (*graph.LoadedM
 	}, nil
 }
 
-// forEachModuleInstance iterates over all instances of the module identified by node.ModuleInfo.Prefix.
+// forEachModuleInstance iterates over all instances of the module identified by node.ModuleInfo.Prefix().
 func (e *Engine) forEachModuleInstance(node *graph.Node, fn func(inst *moduleInstance) error) error {
-	instances, ok := e.moduleInstances.Get(node.ModuleInfo.Prefix)
+	instances, ok := e.moduleInstances.Get(node.ModuleInfo.Prefix())
 	if !ok {
-		return fmt.Errorf("no module instances for prefix %q", node.ModuleInfo.Prefix)
+		return fmt.Errorf("no module instances for prefix %q", node.ModuleInfo.Prefix())
 	}
 	for _, inst := range instances {
 		if err := fn(inst); err != nil {
@@ -2116,7 +2128,7 @@ func (e *Engine) forEachModuleInstance(node *graph.Node, fn func(inst *moduleIns
 func (e *Engine) processModuleVariable(node *graph.Node) error {
 	v := node.Variable
 	modInfo := node.ModuleInfo
-	varName := strings.TrimPrefix(node.Key, modInfo.Prefix+"var.")
+	varName := strings.TrimPrefix(node.Key, modInfo.Prefix()+"var.")
 
 	moduleInputAttrs, _ := modInfo.Module.Config.JustAttributes()
 	inputAttr, hasInput := moduleInputAttrs[varName]
@@ -2125,8 +2137,8 @@ func (e *Engine) processModuleVariable(node *graph.Node) error {
 	// the root evaluator context; for nested modules it is the enclosing module
 	// instance's context so that expressions like var.name resolve correctly.
 	parentEvalCtx := e.evaluator.Context()
-	if modInfo.ParentPrefix != "" {
-		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPrefix)
+	if modInfo.ParentPrefix() != "" {
+		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPrefix())
 		if ok && len(parentInstances) > 0 {
 			parentEvalCtx = parentInstances[0].EvalCtx
 		}
@@ -2187,15 +2199,13 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 	parentEvalCtx := e.evaluator.Context()
 
 	// If this is a nested module, look up the parent instance URN.
-	if modInfo.ParentPrefix != "" {
-		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPrefix)
+	if modInfo.ParentPrefix() != "" {
+		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPrefix())
 		if ok && len(parentInstances) > 0 {
 			parentURN = parentInstances[0].URN
 			parentEvalCtx = parentInstances[0].EvalCtx
 		}
 	}
-
-	baseKey := modInfo.ParentPrefix + "module." + modInfo.ModuleName
 
 	// Load the child module to get variable type constraints for input coercion.
 	childMod, err := e.moduleLoader.LoadModule(mod.Source, e.workDir)
@@ -2225,8 +2235,9 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 
 	// No count/for_each: single instance.
 	if mod.Count == nil && mod.ForEach == nil {
+		instPath := instancePath(modInfo, nil, nil)
 		componentOpts := &ResourceOptions{Parent: parentURN}
-		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, extractResourceName(baseKey), property.NewMap(inputs), componentOpts)
+		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instPath.LogicalName(), property.NewMap(inputs), componentOpts)
 		if err != nil {
 			return fmt.Errorf("registering module component: %w", err)
 		}
@@ -2236,8 +2247,8 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 			e.stackName, e.projectName, e.organization,
 		)
 
-		e.moduleInstances.Set(modInfo.Prefix, []*moduleInstance{{
-			Key:     baseKey,
+		e.moduleInstances.Set(modInfo.Prefix(), []*moduleInstance{{
+			Path:    instPath,
 			EvalCtx: instCtx,
 			URN:     componentURN,
 			Outputs: make(map[string]cty.Value),
@@ -2258,11 +2269,11 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 		var instances []*moduleInstance
 		for i := range count {
 			idx := int(i)
-			instKey := fmt.Sprintf("%s[%d]", baseKey, i)
+			instPath := instancePath(modInfo, &idx, nil)
 			componentOpts := &ResourceOptions{Parent: parentURN}
-			componentURN, _, _, err := e.registerComponentResource(ctx, componentType, extractResourceName(instKey), property.NewMap(inputs), componentOpts)
+			componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instPath.LogicalName(), property.NewMap(inputs), componentOpts)
 			if err != nil {
-				return fmt.Errorf("registering module component %s: %w", instKey, err)
+				return fmt.Errorf("registering module component %s: %w", instPath.String(), err)
 			}
 			instCtx := eval.NewContext(
 				modInfo.SourcePath, e.workDir,
@@ -2270,14 +2281,14 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 			)
 			instCtx.SetCount(idx)
 			instances = append(instances, &moduleInstance{
-				Key:     instKey,
+				Path:    instPath,
 				EvalCtx: instCtx,
 				URN:     componentURN,
 				Index:   &idx,
 				Outputs: make(map[string]cty.Value),
 			})
 		}
-		e.moduleInstances.Set(modInfo.Prefix, instances)
+		e.moduleInstances.Set(modInfo.Prefix(), instances)
 		return nil
 	}
 
@@ -2293,12 +2304,11 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 	it := forEachVal.ElementIterator()
 	for it.Next() {
 		k, v := it.Element()
-		keyStr := k.AsString()
-		instKey := fmt.Sprintf("%s[\"%s\"]", baseKey, keyStr)
+		instPath := instancePath(modInfo, nil, &k)
 		componentOpts := &ResourceOptions{Parent: parentURN}
-		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, extractResourceName(instKey), property.NewMap(inputs), componentOpts)
+		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instPath.LogicalName(), property.NewMap(inputs), componentOpts)
 		if err != nil {
-			return fmt.Errorf("registering module component %s: %w", instKey, err)
+			return fmt.Errorf("registering module component %s: %w", instPath.String(), err)
 		}
 		instCtx := eval.NewContext(
 			modInfo.SourcePath, e.workDir,
@@ -2306,7 +2316,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 		)
 		instCtx.SetEach(k, v)
 		instances = append(instances, &moduleInstance{
-			Key:     instKey,
+			Path:    instPath,
 			EvalCtx: instCtx,
 			URN:     componentURN,
 			EachKey: &k,
@@ -2314,7 +2324,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 			Outputs: make(map[string]cty.Value),
 		})
 	}
-	e.moduleInstances.Set(modInfo.Prefix, instances)
+	e.moduleInstances.Set(modInfo.Prefix(), instances)
 	return nil
 }
 
@@ -2322,7 +2332,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error {
 	output := node.Output
 	modInfo := node.ModuleInfo
-	outputName := strings.TrimPrefix(node.Key, modInfo.Prefix+"output.")
+	outputName := strings.TrimPrefix(node.Key, modInfo.Prefix()+"output.")
 	mod := modInfo.Module
 	isCounted := mod.Count != nil
 	isForEach := mod.ForEach != nil
@@ -2345,13 +2355,13 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 	// can reference them before the completion node runs. For nested modules,
 	// the parent context is the enclosing module instance's eval context.
 	parentCtx := e.evaluator.Context()
-	if modInfo.ParentPrefix != "" {
-		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPrefix)
+	if modInfo.ParentPrefix() != "" {
+		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPrefix())
 		if ok && len(parentInstances) > 0 {
 			parentCtx = parentInstances[0].EvalCtx
 		}
 	}
-	instances, ok := e.moduleInstances.Get(modInfo.Prefix)
+	instances, ok := e.moduleInstances.Get(modInfo.Prefix())
 	if !ok {
 		return nil
 	}
@@ -2363,7 +2373,7 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 			v, has := inst.Outputs[outputName]
 			inst.mu.Unlock()
 			if has {
-				parentCtx.SetModuleOutput(modInfo.ModuleName, outputName, v)
+				parentCtx.SetModuleOutput(modInfo.ModuleName(), outputName, v)
 			}
 		}
 	} else if isCounted {
@@ -2379,9 +2389,9 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 			inst.mu.Unlock()
 		}
 		if len(tupleVals) > 0 {
-			parentCtx.SetModule(modInfo.ModuleName, cty.TupleVal(tupleVals))
+			parentCtx.SetModule(modInfo.ModuleName(), cty.TupleVal(tupleVals))
 		} else {
-			parentCtx.SetModule(modInfo.ModuleName, cty.EmptyTupleVal)
+			parentCtx.SetModule(modInfo.ModuleName(), cty.EmptyTupleVal)
 		}
 	} else {
 		// ForEach: rebuild the map.
@@ -2400,9 +2410,9 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 			inst.mu.Unlock()
 		}
 		if len(mapVals) > 0 {
-			parentCtx.SetModule(modInfo.ModuleName, cty.ObjectVal(mapVals))
+			parentCtx.SetModule(modInfo.ModuleName(), cty.ObjectVal(mapVals))
 		} else {
-			parentCtx.SetModule(modInfo.ModuleName, cty.EmptyObjectVal)
+			parentCtx.SetModule(modInfo.ModuleName(), cty.EmptyObjectVal)
 		}
 	}
 
@@ -2417,9 +2427,9 @@ func (e *Engine) processModuleComplete(ctx context.Context, node *graph.Node) er
 		return fmt.Errorf("module completion node missing ModuleInfo")
 	}
 
-	instances, ok := e.moduleInstances.Get(modInfo.Prefix)
+	instances, ok := e.moduleInstances.Get(modInfo.Prefix())
 	if !ok {
-		return fmt.Errorf("no module instances for prefix %q", modInfo.Prefix)
+		return fmt.Errorf("no module instances for prefix %q", modInfo.Prefix())
 	}
 
 	mod := modInfo.Module
@@ -2445,8 +2455,8 @@ func (e *Engine) processModuleComplete(ctx context.Context, node *graph.Node) er
 	// Assemble module value in parent eval context. For nested modules, the
 	// parent context is the enclosing module instance's eval context.
 	parentCtx := e.evaluator.Context()
-	if modInfo.ParentPrefix != "" {
-		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPrefix)
+	if modInfo.ParentPrefix() != "" {
+		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPrefix())
 		if ok && len(parentInstances) > 0 {
 			parentCtx = parentInstances[0].EvalCtx
 		}
@@ -2456,7 +2466,7 @@ func (e *Engine) processModuleComplete(ctx context.Context, node *graph.Node) er
 		// Single instance: module.X is an object of outputs.
 		if len(instances) == 1 {
 			for k, v := range instances[0].Outputs {
-				parentCtx.SetModuleOutput(modInfo.ModuleName, k, v)
+				parentCtx.SetModuleOutput(modInfo.ModuleName(), k, v)
 			}
 		}
 	} else if isCounted {
@@ -2470,9 +2480,9 @@ func (e *Engine) processModuleComplete(ctx context.Context, node *graph.Node) er
 			}
 		}
 		if len(tupleVals) > 0 {
-			parentCtx.SetModule(modInfo.ModuleName, cty.TupleVal(tupleVals))
+			parentCtx.SetModule(modInfo.ModuleName(), cty.TupleVal(tupleVals))
 		} else {
-			parentCtx.SetModule(modInfo.ModuleName, cty.EmptyTupleVal)
+			parentCtx.SetModule(modInfo.ModuleName(), cty.EmptyTupleVal)
 		}
 	} else {
 		// ForEach: module.X is a map of key → output object.
@@ -2489,9 +2499,9 @@ func (e *Engine) processModuleComplete(ctx context.Context, node *graph.Node) er
 			}
 		}
 		if len(mapVals) > 0 {
-			parentCtx.SetModule(modInfo.ModuleName, cty.ObjectVal(mapVals))
+			parentCtx.SetModule(modInfo.ModuleName(), cty.ObjectVal(mapVals))
 		} else {
-			parentCtx.SetModule(modInfo.ModuleName, cty.EmptyObjectVal)
+			parentCtx.SetModule(modInfo.ModuleName(), cty.EmptyObjectVal)
 		}
 	}
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1468,8 +1468,18 @@ func ExtractSemverFromConstraint(constraint string) string {
 func extractResourceName(key string) string {
 	baseKey, index, eachKey := graph.ParseInstanceKey(key)
 
-	// Strip the "type." prefix from the base key to get the logical name.
-	if _, after, ok := strings.Cut(baseKey, "."); ok {
+	// For module calls (possibly nested) the key looks like
+	// "module.outer.module.inner" — join the module names with hyphens to
+	// produce "outer-inner". For ordinary resources ("type.name") just strip
+	// the leading "type." prefix.
+	if strings.HasPrefix(baseKey, "module.") {
+		parts := strings.Split(baseKey, ".")
+		names := make([]string, 0, len(parts)/2)
+		for i := 0; i+1 < len(parts) && parts[i] == "module"; i += 2 {
+			names = append(names, parts[i+1])
+		}
+		baseKey = strings.Join(names, "-")
+	} else if _, after, ok := strings.Cut(baseKey, "."); ok {
 		baseKey = after
 	}
 

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -1491,6 +1491,83 @@ output "vpc_id" {
 	}
 }
 
+// TestEngine_ModuleNameWithDot verifies that module names containing a "."
+// are preserved verbatim when computing the component's logical resource name,
+// rather than being split apart by dot-based key parsing.
+func TestEngine_ModuleNameWithDot(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	moduleDir := tmpDir + "/modules/vpc"
+	require.NoError(t, os.MkdirAll(moduleDir, 0755))
+
+	moduleMain := `
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+`
+	require.NoError(t, os.WriteFile(moduleDir+"/main.hcl", []byte(moduleMain), 0644))
+
+	rootMain := `
+module "vpc.primary" {
+  source = "./modules/vpc"
+}
+`
+	require.NoError(t, os.WriteFile(tmpDir+"/main.hcl", []byte(rootMain), 0644))
+
+	p := parser.NewParser()
+	config, diags := p.ParseDirectory(tmpDir)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &mockResourceMonitor{}
+	engine := NewEngine(config, &EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         tmpDir,
+		RootDir:         tmpDir,
+		SchemaLoader: newMockReferenceLoader(t, schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:index:Vpc": {
+					InputProperties: map[string]schema.PropertySpec{
+						"cidrBlock": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"cidrBlock": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var moduleComponent *RegisterResourceRequest
+	for i := range mock.registeredResources {
+		if strings.HasPrefix(mock.registeredResources[i].Type, "components:index:") {
+			moduleComponent = &mock.registeredResources[i]
+			break
+		}
+	}
+	require.NotNil(t, moduleComponent, "expected module component to be registered")
+
+	assert.Equal(t, "vpc.primary", moduleComponent.Name)
+
+	var vpcResource *RegisterResourceRequest
+	for i := range mock.registeredResources {
+		if mock.registeredResources[i].Type == "aws:index:Vpc" {
+			vpcResource = &mock.registeredResources[i]
+			break
+		}
+	}
+	require.NotNil(t, vpcResource, "expected aws:index:Vpc resource to be registered")
+	assert.Equal(t, "vpc.primary-main", vpcResource.Name)
+}
+
 // TestEngine_ModuleOutputRace verifies that concurrent processing of multiple
 // module outputs does not trigger a data race on moduleInstance.Outputs.
 // This is a regression test for https://github.com/pulumi-labs/pulumi-hcl/issues/60.

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -1568,6 +1568,120 @@ module "vpc.primary" {
 	assert.Equal(t, "vpc.primary-main", vpcResource.Name)
 }
 
+// runSensitiveMetaArgTest is a shared driver for the four "sensitive value
+// rejected by count/for_each" tests. It writes the given root.hcl into a
+// temp dir, runs the engine, and returns the resulting error.
+func runSensitiveMetaArgTest(t *testing.T, rootMain string) error {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	moduleDir := tmpDir + "/modules/m"
+	require.NoError(t, os.MkdirAll(moduleDir, 0755))
+	require.NoError(t, os.WriteFile(moduleDir+"/main.hcl", []byte(`
+output "name" { value = "leaf" }
+`), 0644))
+	require.NoError(t, os.WriteFile(tmpDir+"/main.hcl", []byte(rootMain), 0644))
+
+	p := parser.NewParser()
+	config, diags := p.ParseDirectory(tmpDir)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &mockResourceMonitor{}
+	engine := NewEngine(config, &EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         tmpDir,
+		RootDir:         tmpDir,
+		SchemaLoader: newMockReferenceLoader(t, schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:index:Vpc": {
+					InputProperties: map[string]schema.PropertySpec{
+						"cidrBlock": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"cidrBlock": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	return engine.Run(t.Context())
+}
+
+// assertSensitiveArgumentError asserts that err is the specific diagnostic
+// emitted when a sensitive value is supplied to a meta-argument.
+func assertSensitiveArgumentError(t *testing.T, argName string, err error) {
+	t.Helper()
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "Invalid "+argName+" argument")
+	assert.Contains(t, msg,
+		"Sensitive values, or values derived from sensitive values, "+
+			"cannot be used as "+argName+" arguments.")
+}
+
+// TestEngine_ModuleForEachSensitive verifies that supplying a sensitive
+// value to a module's `for_each` produces a clean Terraform-style error
+// rather than expanding the module with a leaked secret in the URN.
+func TestEngine_ModuleForEachSensitive(t *testing.T) {
+	t.Parallel()
+
+	err := runSensitiveMetaArgTest(t, `
+module "m" {
+  source   = "./modules/m"
+  for_each = sensitive(toset(["a", "b"]))
+}
+`)
+	assertSensitiveArgumentError(t, "for_each", err)
+}
+
+// TestEngine_ModuleCountSensitive verifies the same behavior for module
+// `count`.
+func TestEngine_ModuleCountSensitive(t *testing.T) {
+	t.Parallel()
+
+	err := runSensitiveMetaArgTest(t, `
+module "m" {
+  source = "./modules/m"
+  count  = sensitive(2)
+}
+`)
+	assertSensitiveArgumentError(t, "count", err)
+}
+
+// TestEngine_ResourceForEachSensitive verifies the same behavior for a
+// resource's `for_each` (handled via [eval.EvaluateForEach]).
+func TestEngine_ResourceForEachSensitive(t *testing.T) {
+	t.Parallel()
+
+	err := runSensitiveMetaArgTest(t, `
+resource "aws_vpc" "v" {
+  for_each   = sensitive(toset(["a"]))
+  cidr_block = "10.0.0.0/16"
+}
+`)
+	assertSensitiveArgumentError(t, "for_each", err)
+}
+
+// TestEngine_ResourceCountSensitive verifies the same behavior for a
+// resource's `count`.
+func TestEngine_ResourceCountSensitive(t *testing.T) {
+	t.Parallel()
+
+	err := runSensitiveMetaArgTest(t, `
+resource "aws_vpc" "v" {
+  count      = sensitive(1)
+  cidr_block = "10.0.0.0/16"
+}
+`)
+	assertSensitiveArgumentError(t, "count", err)
+}
+
 // TestEngine_ModuleOutputRace verifies that concurrent processing of multiple
 // module outputs does not trigger a data race on moduleInstance.Outputs.
 // This is a regression test for https://github.com/pulumi-labs/pulumi-hcl/issues/60.

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -40,8 +40,6 @@ import (
 	"github.com/zclconf/go-cty/cty/convert"
 )
 
-const SensativeMark = "sensitive"
-
 var resourceRefCapsuleType = cty.Capsule("resource_reference", reflect.TypeFor[property.ResourceReference]())
 
 // EvalFunc evaluates an HCL expression.
@@ -467,7 +465,7 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, already
 	if val.IsMarked() {
 		var marks cty.ValueMarks
 		val, marks = val.Unmark()
-		if _, isSensitive := marks[SensativeMark]; isSensitive && !alreadyInSecret {
+		if _, isSensitive := marks[eval.SensitiveMark]; isSensitive && !alreadyInSecret {
 			v, err := ctyToResourceProperty(path, val, prop, true)
 			return v.WithSecret(true), err
 		}
@@ -644,7 +642,7 @@ func ctyToPropertyValue(val cty.Value) (property.Value, error) {
 	// Handle sensitive-marked values by unwrapping, converting, and wrapping as secret.
 	if val.IsMarked() {
 		unmarked, marks := val.Unmark()
-		_, isSensitive := marks[SensativeMark]
+		_, isSensitive := marks[eval.SensitiveMark]
 		pv, err := ctyToPropertyValue(unmarked)
 		return pv.WithSecret(isSensitive), err
 	}
@@ -879,7 +877,7 @@ func propertyValueToCty(path string, v property.Value, typ schema.Type, dryRun b
 	typ = codegen.UnwrapType(typ)
 	if v.Secret() {
 		computedV, err := propertyValueToCty(path, v.WithSecret(false), typ, dryRun)
-		return computedV.Mark(SensativeMark), err
+		return computedV.Mark(eval.SensitiveMark), err
 	}
 
 	switch {
@@ -1006,7 +1004,7 @@ func PropertyValueToCty(pv property.Value) cty.Value {
 
 	if pv.Secret() {
 		return PropertyValueToCty(pv.WithSecret(false)).
-			WithMarks(cty.NewValueMarks(SensativeMark))
+			WithMarks(cty.NewValueMarks(eval.SensitiveMark))
 	}
 
 	if pv.IsNull() {


### PR DESCRIPTION
This PR fixes how module paths are handled, correcting the behavior to fix "l3-component-nested", then hardening how paths are stored to allow module paths to contain resource names like "foo.bar" (which are valid). 