### PR TITLE
codegen: failing repro for nil-Schema scope-traversal panic

### DIFF
--- a/pkg/codegen/generate_panic_test.go
+++ b/pkg/codegen/generate_panic_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateProgramNilResourceSchema asserts that GenerateProgram does not
+// panic when a *pcl.Resource referenced from a scope traversal expression has
+// a nil Schema field.
+//
+// pulumi/pulumi-terraform-bridge invokes pcl.BindProgram with relaxed options
+// (AllowMissingProperties, AllowMissingVariables, SkipResourceTypechecking)
+// while converting third-party Terraform docs.  Under those options the binder
+// can leave Resource.Schema unset.  scopeTraversalTokens (generate.go:2259)
+// dereferences part.Schema.Properties unconditionally, which crashes with
+// "invalid memory address or nil pointer dereference" on inputs the bridge
+// routinely produces.
+//
+// Stack from a failing CI run on the bridge:
+//
+//	github.com/pulumi-labs/pulumi-hcl/pkg/codegen.(*generator).scopeTraversalTokens
+//		/.../pkg/codegen/generate.go:2259
+//	github.com/pulumi-labs/pulumi-hcl/pkg/codegen.(*generator).exprTokens
+//		/.../pkg/codegen/generate.go:1748
+//	github.com/pulumi-labs/pulumi-hcl/pkg/codegen.(*generator).genExpression
+//		/.../pkg/codegen/generate.go:1633
+//	github.com/pulumi-labs/pulumi-hcl/pkg/codegen.(*generator).genOutput
+//		/.../pkg/codegen/generate.go:1535
+//	github.com/pulumi-labs/pulumi-hcl/pkg/codegen.GenerateProgram
+//		/.../pkg/codegen/generate.go:131
+func TestGenerateProgramNilResourceSchema(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+resource aResource "simple:index/resource:Resource" {
+    inputOne = "hello"
+}
+
+output someOutput {
+    value = aResource.result
+}
+`
+	parser := syntax.NewParser()
+	require.NoError(t, parser.ParseFile(strings.NewReader(src), "main.pp"))
+	require.False(t, parser.Diagnostics.HasErrors(), parser.Diagnostics.Error())
+
+	program, diags, err := pcl.BindProgram(parser.Files,
+		pcl.AllowMissingProperties,
+		pcl.AllowMissingVariables,
+		pcl.SkipResourceTypechecking,
+	)
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	require.NotPanics(t, func() {
+		_, _, err := GenerateProgram(program)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

Reproducer for a panic in `(*generator).scopeTraversalTokens` (generate.go:2259).

When a downstream consumer (in this case [pulumi/pulumi-terraform-bridge](https://github.com/pulumi/pulumi-terraform-bridge)) binds a PCL program with the relaxed options it uses for third-party Terraform docs:

\`\`\`go
pcl.AllowMissingProperties,
pcl.AllowMissingVariables,
pcl.SkipResourceTypechecking,
\`\`\`

a \`*pcl.Resource\` whose schema cannot be resolved comes through with \`Resource.Schema == nil\`. \`scopeTraversalTokens\`'s \`*pcl.Resource\` arm dereferences \`part.Schema.Properties\` unconditionally, which crashes with \"invalid memory address or nil pointer dereference\".

The same path that handles \`*pcl.LocalVariable\`-backed invokes already nil-checks \`res.Schema\` (see line 2140 in the same file). The \`*pcl.Resource\` arm should do the equivalent — at minimum, fall through with an unmodified traversal tail.

\`\`\`
github.com/pulumi-labs/pulumi-hcl/pkg/codegen.(*generator).scopeTraversalTokens
    /.../pkg/codegen/generate.go:2259
github.com/pulumi-labs/pulumi-hcl/pkg/codegen.(*generator).exprTokens
    /.../pkg/codegen/generate.go:1748
github.com/pulumi-labs/pulumi-hcl/pkg/codegen.(*generator).genExpression
    /.../pkg/codegen/generate.go:1633
github.com/pulumi-labs/pulumi-hcl/pkg/codegen.(*generator).genOutput
    /.../pkg/codegen/generate.go:1535
github.com/pulumi-labs/pulumi-hcl/pkg/codegen.GenerateProgram
    /.../pkg/codegen/generate.go:131
\`\`\`

The bridge had been working around this with a \`recover\` wrapper around \`GenerateProgram\` and dropping the offending example from generated docs. With #3436 we're attempting to remove that wrapper, and instead fix the upstream panics they were masking — starting with this one.

## Test plan
- [x] \`go test -run TestGenerateProgramNilResourceSchema ./pkg/codegen/\` fails with the panic on this commit.
- [ ] Same test passes once \`scopeTraversalTokens\`'s \`*pcl.Resource\` arm guards \`part.Schema == nil\`.