### PR TITLE
Avoid nil-pointer panic on resource scope traversal without schema

### DIFF
--- a/.changes/unreleased/codegen-bug-fixes-119.yaml
+++ b/.changes/unreleased/codegen-bug-fixes-119.yaml
@@ -1,0 +1,6 @@
+component: codegen
+kind: bug-fixes
+body: Avoid a nil-pointer panic in `GenerateProgram` when a resource scope traversal references a `pcl.Resource` whose schema was not populated (e.g. when the binder ran with `SkipResourceTypechecking`)
+time: 2026-05-08T18:37:49.844475+02:00
+custom:
+    PR: "119"

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -1203,6 +1203,48 @@ func TestNotImplemented(t *testing.T) {
 	})
 }
 
+// TestGenerateProgramSkipResourceTypechecking covers the program-generation path used by
+// pulumi/pulumi-terraform-bridge when converting third-party Terraform docs. The bridge
+// binds with AllowMissingProperties / AllowMissingVariables / SkipResourceTypechecking,
+// which can leave pcl.Resource.Schema unset (no schema is loaded for "simple:..." here).
+// scopeTraversalTokens used to dereference part.Schema.Properties unconditionally and
+// crashed with a nil-pointer panic on this input.
+func TestGenerateProgramSkipResourceTypechecking(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+resource aResource "simple:index/resource:Resource" {
+    inputOne = "hello"
+}
+
+output someOutput {
+    value = aResource.result
+}
+`
+	loader := schemaloader.New(t)
+
+	p := syntax.NewParser()
+	require.NoError(t, p.ParseFile(strings.NewReader(src), "main.pp"))
+	require.False(t, p.Diagnostics.HasErrors(), p.Diagnostics.Error())
+
+	program, bindDiags, err := pcl.BindProgram(p.Files,
+		pcl.Loader(loader),
+		pcl.AllowMissingProperties,
+		pcl.AllowMissingVariables,
+		pcl.SkipResourceTypechecking,
+	)
+	require.NoError(t, err)
+	require.False(t, bindDiags.HasErrors(), bindDiags.Error())
+
+	files, genDiags, err := codegen.GenerateProgram(program)
+	require.NoError(t, err)
+	require.False(t, genDiags.HasErrors(), genDiags.Error())
+
+	hclParser := parser.NewParser()
+	_, hclDiags := hclParser.ParseSource("main.hcl", files["main.hcl"])
+	require.False(t, hclDiags.HasErrors(), hclDiags.Error())
+}
+
 // TestInvokeOutput locks in that traversals into an invoke's outputs are rewritten using
 // the function's schema.
 func TestInvokeOutput(t *testing.T) {

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -2256,7 +2256,13 @@ func (g *generator) scopeTraversalTokens(expr *model.ScopeTraversalExpression) (
 		rewritten := make(hcl.Traversal, 0, len(traversal)+1)
 		rewritten = append(rewritten, hcl.TraverseRoot{Name: hclType})
 		rewritten = append(rewritten, traverseNameStep(part.LogicalName()))
-		return hclwrite.TokensForTraversal(append(rewritten, schemaAwareRewriteTraversal(part.Schema.Properties, traversal[1:])...)), nil
+		// part.Schema can be nil when the binder ran with SkipResourceTypechecking
+		// (or similar relaxed options); fall back to the unmodified traversal.
+		var props []*schema.Property
+		if part.Schema != nil {
+			props = part.Schema.Properties
+		}
+		return hclwrite.TokensForTraversal(append(rewritten, schemaAwareRewriteTraversal(props, traversal[1:])...)), nil
 	case *pcl.Component:
 		// Rewrite "someComponent.output" → "module.someComponent.output".
 		rewritten := make(hcl.Traversal, 0, len(traversal)+1)


### PR DESCRIPTION
## Summary
- Guard `part.Schema` in `scopeTraversalTokens` so resource-rooted scope traversals no longer panic when the binder leaves `pcl.Resource.Schema` unset.
- Add a regression test in `cmd/pulumi-language-hcl/hcl_test.go` that binds with `AllowMissingProperties` / `AllowMissingVariables` / `SkipResourceTypechecking` (the option set pulumi/pulumi-terraform-bridge uses for third-party docs) against an empty schema loader.

## Root cause
`pcl.BindProgram` with the relaxed options above can leave `pcl.Resource.Schema` as `nil`. `pkg/codegen/generate.go:2259` dereferenced `part.Schema.Properties` unconditionally, crashing with `invalid memory address or nil pointer dereference`. `schemaAwareRewriteTraversal` already handles `nil` / empty props by returning the traversal unchanged, so the fix is just to nil-check before passing them in — mirroring the existing guards in `genResource` and `genResourceOptions`.

## Test plan
- [x] `go test ./pkg/codegen/...`
- [x] `go test ./cmd/pulumi-language-hcl/...`
- [x] Verified the new test fails with the panic when the fix is reverted.