### PR TITLE
codegen: add SkipRequiredProvidersVersion option

### DIFF
--- a/.changes/unreleased/codegen-improvements-120.yaml
+++ b/.changes/unreleased/codegen-improvements-120.yaml
@@ -1,0 +1,6 @@
+component: codegen
+kind: improvements
+body: Add a `SkipRequiredProvidersVersion` option to `GenerateProgram` that omits the `version` attribute from each `required_providers` entry while keeping `source`, for use by SDK-doc generators that should not bake the provider version into emitted snippets
+time: 2026-05-11T13:35:00.000000+02:00
+custom:
+    PR: "120"

--- a/.changes/unreleased/language-host-bug-fixes-120.yaml
+++ b/.changes/unreleased/language-host-bug-fixes-120.yaml
@@ -1,0 +1,6 @@
+component: language-host
+kind: bug-fixes
+body: Avoid a panic in the HCL parser when a `required_providers` entry omits the optional `version` attribute
+time: 2026-05-11T13:35:01.000000+02:00
+custom:
+    PR: "120"

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -2178,3 +2178,162 @@ func testConvertedPCLWithComponent(
 
 	return mock
 }
+
+// TestRequiredProvidersWithoutVersion exercises the language host with a
+// `pulumi { required_providers { ... } }` block whose entries omit the
+// optional `version` attribute. SDK documentation snippets generated with
+// codegen.SkipRequiredProvidersVersion() produce input of this shape, so
+// the language host must accept it.
+func TestRequiredProvidersWithoutVersion(t *testing.T) {
+	t.Parallel()
+
+	src := `pulumi {
+  required_providers {
+    aws = {
+      source = "pulumi/aws"
+    }
+  }
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-12345"
+  instance_type = "t2.micro"
+}
+
+output "instance_ami" {
+  value = aws_instance.web.ami
+}`
+
+	awsSchema := schema.PackageSpec{
+		Name:    "aws",
+		Version: "6.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"aws:index:Instance": {
+				InputProperties: map[string]schema.PropertySpec{
+					"ami":          {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"instanceType": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"ami":          {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"instanceType": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	loader := schemaloader.New(t, awsSchema)
+
+	hclParser := parser.NewParser()
+	config, hclDiags := hclParser.ParseSource("main.hcl", []byte(src))
+	require.False(t, hclDiags.HasErrors(), hclDiags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := hclrun.NewEngine(config, &hclrun.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader:    loader,
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	require.Len(t, mock.RegisteredResources, 2)
+	assert.Equal(t, "pulumi:pulumi:Stack", mock.RegisteredResources[0].Type)
+	assert.Equal(t, "aws:index:Instance", mock.RegisteredResources[1].Type)
+	assert.Equal(t, "web", mock.RegisteredResources[1].Name)
+}
+
+// TestGenerateProgramSkipRequiredProvidersVersion verifies the codegen option
+// omits the `version` attribute on every required_providers entry while
+// preserving `source`, and that the resulting HCL still parses and executes
+// end-to-end through the language host.
+func TestGenerateProgramSkipRequiredProvidersVersion(t *testing.T) {
+	t.Parallel()
+
+	const pclSrc = `package "aws" {
+  baseProviderName = "aws"
+  baseProviderVersion = "6.0.0"
+}
+
+resource web "aws:index:Instance" {
+  ami = "ami-12345"
+  instanceType = "t2.micro"
+}
+`
+
+	awsSchema := schema.PackageSpec{
+		Name:    "aws",
+		Version: "6.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"aws:index:Instance": {
+				InputProperties: map[string]schema.PropertySpec{
+					"ami":          {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"instanceType": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"ami":          {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"instanceType": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+	loader := schemaloader.New(t, awsSchema)
+
+	p := syntax.NewParser()
+	require.NoError(t, p.ParseFile(strings.NewReader(pclSrc), "main.pp"))
+	require.False(t, p.Diagnostics.HasErrors(), p.Diagnostics.Error())
+
+	program, bindDiags, err := pcl.BindProgram(p.Files,
+		pcl.Loader(loader),
+		pcl.AllowMissingProperties,
+		pcl.AllowMissingVariables,
+		pcl.SkipResourceTypechecking,
+	)
+	require.NoError(t, err)
+	require.False(t, bindDiags.HasErrors(), bindDiags.Error())
+
+	files, diags, err := codegen.GenerateProgram(program, codegen.SkipRequiredProvidersVersion())
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors(), diags.Error())
+	require.Len(t, files, 1)
+
+	var got []byte
+	for _, content := range files {
+		got = content
+	}
+	assert.Contains(t, string(got), `source = "pulumi/aws"`)
+	assert.NotContains(t, string(got), "version =", "version should be omitted from required_providers entries")
+
+	// Round-trip: write the generated HCL out, parse it back, and run
+	// through the engine to prove it's still executable.
+	outDir := t.TempDir()
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(outDir, name), content, 0o600))
+	}
+
+	hclParser := parser.NewParser()
+	config, hclDiags := hclParser.ParseDirectory(outDir)
+	require.False(t, hclDiags.HasErrors(), hclDiags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := hclrun.NewEngine(config, &hclrun.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         outDir,
+		RootDir:         outDir,
+		SchemaLoader:    loader,
+	})
+	require.NoError(t, engine.Run(t.Context()))
+
+	require.Len(t, mock.RegisteredResources, 2)
+	assert.Equal(t, "pulumi:pulumi:Stack", mock.RegisteredResources[0].Type)
+	assert.Equal(t, "aws:index:Instance", mock.RegisteredResources[1].Type)
+	assert.Equal(t, "web", mock.RegisteredResources[1].Name)
+}

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -38,6 +38,22 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// GenerateProgramOption configures GenerateProgram.
+type GenerateProgramOption func(*generateProgramOptions)
+
+type generateProgramOptions struct {
+	skipRequiredProvidersVersion bool
+}
+
+// SkipRequiredProvidersVersion omits the `version` attribute from each entry
+// of an emitted `pulumi { required_providers { ... } }` block. The `source`
+// attribute is still emitted so symbol resolution remains unambiguous. Use
+// for snippets embedded in SDK documentation, where pinning a version would
+// bake the SDK's in-development version into every regenerated docstring.
+func SkipRequiredProvidersVersion() GenerateProgramOption {
+	return func(o *generateProgramOptions) { o.skipRequiredProvidersVersion = true }
+}
+
 // GenerateProgram generates HCL source code from a bound PCL program.
 //
 // The output preserves the program's source-file structure: each PCL file
@@ -46,12 +62,18 @@ import (
 // declared each package via a `package` block; references with no declaring
 // file are placed in main.hcl (or, if no main.pp exists, the first file in
 // alphabetical order).
-func GenerateProgram(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, error) {
+func GenerateProgram(program *pcl.Program, opts ...GenerateProgramOption) (map[string][]byte, hcl.Diagnostics, error) {
+	var o generateProgramOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	var diags hcl.Diagnostics
 
 	gen := &generator{
-		program:  program,
-		comments: buildProgramComments(program),
+		program:                      program,
+		comments:                     buildProgramComments(program),
+		skipRequiredProvidersVersion: o.skipRequiredProvidersVersion,
 	}
 
 	for _, node := range program.Nodes {
@@ -298,6 +320,9 @@ type generator struct {
 	// comments maps source filenames to leading-comment maps built from the
 	// PCL source files of this program.
 	comments map[string]*comments.Map
+	// skipRequiredProvidersVersion suppresses the `version` attribute on
+	// each `required_providers` entry. See SkipRequiredProvidersVersion.
+	skipRequiredProvidersVersion bool
 }
 
 // buildProgramComments parses the source of every PCL file in the program and
@@ -566,7 +591,7 @@ func (g *generator) genPulumiHeader(
 			attrs := map[string]cty.Value{
 				"source": cty.StringVal(namespace + "/" + ref.Name()),
 			}
-			if v := ref.Version(); v != nil {
+			if v := ref.Version(); v != nil && !g.skipRequiredProvidersVersion {
 				attrs["version"] = cty.StringVal(v.String())
 			}
 			reqProviders.Body().SetAttributeValue(ref.Name(), cty.ObjectVal(attrs))

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -307,11 +307,15 @@ func (p *Parser) parseRequiredProviders(pulumi *ast.Pulumi, block *hcl.Block) hc
 		if val.Type() == cty.String {
 			provider.Version = val.AsString()
 		} else if val.Type().IsObjectType() {
-			if sourceVal := val.GetAttr("source"); !sourceVal.IsNull() {
-				provider.Source = sourceVal.AsString()
+			if val.Type().HasAttribute("source") {
+				if sourceVal := val.GetAttr("source"); !sourceVal.IsNull() {
+					provider.Source = sourceVal.AsString()
+				}
 			}
-			if versionVal := val.GetAttr("version"); !versionVal.IsNull() {
-				provider.Version = versionVal.AsString()
+			if val.Type().HasAttribute("version") {
+				if versionVal := val.GetAttr("version"); !versionVal.IsNull() {
+					provider.Version = versionVal.AsString()
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Add `codegen.SkipRequiredProvidersVersion()` — a `GenerateProgramOption` that omits the `version` attribute on every `required_providers` entry while keeping `source`. Motivation: the pulumi-terraform bridge generates HCL snippets for SDK documentation; baking the in-development SDK version (e.g. `6.0.0-alpha.0+dev`) into each docstring forces a churn-y regen on every SDK version bump.
- Fix `parseRequiredProviders` panic on entries without `version`. The parser called `val.GetAttr("version")` unconditionally, which `cty` panics on if the attribute is absent. Guard both `source` and `version` reads with `HasAttribute`.

## Test plan

- [x] `TestRequiredProvidersWithoutVersion` — language host end-to-end on input that omits `version` (the shape `SkipRequiredProvidersVersion` produces). Previously panicked.
- [x] `TestGenerateProgramSkipRequiredProvidersVersion` — codegen option omits `version`, keeps `source`.
- [x] Existing codegen / parser / converter tests still pass.