### PR TITLE
Don't corrupt resource names when the HCL type contains dots

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-140.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-140.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Don't corrupt the Pulumi resource name when a resource's HCL type contains dots
+time: 2026-05-19T12:00:00+02:00
+custom:
+    Component: runtime
+    PR: "140"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -958,7 +958,7 @@ func (e *Engine) registerResourceInstanceInContext(
 		}
 	}
 
-	resourceName := e.extractModuleResourceName(instance.Key, node.ModuleInfo, modInst)
+	resourceName := e.extractModuleResourceName(res.Name, instance.Key, node.ModuleInfo, modInst)
 
 	urn, id, outputs, err := e.registerResource(ctx, resSchema.Token, resourceName, resourceInputs, opts)
 	if err != nil {
@@ -1400,8 +1400,6 @@ func (e *Engine) evaluateAliases(expr hcl.Expression) ([]Alias, error) {
 	return aliases, nil
 }
 
-// extractResourceName extracts the resource name from an instance key.
-// For example: "pulumi_stash.myStash" -> "myStash", "aws_instance.web[0]" -> "web[0]".
 // packageNameFromResourceType extracts the provider package name from an HCL resource type.
 // For example, "config_resource" returns "config" and "pulumi_providers_config" returns "config".
 func packageNameFromResourceType(token string) string {
@@ -1486,24 +1484,19 @@ func ExtractSemverFromConstraint(constraint string) string {
 	}
 }
 
-// extractResourceName converts an instance key into a Pulumi resource name.
+// buildResourceName builds the Pulumi resource name from the logical name and instance key.
 // Single instances use the logical name as-is. Count instances get a "-N" suffix.
 // ForEach instances get a "-key" suffix.
-func extractResourceName(key string) string {
-	baseKey, index, eachKey := graph.ParseInstanceKey(key)
-
-	// Strip the "type." prefix from the base key to get the logical name.
-	if _, after, ok := strings.Cut(baseKey, "."); ok {
-		baseKey = after
-	}
+func buildResourceName(logicalName, instanceKey string) string {
+	_, index, eachKey := graph.ParseInstanceKey(instanceKey)
 
 	if index != nil {
-		return fmt.Sprintf("%s-%d", baseKey, *index)
+		return fmt.Sprintf("%s-%d", logicalName, *index)
 	}
 	if eachKey != nil {
-		return fmt.Sprintf("%s-%s", baseKey, *eachKey)
+		return fmt.Sprintf("%s-%s", logicalName, *eachKey)
 	}
-	return baseKey
+	return logicalName
 }
 
 // extractModuleResourceName computes the Pulumi resource name for a resource inside a module.
@@ -1511,15 +1504,15 @@ func extractResourceName(key string) string {
 // For example, resource "res" inside component "comp" becomes "comp-res",
 // and inside "comp[0]" becomes "comp[0]-res".
 func (*Engine) extractModuleResourceName(
-	instanceKey string, modInfo *graph.ModuleInfo, modInst *moduleInstance,
+	logicalName, instanceKey string, modInfo *graph.ModuleInfo, modInst *moduleInstance,
 ) string {
 	if modInfo == nil || modInst == nil {
-		return extractResourceName(instanceKey)
+		return buildResourceName(logicalName, instanceKey)
 	}
 
-	// Strip the module prefix to get the bare resource key (e.g., "simple_resource.name").
+	// Strip the module prefix to get the bare instance key (e.g., "simple_resource.name").
 	bareKey := strings.TrimPrefix(instanceKey, modInfo.Prefix())
-	bareResourceName := extractResourceName(bareKey)
+	bareResourceName := buildResourceName(logicalName, bareKey)
 
 	// Extract the module instance name (e.g., "many" or "many[0]").
 	modInstanceName := modInst.Path.LogicalName()

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -1444,6 +1444,73 @@ module "vpc.primary" {
 	assert.Equal(t, "vpc.primary-main", vpcResource.Name)
 }
 
+// TestEngine_ResourceTypeWithDot verifies that a resource whose HCL type label
+// contains dots (e.g. "kubernetes_networking.k8s.io_v1_ingress", resolving to
+// "kubernetes:networking.k8s.io/v1:Ingress") still produces a Pulumi resource
+// name equal to the second block label, rather than leaking part of the type.
+// Regression test for #140.
+func TestEngine_ResourceTypeWithDot(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "kubernetes_networking.k8s.io_v1_ingress" "ingress" {
+  metadata = {
+    name = "minimal-ingress"
+  }
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := run.NewEngine(config, &run.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "kubernetes",
+			Resources: map[string]schema.ResourceSpec{
+				"kubernetes:networking.k8s.io/v1:Ingress": {
+					InputProperties: map[string]schema.PropertySpec{
+						"metadata": {TypeSpec: schema.TypeSpec{Ref: "#/types/kubernetes:meta/v1:ObjectMeta"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"metadata": {TypeSpec: schema.TypeSpec{Ref: "#/types/kubernetes:meta/v1:ObjectMeta"}},
+						},
+					},
+				},
+			},
+			Types: map[string]schema.ComplexTypeSpec{
+				"kubernetes:meta/v1:ObjectMeta": {
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Type: "object",
+						Properties: map[string]schema.PropertySpec{
+							"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var ingress *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Type == "kubernetes:networking.k8s.io/v1:Ingress" {
+			ingress = &mock.RegisteredResources[i]
+			break
+		}
+	}
+	require.NotNil(t, ingress, "expected kubernetes:networking.k8s.io/v1:Ingress resource to be registered")
+	assert.Equal(t, "ingress", ingress.Name)
+}
+
 // runSensitiveMetaArgTest is a shared driver for the four "sensitive value
 // rejected by count/for_each" tests. It writes the given root.hcl into a
 // temp dir, runs the engine, and returns the resulting error.


### PR DESCRIPTION
## Summary

- For tokens with dotted modules (e.g. `kubernetes:networking.k8s.io/v1:Ingress`, HCL form `kubernetes_networking.k8s.io_v1_ingress`), `extractResourceName` was deriving the Pulumi resource name by splitting the instance key on the first `.`, leaking part of the type into the name. The URN ended up with `k8s.io_v1_ingress.ingress` instead of `ingress`, and Kubernetes auto-naming then synthesized an invalid `metadata.name`.
- Pass the resource's logical name (the second HCL block label) directly to `extractResourceName` / `extractModuleResourceName` instead of parsing it back out of the instance key. The instance key is consulted only for the `[N]` / `["key"]` count/for_each suffix.

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/140.

## Test plan

- [x] New in-process integration test `TestEngine_ResourceTypeWithDot` that parses `resource "kubernetes_networking.k8s.io_v1_ingress" "ingress" {...}`, runs the engine against a schema exposing `kubernetes:networking.k8s.io/v1:Ingress`, and asserts the registered name is `ingress`.
- [x] Verified the new test fails on `master` with `actual: "k8s.io_v1_ingress.ingress"` and passes with the fix.
- [x] `go test ./...` passes.