### PR TITLE
Revert the Go version to 1.25

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.1"
+go = "1.25.9"
 gofumpt = "latest"
 golangci-lint = "2.9.0"
 jq = "latest"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi-labs/pulumi-hcl
 
-go 1.26
+go 1.25.9
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+func ptr[T any](v T) *T { return &v }
+
 func TestBuildFromConfig(t *testing.T) {
 	src := []byte(`
 variable "name" {
@@ -191,22 +193,22 @@ func TestParseInstanceKey(t *testing.T) {
 		{
 			input:     "aws_instance.web[0]",
 			wantBase:  "aws_instance.web",
-			wantIndex: new(0),
+			wantIndex: ptr(0),
 		},
 		{
 			input:     "aws_instance.web[42]",
 			wantBase:  "aws_instance.web",
-			wantIndex: new(42),
+			wantIndex: ptr(42),
 		},
 		{
 			input:       `aws_instance.web["a"]`,
 			wantBase:    "aws_instance.web",
-			wantEachKey: new("a"),
+			wantEachKey: ptr("a"),
 		},
 		{
 			input:       `aws_instance.web["my-key"]`,
 			wantBase:    "aws_instance.web",
-			wantEachKey: new("my-key"),
+			wantEachKey: ptr("my-key"),
 		},
 	}
 

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -714,7 +714,7 @@ func (p *Parser) parseLifecycleBlock(block *hcl.Block) (*lifecycleResult, hcl.Di
 		val, valDiags := attr.Expr.Value(nil)
 		diags = append(diags, valDiags...)
 		if val.Type() == cty.Bool {
-			lifecycle.PreventDestroy = new(val.True())
+			lifecycle.PreventDestroy = ptr(val.True())
 		}
 	}
 
@@ -1109,3 +1109,5 @@ func (p *Parser) parseImportBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	config.Imports = append(config.Imports, imp)
 	return diags
 }
+
+func ptr[T any](v T) *T { return &v }

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -988,7 +988,7 @@ func (e *Engine) registerResourceInstanceInContext(
 
 	var iOpts inheritableOpts
 	if opts.Protect {
-		iOpts.Protect = new(true)
+		iOpts.Protect = ptr(true)
 	}
 	iOpts.RetainOnDelete = opts.RetainOnDelete
 	e.resourceInheritableOpts.Set(instance.Key, iOpts)
@@ -2757,3 +2757,5 @@ func (e *Engine) checkPulumiVersion(ctx context.Context) error {
 
 	return e.resmon.CheckPulumiVersion(ctx, versionRange)
 }
+
+func ptr[T any](v T) *T { return &v }

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -955,7 +955,7 @@ func propertyValueToCty(path string, v property.Value, typ schema.Type, dryRun b
 		var t *cty.Type
 		for _, v := range m {
 			if t == nil {
-				t = new(v.Type())
+				t = ptr(v.Type())
 			}
 			if !v.Type().Equals(*t) {
 				return cty.ObjectVal(m), nil
@@ -1110,3 +1110,5 @@ func MakeSecret(pv resource.PropertyValue) resource.PropertyValue {
 func MakeComputed(pv resource.PropertyValue) resource.PropertyValue {
 	return resource.MakeComputed(pv)
 }
+
+func ptr[T any](v T) *T { return &v }


### PR DESCRIPTION
This allows embedding in projects like
https://github.com/pulumi/pulumi-terraform-bridge, since that targets the minimal Go version.