### PR TITLE
Make `provider = <expr>` accept arbitrary expressions

### DIFF
--- a/.changes/unreleased/runtime-Improvements-114.yaml
+++ b/.changes/unreleased/runtime-Improvements-114.yaml
@@ -1,0 +1,6 @@
+component: runtime
+kind: Improvements
+body: Allow `provider` to be an arbitrary expression
+time: 2026-05-06T13:43:44.165321+02:00
+custom:
+    PR: "114"

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -133,10 +133,9 @@ var expectedFailures = map[string]string{
 	"l2-plain": "unsupported in HCL:" +
 		" requires that HCL can distinguish between an empty and null List<Object>" +
 		" - not compatible with block syntax",
-	"l2-resource-option-hooks":         "PCL pcl.Hook nodes not yet supported by HCL codegen",
-	"l2-resource-read":                 "PCL pcl.ReadResource nodes not yet supported by HCL codegen",
-	"l2-component-call-plain":          "component method calls (call.<resource>) not yet supported by the HCL runtime engine",
-	"provider-builtin-info-component":  "missing testdata/providers/builtin-info-component fixture",
+	"l2-resource-option-hooks":        "PCL pcl.Hook nodes not yet supported by HCL codegen",
+	"l2-resource-read":                "PCL pcl.ReadResource nodes not yet supported by HCL codegen",
+	"provider-builtin-info-component": "missing testdata/providers/builtin-info-component fixture",
 }
 
 // expectedEjectFailures lists tests whose eject (HCL→PCL conversion) step is

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-component-call-plain/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-component-call-plain/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-component-call-plain
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-component-call-plain/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-component-call-plain/main.pp
@@ -1,0 +1,26 @@
+resource "configurer" "configurer:index:Configurer" {
+  providerConfig = "propagated"
+}
+
+resource "customFromPlainProvider" "configurer:index:Custom" {
+  value = "from-plain-provider"
+  options {
+    provider = call(configurer, "plainProvider", {})
+  }
+}
+
+resource "customFromNestedPlainProvider" "configurer:index:Custom" {
+  value = "from-nested-plain-provider"
+  options {
+    provider = call(configurer, "nestedPlainProvider", {}).provider
+  }
+}
+
+output "plainValue" {
+  value = call(configurer, "plainValue", {})
+}
+
+output "nestedPlainValue" {
+  value = call(configurer, "nestedPlainProvider", {}).value
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-component-call-plain/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-component-call-plain/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-component-call-plain
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-component-call-plain/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-component-call-plain/main.hcl
@@ -1,0 +1,33 @@
+pulumi {
+  required_providers {
+    configurer = {
+      source  = "pulumi/configurer"
+      version = "38.0.0"
+    }
+  }
+}
+
+call "configurer" "plain_provider" {
+}
+call "configurer" "nested_plain_provider" {
+}
+call "configurer" "plain_value" {
+}
+
+resource "configurer_configurer" "configurer" {
+  provider_config = "propagated"
+}
+resource "configurer_custom" "customFromPlainProvider" {
+  provider = call.configurer.plain_provider
+  value    = "from-plain-provider"
+}
+resource "configurer_custom" "customFromNestedPlainProvider" {
+  provider = call.configurer.nested_plain_provider.provider
+  value    = "from-nested-plain-provider"
+}
+output "plainValue" {
+  value = call.configurer.plain_value
+}
+output "nestedPlainValue" {
+  value = call.configurer.nested_plain_provider.value
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-component-call-plain/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-component-call-plain/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-component-call-plain
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-component-call-plain/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-component-call-plain/main.hcl
@@ -1,0 +1,33 @@
+pulumi {
+  required_providers {
+    configurer = {
+      source  = "pulumi/configurer"
+      version = "38.0.0"
+    }
+  }
+}
+
+call "configurer" "plain_provider" {
+}
+call "configurer" "nested_plain_provider" {
+}
+call "configurer" "plain_value" {
+}
+
+resource "configurer_configurer" "configurer" {
+  provider_config = "propagated"
+}
+resource "configurer_custom" "customFromPlainProvider" {
+  provider = call.configurer.plain_provider
+  value    = "from-plain-provider"
+}
+resource "configurer_custom" "customFromNestedPlainProvider" {
+  provider = call.configurer.nested_plain_provider.provider
+  value    = "from-nested-plain-provider"
+}
+output "plainValue" {
+  value = call.configurer.plain_value
+}
+output "nestedPlainValue" {
+  value = call.configurer.nested_plain_provider.value
+}

--- a/cmd/pulumi-language-hcl/testdata/sdks/configurer-38.0.0/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/sdks/configurer-38.0.0/hcl.sdk.json
@@ -1,0 +1,8 @@
+{
+  "Name": "configurer",
+  "Kind": "resource",
+  "Version": "38.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null
+}

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -667,6 +667,22 @@ func (g *generator) collectCalls(node pcl.Node) {
 		for _, attr := range n.Inputs {
 			g.collectCallsInExpr(attr.Value, srcFile)
 		}
+		if n.Options != nil {
+			for _, expr := range []model.Expression{
+				n.Options.Aliases, n.Options.Range, n.Options.Parent,
+				n.Options.Provider, n.Options.Providers, n.Options.DependsOn,
+				n.Options.Protect, n.Options.RetainOnDelete, n.Options.IgnoreChanges,
+				n.Options.HideDiffs, n.Options.ReplaceOnChanges, n.Options.DeleteBeforeReplace,
+				n.Options.AdditionalSecretOutputs, n.Options.Version, n.Options.CustomTimeouts,
+				n.Options.PluginDownloadURL, n.Options.DeletedWith, n.Options.ReplaceWith,
+				n.Options.ImportID, n.Options.ReplacementTrigger, n.Options.EnvVarMappings,
+				n.Options.Hooks,
+			} {
+				if expr != nil {
+					g.collectCallsInExpr(expr, srcFile)
+				}
+			}
+		}
 	case *pcl.OutputVariable:
 		g.collectCallsInExpr(n.Value, srcFile)
 	case *pcl.LocalVariable:

--- a/pkg/hcl/ast/import.go
+++ b/pkg/hcl/ast/import.go
@@ -35,8 +35,9 @@ type Import struct {
 	// Id is the external resource ID to import.
 	Id string
 
-	// Provider is an optional provider reference for this import.
-	Provider *ProviderRef
+	// Provider is the raw expression from the optional `provider` attribute.
+	// It is evaluated at runtime; the resulting value supplies the provider URN/ID.
+	Provider hcl.Expression
 
 	// DeclRange is the source range of the import block.
 	DeclRange hcl.Range

--- a/pkg/hcl/ast/module.go
+++ b/pkg/hcl/ast/module.go
@@ -64,8 +64,9 @@ type Module struct {
 	// DependsOn contains explicit dependencies from the depends_on meta-argument.
 	DependsOn []hcl.Traversal
 
-	// Providers maps provider names to provider references for passing to the module.
-	Providers map[string]*ProviderRef
+	// Providers maps provider names to raw expressions for passing to the module.
+	// Each expression is evaluated at runtime to obtain the provider URN/ID.
+	Providers map[string]hcl.Expression
 
 	// DeclRange is the source range of the module block.
 	DeclRange hcl.Range

--- a/pkg/hcl/ast/resource.go
+++ b/pkg/hcl/ast/resource.go
@@ -71,8 +71,9 @@ type Resource struct {
 	// DependsOn contains explicit dependencies from the depends_on meta-argument.
 	DependsOn []hcl.Traversal
 
-	// Provider is the provider configuration reference, if specified.
-	Provider *ProviderRef
+	// Provider is the raw expression from the `provider` attribute, if specified.
+	// It is evaluated at runtime; the resulting value supplies the provider URN/ID.
+	Provider hcl.Expression
 
 	// Providers is a list of explicit provider resources to pass to a component resource.
 	// Only valid for component resources.
@@ -147,18 +148,6 @@ type Resource struct {
 
 	// IsDataSource indicates if this is a data source (data block) vs managed resource.
 	IsDataSource bool
-}
-
-// ProviderRef is a reference to a provider configuration.
-type ProviderRef struct {
-	// Name is the provider local name (e.g., "aws").
-	Name string
-
-	// Alias is the provider alias, if specified (e.g., "west" in "aws.west").
-	Alias string
-
-	// Range is the source range of the provider reference.
-	Range hcl.Range
 }
 
 // Lifecycle contains lifecycle configuration for a resource.

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
@@ -54,11 +55,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// AssetCapsuleType is the cty capsule type for Pulumi assets.
-var AssetCapsuleType = cty.Capsule("Asset", reflect.TypeFor[asset.Asset]())
+var (
+	// AssetCapsuleType is the cty capsule type for Pulumi assets.
+	AssetCapsuleType = cty.Capsule("Asset", reflect.TypeFor[asset.Asset]())
 
-// ArchiveCapsuleType is the cty capsule type for Pulumi archives.
-var ArchiveCapsuleType = cty.Capsule("Archive", reflect.TypeFor[archive.Archive]())
+	// ArchiveCapsuleType is the cty capsule type for Pulumi archives.
+	ArchiveCapsuleType = cty.Capsule("Archive", reflect.TypeFor[archive.Archive]())
+
+	// ResourceReferenceCapsuleType is the cty capsule type for Pulumi resource references.
+	ResourceReferenceCapsuleType = cty.Capsule("ResourceReference", reflect.TypeFor[property.ResourceReference]())
+)
 
 // Functions returns a map of all Terraform-compatible functions.
 func Functions(baseDir string) map[string]function.Function {

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -370,13 +370,8 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node 
 			seen[idx] = true
 		}
 	}
-	if resource.Provider != nil {
-		providerKey := resource.Provider.Name
-		if resource.Provider.Alias != "" {
-			providerKey = resource.Provider.Name + "." + resource.Provider.Alias
-		}
-		_, idx := g.newNode(prefix + providerKey)
-		seen[idx] = true
+	for _, dep := range g.exprDeps(resource.Provider, prefix) {
+		seen[dep] = true
 	}
 	for _, traversal := range resource.Providers {
 		if dep := formatTraversal(traversal); dep != "" {

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -539,9 +539,7 @@ func (p *Parser) parseResourceBlock(config *ast.Config, block *hcl.Block, isData
 	}
 
 	if attr, ok := content.Attributes["provider"]; ok {
-		providerRef, refDiags := p.parseProviderRef(attr.Expr)
-		diags = append(diags, refDiags...)
-		resource.Provider = providerRef
+		resource.Provider = attr.Expr
 	}
 
 	if attr, ok := content.Attributes["providers"]; ok {
@@ -686,30 +684,6 @@ func (p *Parser) parseResourceBlock(config *ast.Config, block *hcl.Block, isData
 
 	targetMap[key] = resource
 	return diags
-}
-
-// parseProviderRef parses a provider reference expression.
-func (p *Parser) parseProviderRef(expr hcl.Expression) (*ast.ProviderRef, hcl.Diagnostics) {
-	traversal, diags := hcl.AbsTraversalForExpr(expr)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	ref := &ast.ProviderRef{
-		Range: expr.Range(),
-	}
-
-	if len(traversal) >= 1 {
-		ref.Name = traversal.RootName()
-	}
-
-	if len(traversal) >= 2 {
-		if step, ok := traversal[1].(hcl.TraverseAttr); ok {
-			ref.Alias = step.Name
-		}
-	}
-
-	return ref, diags
 }
 
 // lifecycleResult contains the parsed lifecycle block plus any preconditions/postconditions.
@@ -989,7 +963,7 @@ func (p *Parser) parseModuleBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	module := &ast.Module{
 		Name:      name,
 		Config:    remain,
-		Providers: make(map[string]*ast.ProviderRef),
+		Providers: make(map[string]hcl.Expression),
 		DeclRange: block.DefRange,
 	}
 
@@ -1041,11 +1015,7 @@ func (p *Parser) parseModuleBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 			}
 			key := keyVal.AsString()
 
-			ref, refDiags := p.parseProviderRef(pair.Value)
-			diags = append(diags, refDiags...)
-			if ref != nil {
-				module.Providers[key] = ref
-			}
+			module.Providers[key] = pair.Value
 		}
 	}
 
@@ -1133,9 +1103,7 @@ func (p *Parser) parseImportBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	}
 
 	if attr, ok := content.Attributes["provider"]; ok {
-		ref, refDiags := p.parseProviderRef(attr.Expr)
-		diags = append(diags, refDiags...)
-		imp.Provider = ref
+		imp.Provider = attr.Expr
 	}
 
 	config.Imports = append(config.Imports, imp)

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1111,17 +1111,15 @@ func (e *Engine) buildResourceOptionsInContext(
 	}
 
 	if res.Provider != nil {
-		providerKey := res.Provider.Name
-		if res.Provider.Alias != "" {
-			providerKey = res.Provider.Name + "." + res.Provider.Alias
+		val, valDiags := e.evaluator.EvaluateExpression(res.Provider)
+		if valDiags.HasErrors() {
+			return nil, fmt.Errorf("evaluating provider for %s.%s: %s", res.Type, res.Name, valDiags.Error())
 		}
-		if providerOutputs, ok := e.resourceOutputs.Get(resPrefix + providerKey); ok {
-			urnVal := providerOutputs.GetAttr("urn")
-			idVal := providerOutputs.GetAttr("id")
-			if urnVal.Type() == cty.String && idVal.Type() == cty.String {
-				opts.Provider = urnVal.AsString() + "::" + idVal.AsString()
-			}
+		ref, err := providerRefFromCty(val)
+		if err != nil {
+			return nil, fmt.Errorf("resolving provider for %s.%s: %w", res.Type, res.Name, err)
 		}
+		opts.Provider = ref
 	}
 
 	for _, traversal := range res.Providers {
@@ -1823,17 +1821,15 @@ func (e *Engine) invokeDataSourceOnce(
 	}
 
 	if ds.Provider != nil {
-		providerKey := ds.Provider.Name
-		if ds.Provider.Alias != "" {
-			providerKey = ds.Provider.Name + "." + ds.Provider.Alias
+		val, valDiags := e.evaluator.EvaluateExpression(ds.Provider)
+		if valDiags.HasErrors() {
+			return cty.NilVal, nil, fmt.Errorf("evaluating provider for data %s.%s: %s", ds.Type, ds.Name, valDiags.Error())
 		}
-		if providerOutputs, ok := e.resourceOutputs.Get(providerKey); ok {
-			urnVal := providerOutputs.GetAttr("urn")
-			idVal := providerOutputs.GetAttr("id")
-			if urnVal.Type() == cty.String && idVal.Type() == cty.String {
-				invokeReq.Provider = urnVal.AsString() + "::" + idVal.AsString()
-			}
+		ref, err := providerRefFromCty(val)
+		if err != nil {
+			return cty.NilVal, nil, fmt.Errorf("resolving provider for data %s.%s: %w", ds.Type, ds.Name, err)
 		}
+		invokeReq.Provider = ref
 	}
 
 	if ds.Version != nil {
@@ -2589,6 +2585,51 @@ func (e *Engine) processOutput(_ context.Context, name string, output *ast.Outpu
 	e.stackOutputs[name] = pv
 
 	return nil
+}
+
+// providerRefFromCty extracts a "<urn>::<id>" provider reference from an evaluated
+// `provider` attribute value.
+//
+// The value must be one of:
+//   - a resource-outputs object with direct `urn` and `id` string attributes
+//     (provider blocks like `aws.west` or pulumi_providers_* resources), or
+//   - an object carrying an `__ref` ResourceReference capsule (e.g., the result
+//     of a `call.<resource>.<method>` that returns a provider).
+func providerRefFromCty(val cty.Value) (string, error) {
+	if !val.IsKnown() {
+		return "", errors.New("provider value is not yet known")
+	}
+	if val.IsNull() {
+		return "", errors.New("provider value is null")
+	}
+	if !val.Type().IsObjectType() {
+		return "", fmt.Errorf("provider value must be an object, got %s", val.Type().FriendlyName())
+	}
+	if val.Type().HasAttribute("__ref") {
+		refVal := val.GetAttr("__ref")
+		if refVal.Type() != eval.ResourceReferenceCapsuleType {
+			return "", fmt.Errorf("provider value has __ref of unexpected type %s", refVal.Type().FriendlyName())
+		}
+		if refVal.IsNull() {
+			return "", errors.New("provider value has null __ref")
+		}
+		ref := refVal.EncapsulatedValue().(*property.ResourceReference)
+		id := ""
+		if ref.ID.IsString() {
+			id = ref.ID.AsString()
+		}
+		return string(ref.URN) + "::" + id, nil
+	}
+	if val.Type().HasAttribute("urn") && val.Type().HasAttribute("id") {
+		urnVal := val.GetAttr("urn")
+		idVal := val.GetAttr("id")
+		if urnVal.Type() != cty.String || idVal.Type() != cty.String {
+			return "", fmt.Errorf("provider value urn/id must be strings, got urn=%s id=%s",
+				urnVal.Type().FriendlyName(), idVal.Type().FriendlyName())
+		}
+		return urnVal.AsString() + "::" + idVal.AsString(), nil
+	}
+	return "", errors.New("provider value is not a resource reference")
 }
 
 // camelToSnake converts a camelCase string to snake_case.

--- a/pkg/hcl/run/run_internal_test.go
+++ b/pkg/hcl/run/run_internal_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestProviderRefFromCty(t *testing.T) {
+	t.Parallel()
+
+	providerOutputs := cty.ObjectVal(map[string]cty.Value{
+		"urn": cty.StringVal("urn:pulumi:dev::p::pulumi:providers:aws::aws-west"),
+		"id":  cty.StringVal("provider-id-123"),
+	})
+
+	ref := property.ResourceReference{
+		URN: resource.URN("urn:pulumi:dev::p::pulumi:providers:aws::aws-west"),
+		ID:  property.New("provider-id-123"),
+	}
+	callResult := cty.ObjectVal(map[string]cty.Value{
+		"__ref": cty.CapsuleVal(eval.ResourceReferenceCapsuleType, &ref),
+	})
+
+	nonProviderResource := cty.ObjectVal(map[string]cty.Value{
+		"name": cty.StringVal("my-bucket"),
+		"tags": cty.MapValEmpty(cty.String),
+	})
+
+	tests := []struct {
+		name    string
+		val     cty.Value
+		want    string
+		wantErr string
+	}{
+		{
+			name: "provider resource outputs",
+			val:  providerOutputs,
+			want: "urn:pulumi:dev::p::pulumi:providers:aws::aws-west::provider-id-123",
+		},
+		{
+			name: "call result with __ref",
+			val:  callResult,
+			want: "urn:pulumi:dev::p::pulumi:providers:aws::aws-west::provider-id-123",
+		},
+		{
+			name:    "string value",
+			val:     cty.StringVal("aws.west"),
+			wantErr: "provider value must be an object, got string",
+		},
+		{
+			name:    "non-provider resource (object without urn/id or __ref)",
+			val:     nonProviderResource,
+			wantErr: "provider value is not a resource reference",
+		},
+		{
+			name:    "null value",
+			val:     cty.NullVal(cty.DynamicPseudoType),
+			wantErr: "provider value is null",
+		},
+		{
+			name:    "unknown value",
+			val:     cty.UnknownVal(cty.DynamicPseudoType),
+			wantErr: "provider value is not yet known",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := providerRefFromCty(tt.val)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -39,8 +38,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 )
-
-var resourceRefCapsuleType = cty.Capsule("resource_reference", reflect.TypeFor[property.ResourceReference]())
 
 // EvalFunc evaluates an HCL expression.
 //
@@ -854,7 +851,7 @@ func ctyTypeFromType(typ schema.Type) cty.Type {
 		if typ.Resource == nil {
 			return cty.DynamicPseudoType
 		}
-		attrs := map[string]cty.Type{"__ref": resourceRefCapsuleType}
+		attrs := map[string]cty.Type{"__ref": eval.ResourceReferenceCapsuleType}
 		optional := []string{"__ref"}
 		for _, p := range typ.Resource.Properties {
 			key := snakeCaseFromCamelCase(p.Name)
@@ -920,7 +917,7 @@ func propertyValueToCty(path string, v property.Value, typ schema.Type, dryRun b
 			}
 			if refVal, ok := v.AsMap().GetOk("__ref"); ok && refVal.IsResourceReference() {
 				ref := refVal.AsResourceReference()
-				result["__ref"] = cty.CapsuleVal(resourceRefCapsuleType, &ref)
+				result["__ref"] = cty.CapsuleVal(eval.ResourceReferenceCapsuleType, &ref)
 			}
 			return cty.ObjectVal(result), nil
 		case *schema.ObjectType:
@@ -995,7 +992,7 @@ func propertyValueToCty(path string, v property.Value, typ schema.Type, dryRun b
 		if err != nil {
 			return cty.Value{}, err
 		}
-		result["__ref"] = cty.CapsuleVal(resourceRefCapsuleType, &ref)
+		result["__ref"] = cty.CapsuleVal(eval.ResourceReferenceCapsuleType, &ref)
 		return cty.ObjectVal(result), nil
 
 	case v.IsAsset():


### PR DESCRIPTION
This enables dynamic provider references, like those used in "l2-component-call-plain", unblocking that test.