### PR TITLE
Use the canonical token name when generating HCL

### DIFF
--- a/.changes/unreleased/codegen-Improvements-154.yaml
+++ b/.changes/unreleased/codegen-Improvements-154.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Use the cannonical resource token when converting into HCL
+time: 2026-05-22T12:09:05.162696+02:00
+custom:
+    Component: codegen
+    PR: "154"

--- a/cmd/pulumi-language-hcl/testdata/TestConvertedPCL/function_blocks/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestConvertedPCL/function_blocks/main.hcl
@@ -7,7 +7,7 @@ pulumi {
   }
 }
 
-data "test_getfiltered" "invoke_0" {
+data "test_filtered" "invoke_0" {
   name = "my-filter"
   filters {
     key   = "tag:Name"
@@ -20,5 +20,5 @@ data "test_getfiltered" "invoke_0" {
 }
 
 output "filteredId" {
-  value = data.test_getfiltered.invoke_0.id
+  value = data.test_filtered.invoke_0.id
 }

--- a/cmd/pulumi-language-hcl/testdata/TestConvertedPCL/function_nested_blocks/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestConvertedPCL/function_nested_blocks/main.hcl
@@ -7,7 +7,7 @@ pulumi {
   }
 }
 
-data "test_blockinvoke" "invoke_0" {
+data "test_block_invoke" "invoke_0" {
   outer {
     inner {
       prop = true
@@ -25,19 +25,19 @@ data "test_blockinvoke" "invoke_0" {
     }
   }
 }
-data "test_blockinvoke" "invoke_1" {
+data "test_block_invoke" "invoke_1" {
 }
-data "test_blockinvoke" "invoke_2" {
+data "test_block_invoke" "invoke_2" {
   outer {
   }
 }
 
 output "result" {
-  value = data.test_blockinvoke.invoke_0.id
+  value = data.test_block_invoke.invoke_0.id
 }
 output "emptyOuter" {
-  value = data.test_blockinvoke.invoke_1.id
+  value = data.test_block_invoke.invoke_1.id
 }
 output "emptyInner" {
-  value = data.test_blockinvoke.invoke_2.id
+  value = data.test_block_invoke.invoke_2.id
 }

--- a/cmd/pulumi-language-hcl/testdata/TestInvokeModuleFormat/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestInvokeModuleFormat/main.hcl
@@ -7,7 +7,7 @@ pulumi {
   }
 }
 
-data "test_mod_getthing" "ubuntu" {
+data "test_mod_thing" "ubuntu" {
   object_blocks {
     value = true
   }
@@ -17,5 +17,5 @@ data "test_mod_getthing" "ubuntu" {
 }
 
 output "result" {
-  value = data.test_mod_getthing.ubuntu.id
+  value = data.test_mod_thing.ubuntu.id
 }

--- a/cmd/pulumi-language-hcl/testdata/TestInvokeOutput/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestInvokeOutput/main.hcl
@@ -7,12 +7,12 @@ pulumi {
   }
 }
 
-data "test_getinfo" "info" {
+data "test_info" "info" {
 }
 
 resource "test_sink" "snakeSink" {
-  value = data.test_getinfo.info.snake_case_field
+  value = data.test_info.info.snake_case_field
 }
 resource "test_sink" "tagSink" {
-  value = data.test_getinfo.info.tags_map.UserKey
+  value = data.test_info.info.tags_map.UserKey
 }

--- a/cmd/pulumi-language-hcl/testdata/TestInvokeReturnType/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestInvokeReturnType/main.hcl
@@ -7,12 +7,12 @@ pulumi {
   }
 }
 
-data "test_getinfo" "info" {
+data "test_info" "info" {
 }
 
 resource "test_sink" "snakeSink" {
-  value = data.test_getinfo.info[0].snake_case_field
+  value = data.test_info.info[0].snake_case_field
 }
 resource "test_sink" "tagSink" {
-  value = data.test_getinfo.info[0].tags_map.UserKey
+  value = data.test_info.info[0].tags_map.UserKey
 }

--- a/cmd/pulumi-language-hcl/testdata/TestModuleVariableResolution/mod/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/TestModuleVariableResolution/mod/main.hcl
@@ -7,7 +7,7 @@ pulumi {
   }
 }
 
-data "test_getlen" "invoke_0" {
+data "test_len" "invoke_0" {
   items = var.items
 }
 
@@ -15,7 +15,7 @@ variable "items" {
   type = list(string)
 }
 locals {
-  itemLen = data.test_getlen.invoke_0.result
+  itemLen = data.test_len.invoke_0.result
 }
 output "result" {
   value = local.itemLen

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-stack-reference/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l1-stack-reference/main.pp
@@ -3,14 +3,14 @@ resource "ref" "pulumi:pulumi:StackReference" {
 }
 
 output "plain" {
-  value = getOutput(ref, "plain")
+  value = ref.outputs["plain"]
 }
 
 output "secret" {
-  value = getOutput(ref, "secret")
+  value = ref.outputs["secret"]
 }
 
 output "secret_unsecret" {
-  value = unsecret(getOutput(ref, "secret"))
+  value = unsecret(ref.outputs["secret"])
 }
 

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-stack-reference/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-stack-reference/main.hcl
@@ -1,12 +1,12 @@
-resource "pulumi_stackreference" "ref" {
+resource "pulumi_stack_reference" "ref" {
   name = "organization/other/dev"
 }
 output "plain" {
-  value = pulumi_stackreference.ref.outputs["plain"]
+  value = pulumi_stack_reference.ref.outputs["plain"]
 }
 output "secret" {
-  value = pulumi_stackreference.ref.outputs["secret"]
+  value = pulumi_stack_reference.ref.outputs["secret"]
 }
 output "secret_unsecret" {
-  value = nonsensitive(pulumi_stackreference.ref.outputs["secret"])
+  value = nonsensitive(pulumi_stack_reference.ref.outputs["secret"])
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-builtin-object/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-builtin-object/main.hcl
@@ -7,24 +7,24 @@ pulumi {
   }
 }
 
-resource "output_complexresource" "res" {
+resource "output_complex_resource" "res" {
   value = 1
 }
 output "entriesOutput" {
-  value = entries(output_complexresource.res.output_map)
+  value = entries(output_complex_resource.res.output_map)
 }
 output "lookupOutput" {
-  value = lookup(output_complexresource.res.output_map, "x", "default")
+  value = lookup(output_complex_resource.res.output_map, "x", "default")
 }
 output "lookupOutputDefault" {
-  value = lookup(output_complexresource.res.output_map, "y", "default")
+  value = lookup(output_complex_resource.res.output_map, "y", "default")
 }
 output "entriesObjectOutput" {
-  value = entries(output_complexresource.res.output_object)
+  value = entries(output_complex_resource.res.output_object)
 }
 output "lookupObjectOutput" {
-  value = lookup(output_complexresource.res.output_object, "output", "default")
+  value = lookup(output_complex_resource.res.output_object, "output", "default")
 }
 output "lookupObjectOutputDefault" {
-  value = lookup(output_complexresource.res.output_object, "missing", "default")
+  value = lookup(output_complex_resource.res.output_object, "missing", "default")
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-camel-names/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-camel-names/main.hcl
@@ -7,13 +7,13 @@ pulumi {
   }
 }
 
-resource "camelNames_coolmodule_someresource" "firstResource" {
+resource "camelNames_cool_module_some_resource" "firstResource" {
   the_input = true
 }
-resource "camelNames_coolmodule_someresource" "secondResource" {
-  the_input = camelNames_coolmodule_someresource.firstResource.the_output
+resource "camelNames_cool_module_some_resource" "secondResource" {
+  the_input = camelNames_cool_module_some_resource.firstResource.the_output
 }
-resource "camelNames_coolmodule_someresource" "thirdResource" {
+resource "camelNames_cool_module_some_resource" "thirdResource" {
   the_input     = true
   resource_name = "my-cluster"
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-component-call-simple/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-component-call-simple/main.hcl
@@ -13,7 +13,7 @@ call "component1" "prefixed" {
   prefix = "foo-"
 }
 
-resource "component_componentcallable" "component1" {
+resource "component_component_callable" "component1" {
   value = "bar"
 }
 output "from_identity" {

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-component-component-resource-ref/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-component-component-resource-ref/main.hcl
@@ -7,15 +7,15 @@ pulumi {
   }
 }
 
-resource "component_componentcustomrefoutput" "component1" {
+resource "component_component_custom_ref_output" "component1" {
   value = "foo-bar-baz"
 }
-resource "component_componentcustomrefinputoutput" "component2" {
-  input_ref = component_componentcustomrefoutput.component1.ref
+resource "component_component_custom_ref_input_output" "component2" {
+  input_ref = component_component_custom_ref_output.component1.ref
 }
 resource "component_custom" "custom1" {
-  value = component_componentcustomrefinputoutput.component2.input_ref.value
+  value = component_component_custom_ref_input_output.component2.input_ref.value
 }
 resource "component_custom" "custom2" {
-  value = component_componentcustomrefinputoutput.component2.output_ref.value
+  value = component_component_custom_ref_input_output.component2.output_ref.value
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-component-program-resource-ref/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-component-program-resource-ref/main.hcl
@@ -7,12 +7,12 @@ pulumi {
   }
 }
 
-resource "component_componentcustomrefoutput" "component1" {
+resource "component_component_custom_ref_output" "component1" {
   value = "foo-bar-baz"
 }
 resource "component_custom" "custom1" {
-  value = component_componentcustomrefoutput.component1.value
+  value = component_component_custom_ref_output.component1.value
 }
 resource "component_custom" "custom2" {
-  value = component_componentcustomrefoutput.component1.ref.value
+  value = component_component_custom_ref_output.component1.ref.value
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-elide-index/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-elide-index/main.hcl
@@ -11,7 +11,7 @@ pulumi {
   }
 }
 
-data "simple-invoke_myinvoke" "invoke_0" {
+data "simple-invoke_my_invoke" "invoke_0" {
   value = "test"
 }
 
@@ -19,5 +19,5 @@ resource "simple_resource" "res" {
   value = true
 }
 output "inv" {
-  value = data.simple-invoke_myinvoke.invoke_0.result
+  value = data.simple-invoke_my_invoke.invoke_0.result
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-explicit-providers/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-explicit-providers/main.hcl
@@ -9,11 +9,11 @@ pulumi {
 
 resource "pulumi_providers_component" "explicit" {
 }
-resource "component_componentcallable" "list" {
+resource "component_component_callable" "list" {
   providers = [pulumi_providers_component.explicit]
   value     = "value"
 }
-resource "component_componentcallable" "map" {
+resource "component_component_callable" "map" {
   providers = [pulumi_providers_component.explicit]
   value     = "value"
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-index-mod/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-index-mod/main.hcl
@@ -7,10 +7,10 @@ pulumi {
   }
 }
 
-data "index-mod_indexmine_concatworld" "invoke_0" {
+data "index-mod_index_mine_concat_world" "invoke_0" {
   value = "hello"
 }
-data "index-mod_indexmine_nested_concatworld" "invoke_1" {
+data "index-mod_index_mine_nested_concat_world" "invoke_1" {
   value = "goodbye"
 }
 
@@ -21,11 +21,11 @@ call "res2" "call" {
   input = "xx"
 }
 
-resource "index-mod_indexmine_resource" "res1" {
-  text = data.index-mod_indexmine_concatworld.invoke_0.result
+resource "index-mod_index_mine_resource" "res1" {
+  text = data.index-mod_index_mine_concat_world.invoke_0.result
 }
-resource "index-mod_indexmine_nested_resource" "res2" {
-  text = data.index-mod_indexmine_nested_concatworld.invoke_1.result
+resource "index-mod_index_mine_nested_resource" "res2" {
+  text = data.index-mod_index_mine_nested_concat_world.invoke_1.result
 }
 output "out1" {
   value = call.res1.call.output

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-dependencies/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-dependencies/main.hcl
@@ -11,7 +11,7 @@ pulumi {
   }
 }
 
-data "simple-invoke_secretinvoke" "invoke_0" {
+data "simple-invoke_secret_invoke" "invoke_0" {
   value           = "hello"
   secret_response = simple_resource.first.value
 }
@@ -22,5 +22,5 @@ resource "simple_resource" "first" {
 // assert that resource second depends on resource first
 // because it uses .secret from the invoke which depends on first
 resource "simple_resource" "second" {
-  value = data.simple-invoke_secretinvoke.invoke_0.secret
+  value = data.simple-invoke_secret_invoke.invoke_0.secret
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-options-depends-on/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-options-depends-on/main.hcl
@@ -7,19 +7,19 @@ pulumi {
   }
 }
 
-data "simple-invoke_myinvoke" "data" {
+data "simple-invoke_my_invoke" "data" {
   value      = "hello"
-  depends_on = [simple-invoke_stringresource.first]
+  depends_on = [simple-invoke_string_resource.first]
 }
 
 resource "pulumi_providers_simple-invoke" "explicitProvider" {
 }
-resource "simple-invoke_stringresource" "first" {
+resource "simple-invoke_string_resource" "first" {
   text = "first hello"
 }
-resource "simple-invoke_stringresource" "second" {
-  text = data.simple-invoke_myinvoke.data.result
+resource "simple-invoke_string_resource" "second" {
+  text = data.simple-invoke_my_invoke.data.result
 }
 output "hello" {
-  value = data.simple-invoke_myinvoke.data.result
+  value = data.simple-invoke_my_invoke.data.result
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-options/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-options/main.hcl
@@ -7,7 +7,7 @@ pulumi {
   }
 }
 
-data "simple-invoke_myinvoke" "data" {
+data "simple-invoke_my_invoke" "data" {
   value               = "hello"
   provider            = pulumi_providers_simple-invoke.explicitProvider
   parent              = pulumi_providers_simple-invoke.explicitProvider
@@ -18,5 +18,5 @@ data "simple-invoke_myinvoke" "data" {
 resource "pulumi_providers_simple-invoke" "explicitProvider" {
 }
 output "hello" {
-  value = data.simple-invoke_myinvoke.data.result
+  value = data.simple-invoke_my_invoke.data.result
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-output-only/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-output-only/main.hcl
@@ -7,16 +7,16 @@ pulumi {
   }
 }
 
-data "output-only-invoke_myinvoke" "invoke_0" {
+data "output-only-invoke_my_invoke" "invoke_0" {
   value = "hello"
 }
-data "output-only-invoke_myinvoke" "invoke_1" {
+data "output-only-invoke_my_invoke" "invoke_1" {
   value = "goodbye"
 }
 
 output "hello" {
-  value = data.output-only-invoke_myinvoke.invoke_0.result
+  value = data.output-only-invoke_my_invoke.invoke_0.result
 }
 output "goodbye" {
-  value = data.output-only-invoke_myinvoke.invoke_1.result
+  value = data.output-only-invoke_my_invoke.invoke_1.result
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-scalar/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-scalar/main.hcl
@@ -7,10 +7,10 @@ pulumi {
   }
 }
 
-data "simple-invoke-with-scalar-return_myinvokescalar" "invoke_0" {
+data "simple-invoke-with-scalar-return_my_invoke_scalar" "invoke_0" {
   value = "goodbye"
 }
 
 output "scalar" {
-  value = data.simple-invoke-with-scalar-return_myinvokescalar.invoke_0
+  value = data.simple-invoke-with-scalar-return_my_invoke_scalar.invoke_0
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-scalars/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-scalars/main.hcl
@@ -7,28 +7,28 @@ pulumi {
   }
 }
 
-data "scalar-returns_invokesecret" "invoke_0" {
+data "scalar-returns_invoke_secret" "invoke_0" {
   value = "goodbye"
 }
-data "scalar-returns_invokearray" "invoke_1" {
+data "scalar-returns_invoke_array" "invoke_1" {
   value = "the word"
 }
-data "scalar-returns_invokemap" "invoke_2" {
+data "scalar-returns_invoke_map" "invoke_2" {
   value = "hello"
 }
-data "scalar-returns_invokemap" "invoke_3" {
+data "scalar-returns_invoke_map" "invoke_3" {
   value = "secret"
 }
 
 output "secret" {
-  value = data.scalar-returns_invokesecret.invoke_0
+  value = data.scalar-returns_invoke_secret.invoke_0
 }
 output "array" {
-  value = data.scalar-returns_invokearray.invoke_1
+  value = data.scalar-returns_invoke_array.invoke_1
 }
 output "map" {
-  value = data.scalar-returns_invokemap.invoke_2
+  value = data.scalar-returns_invoke_map.invoke_2
 }
 output "secretMap" {
-  value = data.scalar-returns_invokemap.invoke_3
+  value = data.scalar-returns_invoke_map.invoke_3
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-secrets/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-secrets/main.hcl
@@ -11,15 +11,15 @@ pulumi {
   }
 }
 
-data "simple-invoke_secretinvoke" "invoke_0" {
+data "simple-invoke_secret_invoke" "invoke_0" {
   value           = "hello"
   secret_response = false
 }
-data "simple-invoke_secretinvoke" "invoke_1" {
+data "simple-invoke_secret_invoke" "invoke_1" {
   value           = "hello"
   secret_response = simple_resource.res.value
 }
-data "simple-invoke_secretinvoke" "invoke_2" {
+data "simple-invoke_secret_invoke" "invoke_2" {
   value           = sensitive("goodbye")
   secret_response = false
 }
@@ -29,14 +29,14 @@ resource "simple_resource" "res" {
 }
 // inputs are plain and the invoke response is plain
 output "nonSecret" {
-  value = data.simple-invoke_secretinvoke.invoke_0.response
+  value = data.simple-invoke_secret_invoke.invoke_0.response
 }
 // referencing value from resource
 // invoke response is secret => whole output is secret
 output "firstSecret" {
-  value = data.simple-invoke_secretinvoke.invoke_1.response
+  value = data.simple-invoke_secret_invoke.invoke_1.response
 }
 // inputs are secret, invoke response is plain => whole output is secret
 output "secondSecret" {
-  value = data.simple-invoke_secretinvoke.invoke_2.response
+  value = data.simple-invoke_secret_invoke.invoke_2.response
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-simple/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-simple/main.hcl
@@ -7,16 +7,16 @@ pulumi {
   }
 }
 
-data "simple-invoke_myinvoke" "invoke_0" {
+data "simple-invoke_my_invoke" "invoke_0" {
   value = "hello"
 }
-data "simple-invoke_myinvoke" "invoke_1" {
+data "simple-invoke_my_invoke" "invoke_1" {
   value = "goodbye"
 }
 
 output "hello" {
-  value = data.simple-invoke_myinvoke.invoke_0.result
+  value = data.simple-invoke_my_invoke.invoke_0.result
 }
 output "goodbye" {
-  value = data.simple-invoke_myinvoke.invoke_1.result
+  value = data.simple-invoke_my_invoke.invoke_1.result
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-variants/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-invoke-variants/main.hcl
@@ -7,17 +7,17 @@ pulumi {
   }
 }
 
-data "simple-invoke_myinvoke" "invoke_0" {
-  value = simple-invoke_stringresource.res.text
+data "simple-invoke_my_invoke" "invoke_0" {
+  value = simple-invoke_string_resource.res.text
 }
 data "simple-invoke_unit" "invoke_1" {
 }
 
-resource "simple-invoke_stringresource" "res" {
+resource "simple-invoke_string_resource" "res" {
   text = "hello"
 }
 output "outputInput" {
-  value = data.simple-invoke_myinvoke.invoke_0.result
+  value = data.simple-invoke_my_invoke.invoke_0.result
 }
 output "unit" {
   value = data.simple-invoke_unit.invoke_1.result

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-keywords/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-keywords/main.hcl
@@ -7,17 +7,17 @@ pulumi {
   }
 }
 
-resource "keywords_someresource" "firstResource" {
+resource "keywords_some_resource" "firstResource" {
   builtins = "builtins"
   lambda   = "lambda"
   property = "property"
 }
-resource "keywords_someresource" "secondResource" {
-  builtins = keywords_someresource.firstResource.builtins
-  lambda   = keywords_someresource.firstResource.lambda
-  property = keywords_someresource.firstResource.property
+resource "keywords_some_resource" "secondResource" {
+  builtins = keywords_some_resource.firstResource.builtins
+  lambda   = keywords_some_resource.firstResource.lambda
+  property = keywords_some_resource.firstResource.property
 }
-resource "keywords_lambda_someresource" "lambdaModuleResource" {
+resource "keywords_lambda_some_resource" "lambdaModuleResource" {
   builtins = "builtins"
   lambda   = "lambda"
   property = "property"

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-module-format/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-module-format/main.hcl
@@ -7,25 +7,25 @@ pulumi {
   }
 }
 
-data "module-format_mod_concatworld" "invoke_0" {
+data "module-format_mod_concat_world" "invoke_0" {
   value = "hello"
 }
-data "module-format_mod_concatworld" "invoke_1" {
+data "module-format_mod_concat_world" "invoke_1" {
   value = "goodbye"
 }
-data "module-format_mod_nested_concatworld" "invoke_2" {
+data "module-format_mod_nested_concat_world" "invoke_2" {
   value = "hello"
 }
-data "module-format_mod_nested_concatworld" "invoke_3" {
+data "module-format_mod_nested_concat_world" "invoke_3" {
   value = "goodbye"
 }
-data "module-format_concatworld" "invoke_4" {
+data "module-format_concat_world" "invoke_4" {
   value = "bonjour"
 }
-data "module-format_concatworld" "invoke_5" {
+data "module-format_concat_world" "invoke_5" {
   value = "youkoso"
 }
-data "module-format_concatworld" "invoke_6" {
+data "module-format_concat_world" "invoke_6" {
   value = "guten tag"
 }
 
@@ -55,31 +55,31 @@ call "res7" "call" {
 // member name.
 // First use the fully specified token to invoke and create a resource.
 resource "module-format_mod_resource" "res1" {
-  text = data.module-format_mod_concatworld.invoke_0.result
+  text = data.module-format_mod_concat_world.invoke_0.result
 }
 // Next use just the module name as defined by the module format
 resource "module-format_mod_resource" "res2" {
-  text = data.module-format_mod_concatworld.invoke_1.result
+  text = data.module-format_mod_concat_world.invoke_1.result
 }
 // First use the fully specified token to invoke and create a resource.
 resource "module-format_mod_nested_resource" "res3" {
-  text = data.module-format_mod_nested_concatworld.invoke_2.result
+  text = data.module-format_mod_nested_concat_world.invoke_2.result
 }
 // Next use just the module name as defined by the module format
 resource "module-format_mod_nested_resource" "res4" {
-  text = data.module-format_mod_nested_concatworld.invoke_3.result
+  text = data.module-format_mod_nested_concat_world.invoke_3.result
 }
 // First use the fully specified token to invoke and create a resource in the index module.
 resource "module-format_resource" "res5" {
-  text = data.module-format_concatworld.invoke_4.result
+  text = data.module-format_concat_world.invoke_4.result
 }
 // Next use just the module name as defined by the module format
 resource "module-format_resource" "res6" {
-  text = data.module-format_concatworld.invoke_5.result
+  text = data.module-format_concat_world.invoke_5.result
 }
 // Next use the short, 2 component, form because this is the index module
 resource "module-format_resource" "res7" {
-  text = data.module-format_concatworld.invoke_6.result
+  text = data.module-format_concat_world.invoke_6.result
 }
 output "out1" {
   value = call.res1.call.output

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-namespaced-provider/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-namespaced-provider/main.hcl
@@ -11,10 +11,10 @@ pulumi {
   }
 }
 
-resource "component_componentcustomrefoutput" "componentRes" {
+resource "component_component_custom_ref_output" "componentRes" {
   value = "foo-bar-baz"
 }
 resource "namespaced_resource" "res" {
   value        = true
-  resource_ref = component_componentcustomrefoutput.componentRes.ref
+  resource_ref = component_component_custom_ref_output.componentRes.ref
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-invoke/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-invoke/main.hcl
@@ -7,11 +7,11 @@ pulumi {
   }
 }
 
-data "subpackage_dohelloworld" "invoke_0" {
+data "subpackage_do_hello_world" "invoke_0" {
   input = "goodbye"
 }
 
 // The invoke name is based on the parameter value
 output "parameterValue" {
-  value = data.subpackage_dohelloworld.invoke_0.output
+  value = data.subpackage_do_hello_world.invoke_0.output
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-resource-twice/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-resource-twice/main.hcl
@@ -12,24 +12,24 @@ pulumi {
 }
 
 // The resource name is based on the parameter value
-resource "hipackage_helloworld" "example1" {
+resource "hipackage_hello_world" "example1" {
 }
-resource "hipackage_helloworldcomponent" "exampleComponent1" {
+resource "hipackage_hello_world_component" "exampleComponent1" {
 }
 // The resource name is based on the parameter value
-resource "byepackage_goodbyeworld" "example2" {
+resource "byepackage_goodbye_world" "example2" {
 }
-resource "byepackage_goodbyeworldcomponent" "exampleComponent2" {
+resource "byepackage_goodbye_world_component" "exampleComponent2" {
 }
 output "parameterValue1" {
-  value = hipackage_helloworld.example1.parameter_value
+  value = hipackage_hello_world.example1.parameter_value
 }
 output "parameterValueFromComponent1" {
-  value = hipackage_helloworldcomponent.exampleComponent1.parameter_value
+  value = hipackage_hello_world_component.exampleComponent1.parameter_value
 }
 output "parameterValue2" {
-  value = byepackage_goodbyeworld.example2.parameter_value
+  value = byepackage_goodbye_world.example2.parameter_value
 }
 output "parameterValueFromComponent2" {
-  value = byepackage_goodbyeworldcomponent.exampleComponent2.parameter_value
+  value = byepackage_goodbye_world_component.exampleComponent2.parameter_value
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-resource/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-parameterized-resource/main.hcl
@@ -8,13 +8,13 @@ pulumi {
 }
 
 // The resource name is based on the parameter value
-resource "subpackage_helloworld" "example" {
+resource "subpackage_hello_world" "example" {
 }
-resource "subpackage_helloworldcomponent" "exampleComponent" {
+resource "subpackage_hello_world_component" "exampleComponent" {
 }
 output "parameterValue" {
-  value = subpackage_helloworld.example.parameter_value
+  value = subpackage_hello_world.example.parameter_value
 }
 output "parameterValueFromComponent" {
-  value = subpackage_helloworldcomponent.exampleComponent.parameter_value
+  value = subpackage_hello_world_component.exampleComponent.parameter_value
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config-schema-secret/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config-schema-secret/main.hcl
@@ -22,6 +22,6 @@ resource "pulumi_providers_config-grpc" "config_grpc_provider" {
     secret_x = "SECRET"
   }
 }
-resource "config-grpc_configfetcher" "config" {
+resource "config-grpc_config_fetcher" "config" {
   provider = pulumi_providers_config-grpc.config_grpc_provider
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config-secret/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config-secret/main.hcl
@@ -7,51 +7,51 @@ pulumi {
   }
 }
 
-data "config-grpc_tosecret" "invoke_0" {
+data "config-grpc_to_secret" "invoke_0" {
   string1 = "SECRET"
 }
-data "config-grpc_tosecret" "invoke_1" {
+data "config-grpc_to_secret" "invoke_1" {
   int1 = 1234567890
 }
-data "config-grpc_tosecret" "invoke_2" {
+data "config-grpc_to_secret" "invoke_2" {
   num1 = 123456.789
 }
-data "config-grpc_tosecret" "invoke_3" {
+data "config-grpc_to_secret" "invoke_3" {
   bool1 = true
 }
-data "config-grpc_tosecret" "invoke_4" {
+data "config-grpc_to_secret" "invoke_4" {
   list_string1 = ["SECRET", "SECRET2"]
 }
-data "config-grpc_tosecret" "invoke_5" {
+data "config-grpc_to_secret" "invoke_5" {
   string1 = "SECRET"
 }
-data "config-grpc_tosecret" "invoke_6" {
+data "config-grpc_to_secret" "invoke_6" {
   string1 = "SECRET"
 }
-data "config-grpc_tosecret" "invoke_7" {
+data "config-grpc_to_secret" "invoke_7" {
   string1 = "SECRET"
 }
 
 # This provider covers scenarios where user passes secret values to the provider.
 resource "pulumi_providers_config-grpc" "config_grpc_provider" {
-  string1      = data.config-grpc_tosecret.invoke_0.string1
-  int1         = data.config-grpc_tosecret.invoke_1.int1
-  num1         = data.config-grpc_tosecret.invoke_2.num1
-  bool1        = data.config-grpc_tosecret.invoke_3.bool1
-  list_string1 = data.config-grpc_tosecret.invoke_4.list_string1
-  list_string2 = ["VALUE", data.config-grpc_tosecret.invoke_5.string1]
+  string1      = data.config-grpc_to_secret.invoke_0.string1
+  int1         = data.config-grpc_to_secret.invoke_1.int1
+  num1         = data.config-grpc_to_secret.invoke_2.num1
+  bool1        = data.config-grpc_to_secret.invoke_3.bool1
+  list_string1 = data.config-grpc_to_secret.invoke_4.list_string1
+  list_string2 = ["VALUE", data.config-grpc_to_secret.invoke_5.string1]
   # TODO[pulumi/pulumi#17535] this currently breaks Go compilation unfortunately.
   # mapString1 = invoke("config-grpc:index:toSecret", {mapString1 = { key1 = "SECRET", key2 = "SECRET2" }}).mapString1
   map_string2 = {
     "key1" = "value1"
-    "key2" = data.config-grpc_tosecret.invoke_6.string1
+    "key2" = data.config-grpc_to_secret.invoke_6.string1
   }
   # TODO[pulumi/pulumi#17535] this breaks Go compilation as well.
   # os1 = invoke("config-grpc:index:toSecret", {objString1 = { x = "SECRET" }}).objString1
   obj_string2 = {
-    x = data.config-grpc_tosecret.invoke_7.string1
+    x = data.config-grpc_to_secret.invoke_7.string1
   }
 }
-resource "config-grpc_configfetcher" "config" {
+resource "config-grpc_config_fetcher" "config" {
   provider = pulumi_providers_config-grpc.config_grpc_provider
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-provider-grpc-config/main.hcl
@@ -39,6 +39,6 @@ resource "pulumi_providers_config-grpc" "config_grpc_provider" {
     x = 42
   }
 }
-resource "config-grpc_configfetcher" "config" {
+resource "config-grpc_config_fetcher" "config" {
   provider = pulumi_providers_config-grpc.config_grpc_provider
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-asset-archive/subdir/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-asset-archive/subdir/main.hcl
@@ -7,16 +7,16 @@ pulumi {
   }
 }
 
-resource "asset-archive_assetresource" "ass" {
+resource "asset-archive_asset_resource" "ass" {
   value = fileAsset("../test.txt")
 }
-resource "asset-archive_archiveresource" "arc" {
+resource "asset-archive_archive_resource" "arc" {
   value = fileArchive("../archive.tar")
 }
-resource "asset-archive_archiveresource" "dir" {
+resource "asset-archive_archive_resource" "dir" {
   value = fileArchive("../folder")
 }
-resource "asset-archive_archiveresource" "assarc" {
+resource "asset-archive_archive_resource" "assarc" {
   value = assetArchive({
     "string"  = stringAsset("file contents")
     "file"    = fileAsset("../test.txt")
@@ -24,10 +24,10 @@ resource "asset-archive_archiveresource" "assarc" {
     "archive" = fileArchive("../archive.tar")
   })
 }
-resource "asset-archive_assetresource" "remoteass" {
+resource "asset-archive_asset_resource" "remoteass" {
   value = remoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt")
 }
-resource "asset-archive_archiveresource" "remotearc" {
+resource "asset-archive_archive_resource" "remotearc" {
   value = remoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")
 }
 // Plain (non-nested) asset/archive outputs must round-trip through stack

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-elide-unknowns/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-elide-unknowns/main.hcl
@@ -20,7 +20,7 @@ resource "output_resource" "unknown" {
   provider = pulumi_providers_output.prov
   value    = 1
 }
-resource "output_complexresource" "complex" {
+resource "output_complex_resource" "complex" {
   provider = pulumi_providers_output.prov
   value    = 1
 }
@@ -29,24 +29,24 @@ resource "simple_resource" "res" {
   value = output_resource.unknown.output == "hello"
 }
 resource "simple_resource" "resArray" {
-  value = output_complexresource.complex.output_array[0] == "hello"
+  value = output_complex_resource.complex.output_array[0] == "hello"
 }
 resource "simple_resource" "resMap" {
-  value = output_complexresource.complex.output_map["x"] == "hello"
+  value = output_complex_resource.complex.output_map["x"] == "hello"
 }
 resource "simple_resource" "resObject" {
-  value = output_complexresource.complex.output_object.output == "hello"
+  value = output_complex_resource.complex.output_object.output == "hello"
 }
 // And try to use it has an output
 output "out" {
   value = output_resource.unknown.output
 }
 output "outArray" {
-  value = output_complexresource.complex.output_array[0]
+  value = output_complex_resource.complex.output_array[0]
 }
 output "outMap" {
-  value = output_complexresource.complex.output_map["x"]
+  value = output_complex_resource.complex.output_map["x"]
 }
 output "outObject" {
-  value = output_complexresource.complex.output_object.output
+  value = output_complex_resource.complex.output_object.output
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-invoke-dynamic-function/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-invoke-dynamic-function/main.hcl
@@ -7,7 +7,7 @@ pulumi {
   }
 }
 
-data "any-type-function_dynlisttodyn" "invoke_0" {
+data "any-type-function_dyn_list_to_dyn" "invoke_0" {
   inputs = ["hello", local.localValue, {}]
 }
 
@@ -15,5 +15,5 @@ locals {
   localValue = "hello"
 }
 output "dynamic" {
-  value = data.any-type-function_dynlisttodyn.invoke_0.result
+  value = data.any-type-function_dyn_list_to_dyn.invoke_0.result
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-names/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-names/main.hcl
@@ -7,16 +7,16 @@ pulumi {
   }
 }
 
-resource "names_resmap" "res1" {
+resource "names_res_map" "res1" {
   value = true
 }
-resource "names_resarray" "res2" {
+resource "names_res_array" "res2" {
   value = true
 }
-resource "names_reslist" "res3" {
+resource "names_res_list" "res3" {
   value = true
 }
-resource "names_resresource" "res4" {
+resource "names_res_resource" "res4" {
   value = true
 }
 resource "names_mod_res" "res5" {

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-ignore-changes/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-ignore-changes/main.hcl
@@ -16,7 +16,7 @@ resource "nestedobject_receiver" "receiverIgnore" {
     value = "b"
   }
 }
-resource "nestedobject_mapcontainer" "mapIgnore" {
+resource "nestedobject_map_container" "mapIgnore" {
   lifecycle {
     ignore_changes = [tags["env"], tags["with.dot"], tags["with escaped \""]]
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-replace-on-changes/0/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-replace-on-changes/0/main.hcl
@@ -9,45 +9,45 @@ pulumi {
 
 // Stage 0: Initial resource creation
 // Scenario 1: Schema-based replaceOnChanges on replaceProp
-resource "replaceonchanges_resourcea" "schemaReplace" {
+resource "replaceonchanges_resource_a" "schemaReplace" {
   replace_on_changes = ["replaceProp"]
   value              = true
   replace_prop       = true
 }
 // Scenario 2: Option-based replaceOnChanges on value
-resource "replaceonchanges_resourceb" "optionReplace" {
+resource "replaceonchanges_resource_b" "optionReplace" {
   replace_on_changes = ["value"]
   value              = true
 }
 // Scenario 3: Both schema and option - will change value
-resource "replaceonchanges_resourcea" "bothReplaceValue" {
+resource "replaceonchanges_resource_a" "bothReplaceValue" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
 // Scenario 4: Both schema and option - will change replaceProp
-resource "replaceonchanges_resourcea" "bothReplaceProp" {
+resource "replaceonchanges_resource_a" "bothReplaceProp" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
 // Scenario 5: No replaceOnChanges - baseline update
-resource "replaceonchanges_resourceb" "regularUpdate" {
+resource "replaceonchanges_resource_b" "regularUpdate" {
   value = true
 }
 // Scenario 6: replaceOnChanges set but no change
-resource "replaceonchanges_resourceb" "noChange" {
+resource "replaceonchanges_resource_b" "noChange" {
   replace_on_changes = ["value"]
   value              = true
 }
 // Scenario 7: replaceOnChanges on value, but only replaceProp changes
-resource "replaceonchanges_resourcea" "wrongPropChange" {
+resource "replaceonchanges_resource_a" "wrongPropChange" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
 // Scenario 8: Multiple properties in replaceOnChanges array
-resource "replaceonchanges_resourcea" "multiplePropReplace" {
+resource "replaceonchanges_resource_a" "multiplePropReplace" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-replace-on-changes/1/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-replace-on-changes/1/main.hcl
@@ -9,45 +9,45 @@ pulumi {
 
 // Stage 1: Change properties to trigger replacements
 // Scenario 1: Change replaceProp → REPLACE (schema triggers)
-resource "replaceonchanges_resourcea" "schemaReplace" {
+resource "replaceonchanges_resource_a" "schemaReplace" {
   replace_on_changes = ["replaceProp"]
   value              = true
   replace_prop       = false // Changed from true
 }
 // Scenario 2: Change value → REPLACE (option triggers)
-resource "replaceonchanges_resourceb" "optionReplace" {
+resource "replaceonchanges_resource_b" "optionReplace" {
   replace_on_changes = ["value"]
   value              = false // Changed from true
 }
 // Scenario 3: Change value → REPLACE (option on value triggers)
-resource "replaceonchanges_resourcea" "bothReplaceValue" {
+resource "replaceonchanges_resource_a" "bothReplaceValue" {
   replace_on_changes = ["replaceProp", "value"]
   value              = false // Changed from true
   replace_prop       = true // Unchanged
 }
 // Scenario 4: Change replaceProp → REPLACE (schema on replaceProp triggers)
-resource "replaceonchanges_resourcea" "bothReplaceProp" {
+resource "replaceonchanges_resource_a" "bothReplaceProp" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true // Unchanged
   replace_prop       = false // Changed from true
 }
 // Scenario 5: Change value → UPDATE (no replaceOnChanges)
-resource "replaceonchanges_resourceb" "regularUpdate" {
+resource "replaceonchanges_resource_b" "regularUpdate" {
   value = false // Changed from true
 }
 // Scenario 6: No change → SAME (no operation)
-resource "replaceonchanges_resourceb" "noChange" {
+resource "replaceonchanges_resource_b" "noChange" {
   replace_on_changes = ["value"]
   value              = true // Unchanged
 }
 // Scenario 7: Change replaceProp (not value) → UPDATE (marked property unchanged)
-resource "replaceonchanges_resourcea" "wrongPropChange" {
+resource "replaceonchanges_resource_a" "wrongPropChange" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true // Unchanged (this is marked for replacement)
   replace_prop       = false // Changed from true (this is NOT marked for replacement by option)
 }
 // Scenario 8: Change value → REPLACE (multiple properties marked)
-resource "replaceonchanges_resourcea" "multiplePropReplace" {
+resource "replaceonchanges_resource_a" "multiplePropReplace" {
   replace_on_changes = ["replaceProp", "value"]
   value              = false // Changed from true
   replace_prop       = true // Unchanged

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-union/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-union/main.hcl
@@ -29,11 +29,11 @@ resource "union_example" "safeEnumExample" {
   typed_enum_property = "Block"
 }
 // Output enum: output from another resource used as enum input
-resource "union_enumoutput" "enumOutputExample" {
+resource "union_enum_output" "enumOutputExample" {
   name = "example"
 }
 resource "union_example" "outputEnumExample" {
-  typed_enum_property = union_enumoutput.enumOutputExample.type
+  typed_enum_property = union_enum_output.enumOutputExample.type
 }
 output "mapMapUnionOutput" {
   value = union_example.mapMapUnionExample.map_map_union_property

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-for-resource/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-for-resource/main.hcl
@@ -25,6 +25,6 @@ resource "nestedobject_container" "fromSimple" {
   inputs = [for _, detail in nestedobject_container.source.details : detail.value]
 }
 # for producing a map
-resource "nestedobject_mapcontainer" "mapped" {
+resource "nestedobject_map_container" "mapped" {
   tags = {for _, detail in nestedobject_container.source.details : detail.key => detail.value}
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-range-resource-output-traversal/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-range-resource-output-traversal/main.hcl
@@ -10,7 +10,7 @@ pulumi {
 resource "nestedobject_container" "container" {
   inputs = ["alpha", "bravo"]
 }
-resource "nestedobject_mapcontainer" "mapContainer" {
+resource "nestedobject_map_container" "mapContainer" {
   tags = {
     "k1" = "charlie"
     "k2" = "delta"
@@ -23,6 +23,6 @@ resource "nestedobject_target" "listOutput" {
 }
 # A resource that ranges over a computed map
 resource "nestedobject_target" "mapOutput" {
-  for_each = nestedobject_mapcontainer.mapContainer.tags
+  for_each = nestedobject_map_container.mapContainer.tags
   name     ="${each.key}=>${each.value}"
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/provider-builtin-info-component/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/projects/provider-builtin-info-component/main.hcl
@@ -7,5 +7,5 @@ pulumi {
   }
 }
 
-resource "builtin-info-component_builtininfo" "res" {
+resource "builtin-info-component_builtin_info" "res" {
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-stack-reference/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-stack-reference/main.hcl
@@ -1,12 +1,12 @@
-resource "pulumi_stackreference" "ref" {
+resource "pulumi_stack_reference" "ref" {
   name = "organization/other/dev"
 }
 output "plain" {
-  value = pulumi_stackreference.ref.outputs["plain"]
+  value = pulumi_stack_reference.ref.outputs["plain"]
 }
 output "secret" {
-  value = pulumi_stackreference.ref.outputs["secret"]
+  value = pulumi_stack_reference.ref.outputs["secret"]
 }
 output "secret_unsecret" {
-  value = nonsensitive(pulumi_stackreference.ref.outputs["secret"])
+  value = nonsensitive(pulumi_stack_reference.ref.outputs["secret"])
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-builtin-object/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-builtin-object/main.hcl
@@ -7,24 +7,24 @@ pulumi {
   }
 }
 
-resource "output_complexresource" "res" {
+resource "output_complex_resource" "res" {
   value = 1
 }
 output "entriesOutput" {
-  value = entries(output_complexresource.res.output_map)
+  value = entries(output_complex_resource.res.output_map)
 }
 output "lookupOutput" {
-  value = lookup(output_complexresource.res.output_map, "x", "default")
+  value = lookup(output_complex_resource.res.output_map, "x", "default")
 }
 output "lookupOutputDefault" {
-  value = lookup(output_complexresource.res.output_map, "y", "default")
+  value = lookup(output_complex_resource.res.output_map, "y", "default")
 }
 output "entriesObjectOutput" {
-  value = entries(output_complexresource.res.output_object)
+  value = entries(output_complex_resource.res.output_object)
 }
 output "lookupObjectOutput" {
-  value = lookup(output_complexresource.res.output_object, "output", "default")
+  value = lookup(output_complex_resource.res.output_object, "output", "default")
 }
 output "lookupObjectOutputDefault" {
-  value = lookup(output_complexresource.res.output_object, "missing", "default")
+  value = lookup(output_complex_resource.res.output_object, "missing", "default")
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-camel-names/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-camel-names/main.hcl
@@ -7,13 +7,13 @@ pulumi {
   }
 }
 
-resource "camelNames_coolmodule_someresource" "firstResource" {
+resource "camelNames_cool_module_some_resource" "firstResource" {
   the_input = true
 }
-resource "camelNames_coolmodule_someresource" "secondResource" {
-  the_input = camelNames_coolmodule_someresource.firstResource.the_output
+resource "camelNames_cool_module_some_resource" "secondResource" {
+  the_input = camelNames_cool_module_some_resource.firstResource.the_output
 }
-resource "camelNames_coolmodule_someresource" "thirdResource" {
+resource "camelNames_cool_module_some_resource" "thirdResource" {
   the_input     = true
   resource_name = "my-cluster"
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-component-call-simple/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-component-call-simple/main.hcl
@@ -13,7 +13,7 @@ call "component1" "prefixed" {
   prefix = "foo-"
 }
 
-resource "component_componentcallable" "component1" {
+resource "component_component_callable" "component1" {
   value = "bar"
 }
 output "from_identity" {

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-component-component-resource-ref/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-component-component-resource-ref/main.hcl
@@ -7,15 +7,15 @@ pulumi {
   }
 }
 
-resource "component_componentcustomrefoutput" "component1" {
+resource "component_component_custom_ref_output" "component1" {
   value = "foo-bar-baz"
 }
-resource "component_componentcustomrefinputoutput" "component2" {
-  input_ref = component_componentcustomrefoutput.component1.ref
+resource "component_component_custom_ref_input_output" "component2" {
+  input_ref = component_component_custom_ref_output.component1.ref
 }
 resource "component_custom" "custom1" {
-  value = component_componentcustomrefinputoutput.component2.input_ref.value
+  value = component_component_custom_ref_input_output.component2.input_ref.value
 }
 resource "component_custom" "custom2" {
-  value = component_componentcustomrefinputoutput.component2.output_ref.value
+  value = component_component_custom_ref_input_output.component2.output_ref.value
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-component-program-resource-ref/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-component-program-resource-ref/main.hcl
@@ -7,12 +7,12 @@ pulumi {
   }
 }
 
-resource "component_componentcustomrefoutput" "component1" {
+resource "component_component_custom_ref_output" "component1" {
   value = "foo-bar-baz"
 }
 resource "component_custom" "custom1" {
-  value = component_componentcustomrefoutput.component1.value
+  value = component_component_custom_ref_output.component1.value
 }
 resource "component_custom" "custom2" {
-  value = component_componentcustomrefoutput.component1.ref.value
+  value = component_component_custom_ref_output.component1.ref.value
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-elide-index/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-elide-index/main.hcl
@@ -11,7 +11,7 @@ pulumi {
   }
 }
 
-data "simple-invoke_myinvoke" "invoke_0" {
+data "simple-invoke_my_invoke" "invoke_0" {
   value = "test"
 }
 
@@ -19,5 +19,5 @@ resource "simple_resource" "res" {
   value = true
 }
 output "inv" {
-  value = data.simple-invoke_myinvoke.invoke_0.result
+  value = data.simple-invoke_my_invoke.invoke_0.result
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-explicit-providers/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-explicit-providers/main.hcl
@@ -9,11 +9,11 @@ pulumi {
 
 resource "pulumi_providers_component" "explicit" {
 }
-resource "component_componentcallable" "list" {
+resource "component_component_callable" "list" {
   providers = [pulumi_providers_component.explicit]
   value     = "value"
 }
-resource "component_componentcallable" "map" {
+resource "component_component_callable" "map" {
   providers = [pulumi_providers_component.explicit]
   value     = "value"
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-index-mod/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-index-mod/main.hcl
@@ -7,10 +7,10 @@ pulumi {
   }
 }
 
-data "index-mod_indexmine_concatworld" "invoke_0" {
+data "index-mod_index_mine_concat_world" "invoke_0" {
   value = "hello"
 }
-data "index-mod_indexmine_nested_concatworld" "invoke_1" {
+data "index-mod_index_mine_nested_concat_world" "invoke_1" {
   value = "goodbye"
 }
 
@@ -21,11 +21,11 @@ call "res2" "call" {
   input = "xx"
 }
 
-resource "index-mod_indexmine_resource" "res1" {
-  text = data.index-mod_indexmine_concatworld.invoke_0.result
+resource "index-mod_index_mine_resource" "res1" {
+  text = data.index-mod_index_mine_concat_world.invoke_0.result
 }
-resource "index-mod_indexmine_nested_resource" "res2" {
-  text = data.index-mod_indexmine_nested_concatworld.invoke_1.result
+resource "index-mod_index_mine_nested_resource" "res2" {
+  text = data.index-mod_index_mine_nested_concat_world.invoke_1.result
 }
 output "out1" {
   value = call.res1.call.output

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-dependencies/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-dependencies/main.hcl
@@ -11,7 +11,7 @@ pulumi {
   }
 }
 
-data "simple-invoke_secretinvoke" "invoke_0" {
+data "simple-invoke_secret_invoke" "invoke_0" {
   value           = "hello"
   secret_response = simple_resource.first.value
 }
@@ -22,5 +22,5 @@ resource "simple_resource" "first" {
 // assert that resource second depends on resource first
 // because it uses .secret from the invoke which depends on first
 resource "simple_resource" "second" {
-  value = data.simple-invoke_secretinvoke.invoke_0.secret
+  value = data.simple-invoke_secret_invoke.invoke_0.secret
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-options-depends-on/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-options-depends-on/main.hcl
@@ -7,23 +7,23 @@ pulumi {
   }
 }
 
-data "simple-invoke_myinvoke" "invoke_0" {
+data "simple-invoke_my_invoke" "invoke_0" {
   value      = "hello"
-  depends_on = [simple-invoke_stringresource.first]
+  depends_on = [simple-invoke_string_resource.first]
 }
-data "simple-invoke_myinvoke" "invoke_1" {
+data "simple-invoke_my_invoke" "invoke_1" {
   value      = "hello"
-  depends_on = [simple-invoke_stringresource.first]
+  depends_on = [simple-invoke_string_resource.first]
 }
 
 resource "pulumi_providers_simple-invoke" "explicitProvider" {
 }
-resource "simple-invoke_stringresource" "first" {
+resource "simple-invoke_string_resource" "first" {
   text = "first hello"
 }
-resource "simple-invoke_stringresource" "second" {
-  text = data.simple-invoke_myinvoke.invoke_0.result
+resource "simple-invoke_string_resource" "second" {
+  text = data.simple-invoke_my_invoke.invoke_0.result
 }
 output "hello" {
-  value = data.simple-invoke_myinvoke.invoke_1.result
+  value = data.simple-invoke_my_invoke.invoke_1.result
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-options/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-options/main.hcl
@@ -7,7 +7,7 @@ pulumi {
   }
 }
 
-data "simple-invoke_myinvoke" "invoke_0" {
+data "simple-invoke_my_invoke" "invoke_0" {
   value               = "hello"
   provider            = pulumi_providers_simple-invoke.explicitProvider
   parent              = pulumi_providers_simple-invoke.explicitProvider
@@ -18,5 +18,5 @@ data "simple-invoke_myinvoke" "invoke_0" {
 resource "pulumi_providers_simple-invoke" "explicitProvider" {
 }
 output "hello" {
-  value = data.simple-invoke_myinvoke.invoke_0.result
+  value = data.simple-invoke_my_invoke.invoke_0.result
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-output-only/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-output-only/main.hcl
@@ -7,16 +7,16 @@ pulumi {
   }
 }
 
-data "output-only-invoke_myinvoke" "invoke_0" {
+data "output-only-invoke_my_invoke" "invoke_0" {
   value = "hello"
 }
-data "output-only-invoke_myinvoke" "invoke_1" {
+data "output-only-invoke_my_invoke" "invoke_1" {
   value = "goodbye"
 }
 
 output "hello" {
-  value = data.output-only-invoke_myinvoke.invoke_0.result
+  value = data.output-only-invoke_my_invoke.invoke_0.result
 }
 output "goodbye" {
-  value = data.output-only-invoke_myinvoke.invoke_1.result
+  value = data.output-only-invoke_my_invoke.invoke_1.result
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-scalar/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-scalar/main.hcl
@@ -7,10 +7,10 @@ pulumi {
   }
 }
 
-data "simple-invoke-with-scalar-return_myinvokescalar" "invoke_0" {
+data "simple-invoke-with-scalar-return_my_invoke_scalar" "invoke_0" {
   value = "goodbye"
 }
 
 output "scalar" {
-  value = data.simple-invoke-with-scalar-return_myinvokescalar.invoke_0
+  value = data.simple-invoke-with-scalar-return_my_invoke_scalar.invoke_0
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-scalars/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-scalars/main.hcl
@@ -7,28 +7,28 @@ pulumi {
   }
 }
 
-data "scalar-returns_invokesecret" "invoke_0" {
+data "scalar-returns_invoke_secret" "invoke_0" {
   value = "goodbye"
 }
-data "scalar-returns_invokearray" "invoke_1" {
+data "scalar-returns_invoke_array" "invoke_1" {
   value = "the word"
 }
-data "scalar-returns_invokemap" "invoke_2" {
+data "scalar-returns_invoke_map" "invoke_2" {
   value = "hello"
 }
-data "scalar-returns_invokemap" "invoke_3" {
+data "scalar-returns_invoke_map" "invoke_3" {
   value = "secret"
 }
 
 output "secret" {
-  value = data.scalar-returns_invokesecret.invoke_0
+  value = data.scalar-returns_invoke_secret.invoke_0
 }
 output "array" {
-  value = data.scalar-returns_invokearray.invoke_1
+  value = data.scalar-returns_invoke_array.invoke_1
 }
 output "map" {
-  value = data.scalar-returns_invokemap.invoke_2
+  value = data.scalar-returns_invoke_map.invoke_2
 }
 output "secretMap" {
-  value = data.scalar-returns_invokemap.invoke_3
+  value = data.scalar-returns_invoke_map.invoke_3
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-secrets/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-secrets/main.hcl
@@ -11,15 +11,15 @@ pulumi {
   }
 }
 
-data "simple-invoke_secretinvoke" "invoke_0" {
+data "simple-invoke_secret_invoke" "invoke_0" {
   value           = "hello"
   secret_response = false
 }
-data "simple-invoke_secretinvoke" "invoke_1" {
+data "simple-invoke_secret_invoke" "invoke_1" {
   value           = "hello"
   secret_response = simple_resource.res.value
 }
-data "simple-invoke_secretinvoke" "invoke_2" {
+data "simple-invoke_secret_invoke" "invoke_2" {
   value           = sensitive("goodbye")
   secret_response = false
 }
@@ -29,14 +29,14 @@ resource "simple_resource" "res" {
 }
 // inputs are plain and the invoke response is plain
 output "nonSecret" {
-  value = data.simple-invoke_secretinvoke.invoke_0.response
+  value = data.simple-invoke_secret_invoke.invoke_0.response
 }
 // referencing value from resource
 // invoke response is secret => whole output is secret
 output "firstSecret" {
-  value = data.simple-invoke_secretinvoke.invoke_1.response
+  value = data.simple-invoke_secret_invoke.invoke_1.response
 }
 // inputs are secret, invoke response is plain => whole output is secret
 output "secondSecret" {
-  value = data.simple-invoke_secretinvoke.invoke_2.response
+  value = data.simple-invoke_secret_invoke.invoke_2.response
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-simple/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-simple/main.hcl
@@ -7,16 +7,16 @@ pulumi {
   }
 }
 
-data "simple-invoke_myinvoke" "invoke_0" {
+data "simple-invoke_my_invoke" "invoke_0" {
   value = "hello"
 }
-data "simple-invoke_myinvoke" "invoke_1" {
+data "simple-invoke_my_invoke" "invoke_1" {
   value = "goodbye"
 }
 
 output "hello" {
-  value = data.simple-invoke_myinvoke.invoke_0.result
+  value = data.simple-invoke_my_invoke.invoke_0.result
 }
 output "goodbye" {
-  value = data.simple-invoke_myinvoke.invoke_1.result
+  value = data.simple-invoke_my_invoke.invoke_1.result
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-variants/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-invoke-variants/main.hcl
@@ -7,17 +7,17 @@ pulumi {
   }
 }
 
-data "simple-invoke_myinvoke" "invoke_0" {
-  value = simple-invoke_stringresource.res.text
+data "simple-invoke_my_invoke" "invoke_0" {
+  value = simple-invoke_string_resource.res.text
 }
 data "simple-invoke_unit" "invoke_1" {
 }
 
-resource "simple-invoke_stringresource" "res" {
+resource "simple-invoke_string_resource" "res" {
   text = "hello"
 }
 output "outputInput" {
-  value = data.simple-invoke_myinvoke.invoke_0.result
+  value = data.simple-invoke_my_invoke.invoke_0.result
 }
 output "unit" {
   value = data.simple-invoke_unit.invoke_1.result

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-keywords/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-keywords/main.hcl
@@ -7,17 +7,17 @@ pulumi {
   }
 }
 
-resource "keywords_someresource" "firstResource" {
+resource "keywords_some_resource" "firstResource" {
   builtins = "builtins"
   lambda   = "lambda"
   property = "property"
 }
-resource "keywords_someresource" "secondResource" {
-  builtins = keywords_someresource.firstResource.builtins
-  lambda   = keywords_someresource.firstResource.lambda
-  property = keywords_someresource.firstResource.property
+resource "keywords_some_resource" "secondResource" {
+  builtins = keywords_some_resource.firstResource.builtins
+  lambda   = keywords_some_resource.firstResource.lambda
+  property = keywords_some_resource.firstResource.property
 }
-resource "keywords_lambda_someresource" "lambdaModuleResource" {
+resource "keywords_lambda_some_resource" "lambdaModuleResource" {
   builtins = "builtins"
   lambda   = "lambda"
   property = "property"

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-module-format/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-module-format/main.hcl
@@ -7,25 +7,25 @@ pulumi {
   }
 }
 
-data "module-format_mod_concatworld" "invoke_0" {
+data "module-format_mod_concat_world" "invoke_0" {
   value = "hello"
 }
-data "module-format_mod_concatworld" "invoke_1" {
+data "module-format_mod_concat_world" "invoke_1" {
   value = "goodbye"
 }
-data "module-format_mod_nested_concatworld" "invoke_2" {
+data "module-format_mod_nested_concat_world" "invoke_2" {
   value = "hello"
 }
-data "module-format_mod_nested_concatworld" "invoke_3" {
+data "module-format_mod_nested_concat_world" "invoke_3" {
   value = "goodbye"
 }
-data "module-format_concatworld" "invoke_4" {
+data "module-format_concat_world" "invoke_4" {
   value = "bonjour"
 }
-data "module-format_concatworld" "invoke_5" {
+data "module-format_concat_world" "invoke_5" {
   value = "youkoso"
 }
-data "module-format_concatworld" "invoke_6" {
+data "module-format_concat_world" "invoke_6" {
   value = "guten tag"
 }
 
@@ -55,31 +55,31 @@ call "res7" "call" {
 // member name.
 // First use the fully specified token to invoke and create a resource.
 resource "module-format_mod_resource" "res1" {
-  text = data.module-format_mod_concatworld.invoke_0.result
+  text = data.module-format_mod_concat_world.invoke_0.result
 }
 // Next use just the module name as defined by the module format
 resource "module-format_mod_resource" "res2" {
-  text = data.module-format_mod_concatworld.invoke_1.result
+  text = data.module-format_mod_concat_world.invoke_1.result
 }
 // First use the fully specified token to invoke and create a resource.
 resource "module-format_mod_nested_resource" "res3" {
-  text = data.module-format_mod_nested_concatworld.invoke_2.result
+  text = data.module-format_mod_nested_concat_world.invoke_2.result
 }
 // Next use just the module name as defined by the module format
 resource "module-format_mod_nested_resource" "res4" {
-  text = data.module-format_mod_nested_concatworld.invoke_3.result
+  text = data.module-format_mod_nested_concat_world.invoke_3.result
 }
 // First use the fully specified token to invoke and create a resource in the index module.
 resource "module-format_resource" "res5" {
-  text = data.module-format_concatworld.invoke_4.result
+  text = data.module-format_concat_world.invoke_4.result
 }
 // Next use just the module name as defined by the module format
 resource "module-format_resource" "res6" {
-  text = data.module-format_concatworld.invoke_5.result
+  text = data.module-format_concat_world.invoke_5.result
 }
 // Next use the short, 2 component, form because this is the index module
 resource "module-format_resource" "res7" {
-  text = data.module-format_concatworld.invoke_6.result
+  text = data.module-format_concat_world.invoke_6.result
 }
 output "out1" {
   value = call.res1.call.output

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-namespaced-provider/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-namespaced-provider/main.hcl
@@ -11,10 +11,10 @@ pulumi {
   }
 }
 
-resource "component_componentcustomrefoutput" "componentRes" {
+resource "component_component_custom_ref_output" "componentRes" {
   value = "foo-bar-baz"
 }
 resource "namespaced_resource" "res" {
   value        = true
-  resource_ref = component_componentcustomrefoutput.componentRes.ref
+  resource_ref = component_component_custom_ref_output.componentRes.ref
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-invoke/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-invoke/main.hcl
@@ -7,11 +7,11 @@ pulumi {
   }
 }
 
-data "subpackage_dohelloworld" "invoke_0" {
+data "subpackage_do_hello_world" "invoke_0" {
   input = "goodbye"
 }
 
 // The invoke name is based on the parameter value
 output "parameterValue" {
-  value = data.subpackage_dohelloworld.invoke_0.output
+  value = data.subpackage_do_hello_world.invoke_0.output
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-resource-twice/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-resource-twice/main.hcl
@@ -12,24 +12,24 @@ pulumi {
 }
 
 // The resource name is based on the parameter value
-resource "hipackage_helloworld" "example1" {
+resource "hipackage_hello_world" "example1" {
 }
-resource "hipackage_helloworldcomponent" "exampleComponent1" {
+resource "hipackage_hello_world_component" "exampleComponent1" {
 }
 // The resource name is based on the parameter value
-resource "byepackage_goodbyeworld" "example2" {
+resource "byepackage_goodbye_world" "example2" {
 }
-resource "byepackage_goodbyeworldcomponent" "exampleComponent2" {
+resource "byepackage_goodbye_world_component" "exampleComponent2" {
 }
 output "parameterValue1" {
-  value = hipackage_helloworld.example1.parameter_value
+  value = hipackage_hello_world.example1.parameter_value
 }
 output "parameterValueFromComponent1" {
-  value = hipackage_helloworldcomponent.exampleComponent1.parameter_value
+  value = hipackage_hello_world_component.exampleComponent1.parameter_value
 }
 output "parameterValue2" {
-  value = byepackage_goodbyeworld.example2.parameter_value
+  value = byepackage_goodbye_world.example2.parameter_value
 }
 output "parameterValueFromComponent2" {
-  value = byepackage_goodbyeworldcomponent.exampleComponent2.parameter_value
+  value = byepackage_goodbye_world_component.exampleComponent2.parameter_value
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-resource/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-parameterized-resource/main.hcl
@@ -8,13 +8,13 @@ pulumi {
 }
 
 // The resource name is based on the parameter value
-resource "subpackage_helloworld" "example" {
+resource "subpackage_hello_world" "example" {
 }
-resource "subpackage_helloworldcomponent" "exampleComponent" {
+resource "subpackage_hello_world_component" "exampleComponent" {
 }
 output "parameterValue" {
-  value = subpackage_helloworld.example.parameter_value
+  value = subpackage_hello_world.example.parameter_value
 }
 output "parameterValueFromComponent" {
-  value = subpackage_helloworldcomponent.exampleComponent.parameter_value
+  value = subpackage_hello_world_component.exampleComponent.parameter_value
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config-schema-secret/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config-schema-secret/main.hcl
@@ -22,6 +22,6 @@ resource "pulumi_providers_config-grpc" "config_grpc_provider" {
     secret_x = "SECRET"
   }
 }
-resource "config-grpc_configfetcher" "config" {
+resource "config-grpc_config_fetcher" "config" {
   provider = pulumi_providers_config-grpc.config_grpc_provider
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config-secret/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config-secret/main.hcl
@@ -7,51 +7,51 @@ pulumi {
   }
 }
 
-data "config-grpc_tosecret" "invoke_0" {
+data "config-grpc_to_secret" "invoke_0" {
   string1 = "SECRET"
 }
-data "config-grpc_tosecret" "invoke_1" {
+data "config-grpc_to_secret" "invoke_1" {
   int1 = 1234567890
 }
-data "config-grpc_tosecret" "invoke_2" {
+data "config-grpc_to_secret" "invoke_2" {
   num1 = 123456.789
 }
-data "config-grpc_tosecret" "invoke_3" {
+data "config-grpc_to_secret" "invoke_3" {
   bool1 = true
 }
-data "config-grpc_tosecret" "invoke_4" {
+data "config-grpc_to_secret" "invoke_4" {
   list_string1 = ["SECRET", "SECRET2"]
 }
-data "config-grpc_tosecret" "invoke_5" {
+data "config-grpc_to_secret" "invoke_5" {
   string1 = "SECRET"
 }
-data "config-grpc_tosecret" "invoke_6" {
+data "config-grpc_to_secret" "invoke_6" {
   string1 = "SECRET"
 }
-data "config-grpc_tosecret" "invoke_7" {
+data "config-grpc_to_secret" "invoke_7" {
   string1 = "SECRET"
 }
 
 # This provider covers scenarios where user passes secret values to the provider.
 resource "pulumi_providers_config-grpc" "config_grpc_provider" {
-  string1      = data.config-grpc_tosecret.invoke_0.string1
-  int1         = data.config-grpc_tosecret.invoke_1.int1
-  num1         = data.config-grpc_tosecret.invoke_2.num1
-  bool1        = data.config-grpc_tosecret.invoke_3.bool1
-  list_string1 = data.config-grpc_tosecret.invoke_4.list_string1
-  list_string2 = ["VALUE", data.config-grpc_tosecret.invoke_5.string1]
+  string1      = data.config-grpc_to_secret.invoke_0.string1
+  int1         = data.config-grpc_to_secret.invoke_1.int1
+  num1         = data.config-grpc_to_secret.invoke_2.num1
+  bool1        = data.config-grpc_to_secret.invoke_3.bool1
+  list_string1 = data.config-grpc_to_secret.invoke_4.list_string1
+  list_string2 = ["VALUE", data.config-grpc_to_secret.invoke_5.string1]
   # TODO[pulumi/pulumi#17535] this currently breaks Go compilation unfortunately.
   # mapString1 = invoke("config-grpc:index:toSecret", {mapString1 = { key1 = "SECRET", key2 = "SECRET2" }}).mapString1
   map_string2 = {
     "key1" = "value1"
-    "key2" = data.config-grpc_tosecret.invoke_6.string1
+    "key2" = data.config-grpc_to_secret.invoke_6.string1
   }
   # TODO[pulumi/pulumi#17535] this breaks Go compilation as well.
   # os1 = invoke("config-grpc:index:toSecret", {objString1 = { x = "SECRET" }}).objString1
   obj_string2 = {
-    x = data.config-grpc_tosecret.invoke_7.string1
+    x = data.config-grpc_to_secret.invoke_7.string1
   }
 }
-resource "config-grpc_configfetcher" "config" {
+resource "config-grpc_config_fetcher" "config" {
   provider = pulumi_providers_config-grpc.config_grpc_provider
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-provider-grpc-config/main.hcl
@@ -39,6 +39,6 @@ resource "pulumi_providers_config-grpc" "config_grpc_provider" {
     x = 42
   }
 }
-resource "config-grpc_configfetcher" "config" {
+resource "config-grpc_config_fetcher" "config" {
   provider = pulumi_providers_config-grpc.config_grpc_provider
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-asset-archive/subdir/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-asset-archive/subdir/main.hcl
@@ -7,16 +7,16 @@ pulumi {
   }
 }
 
-resource "asset-archive_assetresource" "ass" {
+resource "asset-archive_asset_resource" "ass" {
   value = fileAsset("../test.txt")
 }
-resource "asset-archive_archiveresource" "arc" {
+resource "asset-archive_archive_resource" "arc" {
   value = fileArchive("../archive.tar")
 }
-resource "asset-archive_archiveresource" "dir" {
+resource "asset-archive_archive_resource" "dir" {
   value = fileArchive("../folder")
 }
-resource "asset-archive_archiveresource" "assarc" {
+resource "asset-archive_archive_resource" "assarc" {
   value = assetArchive({
     "string"  = stringAsset("file contents")
     "file"    = fileAsset("../test.txt")
@@ -24,10 +24,10 @@ resource "asset-archive_archiveresource" "assarc" {
     "archive" = fileArchive("../archive.tar")
   })
 }
-resource "asset-archive_assetresource" "remoteass" {
+resource "asset-archive_asset_resource" "remoteass" {
   value = remoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt")
 }
-resource "asset-archive_archiveresource" "remotearc" {
+resource "asset-archive_archive_resource" "remotearc" {
   value = remoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")
 }
 // Plain (non-nested) asset/archive outputs must round-trip through stack

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-elide-unknowns/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-elide-unknowns/main.hcl
@@ -20,7 +20,7 @@ resource "output_resource" "unknown" {
   provider = pulumi_providers_output.prov
   value    = 1
 }
-resource "output_complexresource" "complex" {
+resource "output_complex_resource" "complex" {
   provider = pulumi_providers_output.prov
   value    = 1
 }
@@ -29,24 +29,24 @@ resource "simple_resource" "res" {
   value = output_resource.unknown.output == "hello"
 }
 resource "simple_resource" "resArray" {
-  value = output_complexresource.complex.output_array[0] == "hello"
+  value = output_complex_resource.complex.output_array[0] == "hello"
 }
 resource "simple_resource" "resMap" {
-  value = output_complexresource.complex.output_map["x"] == "hello"
+  value = output_complex_resource.complex.output_map["x"] == "hello"
 }
 resource "simple_resource" "resObject" {
-  value = output_complexresource.complex.output_object.output == "hello"
+  value = output_complex_resource.complex.output_object.output == "hello"
 }
 // And try to use it has an output
 output "out" {
   value = output_resource.unknown.output
 }
 output "outArray" {
-  value = output_complexresource.complex.output_array[0]
+  value = output_complex_resource.complex.output_array[0]
 }
 output "outMap" {
-  value = output_complexresource.complex.output_map["x"]
+  value = output_complex_resource.complex.output_map["x"]
 }
 output "outObject" {
-  value = output_complexresource.complex.output_object.output
+  value = output_complex_resource.complex.output_object.output
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-invoke-dynamic-function/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-invoke-dynamic-function/main.hcl
@@ -7,7 +7,7 @@ pulumi {
   }
 }
 
-data "any-type-function_dynlisttodyn" "invoke_0" {
+data "any-type-function_dyn_list_to_dyn" "invoke_0" {
   inputs = ["hello", local.localValue, {}]
 }
 
@@ -15,5 +15,5 @@ locals {
   localValue = "hello"
 }
 output "dynamic" {
-  value = data.any-type-function_dynlisttodyn.invoke_0.result
+  value = data.any-type-function_dyn_list_to_dyn.invoke_0.result
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-names/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-names/main.hcl
@@ -7,16 +7,16 @@ pulumi {
   }
 }
 
-resource "names_resmap" "res1" {
+resource "names_res_map" "res1" {
   value = true
 }
-resource "names_resarray" "res2" {
+resource "names_res_array" "res2" {
   value = true
 }
-resource "names_reslist" "res3" {
+resource "names_res_list" "res3" {
   value = true
 }
-resource "names_resresource" "res4" {
+resource "names_res_resource" "res4" {
   value = true
 }
 resource "names_mod_res" "res5" {

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-ignore-changes/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-ignore-changes/main.hcl
@@ -16,7 +16,7 @@ resource "nestedobject_receiver" "receiverIgnore" {
     value = "b"
   }
 }
-resource "nestedobject_mapcontainer" "mapIgnore" {
+resource "nestedobject_map_container" "mapIgnore" {
   lifecycle {
     ignore_changes = [tags["env"], tags["with.dot"], tags["with escaped \""]]
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-replace-on-changes/0/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-replace-on-changes/0/main.hcl
@@ -9,45 +9,45 @@ pulumi {
 
 // Stage 0: Initial resource creation
 // Scenario 1: Schema-based replaceOnChanges on replaceProp
-resource "replaceonchanges_resourcea" "schemaReplace" {
+resource "replaceonchanges_resource_a" "schemaReplace" {
   replace_on_changes = ["replaceProp"]
   value              = true
   replace_prop       = true
 }
 // Scenario 2: Option-based replaceOnChanges on value
-resource "replaceonchanges_resourceb" "optionReplace" {
+resource "replaceonchanges_resource_b" "optionReplace" {
   replace_on_changes = ["value"]
   value              = true
 }
 // Scenario 3: Both schema and option - will change value
-resource "replaceonchanges_resourcea" "bothReplaceValue" {
+resource "replaceonchanges_resource_a" "bothReplaceValue" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
 // Scenario 4: Both schema and option - will change replaceProp
-resource "replaceonchanges_resourcea" "bothReplaceProp" {
+resource "replaceonchanges_resource_a" "bothReplaceProp" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
 // Scenario 5: No replaceOnChanges - baseline update
-resource "replaceonchanges_resourceb" "regularUpdate" {
+resource "replaceonchanges_resource_b" "regularUpdate" {
   value = true
 }
 // Scenario 6: replaceOnChanges set but no change
-resource "replaceonchanges_resourceb" "noChange" {
+resource "replaceonchanges_resource_b" "noChange" {
   replace_on_changes = ["value"]
   value              = true
 }
 // Scenario 7: replaceOnChanges on value, but only replaceProp changes
-resource "replaceonchanges_resourcea" "wrongPropChange" {
+resource "replaceonchanges_resource_a" "wrongPropChange" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true
 }
 // Scenario 8: Multiple properties in replaceOnChanges array
-resource "replaceonchanges_resourcea" "multiplePropReplace" {
+resource "replaceonchanges_resource_a" "multiplePropReplace" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true
   replace_prop       = true

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-replace-on-changes/1/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-replace-on-changes/1/main.hcl
@@ -9,45 +9,45 @@ pulumi {
 
 // Stage 1: Change properties to trigger replacements
 // Scenario 1: Change replaceProp → REPLACE (schema triggers)
-resource "replaceonchanges_resourcea" "schemaReplace" {
+resource "replaceonchanges_resource_a" "schemaReplace" {
   replace_on_changes = ["replaceProp"]
   value              = true
   replace_prop       = false // Changed from true
 }
 // Scenario 2: Change value → REPLACE (option triggers)
-resource "replaceonchanges_resourceb" "optionReplace" {
+resource "replaceonchanges_resource_b" "optionReplace" {
   replace_on_changes = ["value"]
   value              = false // Changed from true
 }
 // Scenario 3: Change value → REPLACE (option on value triggers)
-resource "replaceonchanges_resourcea" "bothReplaceValue" {
+resource "replaceonchanges_resource_a" "bothReplaceValue" {
   replace_on_changes = ["replaceProp", "value"]
   value              = false // Changed from true
   replace_prop       = true // Unchanged
 }
 // Scenario 4: Change replaceProp → REPLACE (schema on replaceProp triggers)
-resource "replaceonchanges_resourcea" "bothReplaceProp" {
+resource "replaceonchanges_resource_a" "bothReplaceProp" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true // Unchanged
   replace_prop       = false // Changed from true
 }
 // Scenario 5: Change value → UPDATE (no replaceOnChanges)
-resource "replaceonchanges_resourceb" "regularUpdate" {
+resource "replaceonchanges_resource_b" "regularUpdate" {
   value = false // Changed from true
 }
 // Scenario 6: No change → SAME (no operation)
-resource "replaceonchanges_resourceb" "noChange" {
+resource "replaceonchanges_resource_b" "noChange" {
   replace_on_changes = ["value"]
   value              = true // Unchanged
 }
 // Scenario 7: Change replaceProp (not value) → UPDATE (marked property unchanged)
-resource "replaceonchanges_resourcea" "wrongPropChange" {
+resource "replaceonchanges_resource_a" "wrongPropChange" {
   replace_on_changes = ["replaceProp", "value"]
   value              = true // Unchanged (this is marked for replacement)
   replace_prop       = false // Changed from true (this is NOT marked for replacement by option)
 }
 // Scenario 8: Change value → REPLACE (multiple properties marked)
-resource "replaceonchanges_resourcea" "multiplePropReplace" {
+resource "replaceonchanges_resource_a" "multiplePropReplace" {
   replace_on_changes = ["replaceProp", "value"]
   value              = false // Changed from true
   replace_prop       = true // Unchanged

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-union/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-union/main.hcl
@@ -29,11 +29,11 @@ resource "union_example" "safeEnumExample" {
   typed_enum_property = "Block"
 }
 // Output enum: output from another resource used as enum input
-resource "union_enumoutput" "enumOutputExample" {
+resource "union_enum_output" "enumOutputExample" {
   name = "example"
 }
 resource "union_example" "outputEnumExample" {
-  typed_enum_property = union_enumoutput.enumOutputExample.type
+  typed_enum_property = union_enum_output.enumOutputExample.type
 }
 output "mapMapUnionOutput" {
   value = union_example.mapMapUnionExample.map_map_union_property

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-for-resource/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-for-resource/main.hcl
@@ -25,6 +25,6 @@ resource "nestedobject_container" "fromSimple" {
   inputs = [for _, detail in nestedobject_container.source.details : detail.value]
 }
 # for producing a map
-resource "nestedobject_mapcontainer" "mapped" {
+resource "nestedobject_map_container" "mapped" {
   tags = {for _, detail in nestedobject_container.source.details : detail.key => detail.value}
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-resource-output-traversal/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-resource-output-traversal/main.hcl
@@ -10,7 +10,7 @@ pulumi {
 resource "nestedobject_container" "container" {
   inputs = ["alpha", "bravo"]
 }
-resource "nestedobject_mapcontainer" "mapContainer" {
+resource "nestedobject_map_container" "mapContainer" {
   tags = {
     "k1" = "charlie"
     "k2" = "delta"
@@ -23,6 +23,6 @@ resource "nestedobject_target" "listOutput" {
 }
 # A resource that ranges over a computed map
 resource "nestedobject_target" "mapOutput" {
-  for_each = nestedobject_mapcontainer.mapContainer.tags
+  for_each = nestedobject_map_container.mapContainer.tags
   name     ="${each.key}=>${each.value}"
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/provider-builtin-info-component/main.hcl
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/provider-builtin-info-component/main.hcl
@@ -7,5 +7,5 @@ pulumi {
   }
 }
 
-resource "builtin-info-component_builtininfo" "res" {
+resource "builtin-info-component_builtin_info" "res" {
 }

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -813,6 +813,39 @@ func (g *generator) genCallBlock(body *hclwrite.Body, cb spilledCall) hcl.Diagno
 	return diags
 }
 
+func invokeSchemaPackage(f *schema.Function) schema.PackageReference {
+	if f == nil {
+		return nil
+	}
+	return f.PackageReference
+}
+
+// invokeSchemaToken returns the source-form token from the schema when available.
+// PCL canonicalizes tokens by applying ModuleFormat once during binding, which
+// strips the regex-matched suffix from the module component. Re-applying
+// TokenToModule on the canonicalized token would produce an incorrect (empty)
+// module, so codegen passes the schema's stored token instead.
+func invokeSchemaToken(f *schema.Function, fallback string) string {
+	if f == nil {
+		return fallback
+	}
+	return f.Token
+}
+
+func resourceSchemaPackage(r *schema.Resource) schema.PackageReference {
+	if r == nil {
+		return nil
+	}
+	return r.PackageReference
+}
+
+func resourceSchemaToken(r *schema.Resource, fallback string) string {
+	if r == nil {
+		return fallback
+	}
+	return r.Token
+}
+
 // lookupInvokeSchema resolves an invoke token against the program's loaded
 // package references and returns the function schema. It returns the
 // canonical token (with the module re-filled when PCL has stripped "index")
@@ -896,7 +929,7 @@ func (g *generator) genInvokeDataSource(body *hclwrite.Body, ds spilledDataSourc
 	}
 	token = schemaToken
 
-	dsType, diags := packages.PulumiTokenToHCL(token)
+	dsType, diags := packages.PulumiFunctionTokenToHCL(invokeSchemaPackage(invokeSchema), invokeSchemaToken(invokeSchema, token))
 	if diags.HasErrors() {
 		return diags
 	}
@@ -1006,7 +1039,7 @@ func (g *generator) genResource(body *hclwrite.Body, r *pcl.Resource) hcl.Diagno
 	defer func() { g.currentRangeKind = rangeKindNone }()
 
 	token, _ := r.GetToken()
-	hclType, d := packages.PulumiTokenToHCL(token)
+	hclType, d := packages.PulumiResourceTokenToHCL(resourceSchemaPackage(r.Schema), resourceSchemaToken(r.Schema, token))
 	if d.HasErrors() {
 		return d
 	}
@@ -1730,7 +1763,7 @@ func (g *generator) exprTokens(expr model.Expression, typ schema.Type) (hclwrite
 	case *model.TemplateExpression:
 		return g.templateTokens(e)
 	case *model.FunctionCallExpression:
-		// Check if this is an invoke that maps to a TF builtin — inline it.
+		// Check if this is an invoke or a TF builtin — inline it.
 		// Standalone use (not wrapped in .result) wraps the call in a single-
 		// field object so downstream .result access resolves correctly; the
 		// common .result wrapping is intercepted in relativeTraversalTokens
@@ -1763,7 +1796,8 @@ func (g *generator) exprTokens(expr model.Expression, typ schema.Type) (hclwrite
 						Detail:   "invoke token must be a string literal",
 					}}
 				}
-				dsType, diags := packages.PulumiTokenToHCL(token)
+				invokeSchema, schemaToken, _ := g.lookupInvokeSchema(token)
+				dsType, diags := packages.PulumiFunctionTokenToHCL(invokeSchemaPackage(invokeSchema), invokeSchemaToken(invokeSchema, schemaToken))
 				if diags.HasErrors() {
 					return nil, diags
 				}
@@ -2078,7 +2112,7 @@ func (g *generator) getOutputTokens(expr *model.FunctionCallExpression) (hclwrit
 
 	// Get the HCL resource type
 	token, _ := res.GetToken()
-	hclType, diags := packages.PulumiTokenToHCL(token)
+	hclType, diags := packages.PulumiResourceTokenToHCL(resourceSchemaPackage(res.Schema), resourceSchemaToken(res.Schema, token))
 	if diags.HasErrors() {
 		return nil, diags
 	}
@@ -2292,7 +2326,7 @@ func (g *generator) scopeTraversalTokens(expr *model.ScopeTraversalExpression) (
 					token, ok := extractStringLiteral(call.Args[0])
 					if ok {
 						invokeSchema, schemaToken, _ := g.lookupInvokeSchema(token)
-						dsType, d := packages.PulumiTokenToHCL(schemaToken)
+						dsType, d := packages.PulumiFunctionTokenToHCL(invokeSchemaPackage(invokeSchema), invokeSchemaToken(invokeSchema, schemaToken))
 						if !d.HasErrors() {
 							rewritten := hcl.Traversal{
 								hcl.TraverseRoot{Name: "data"},
@@ -2318,7 +2352,7 @@ func (g *generator) scopeTraversalTokens(expr *model.ScopeTraversalExpression) (
 		// [transform.SnakeCaseFromPulumiCase] on property values, and the invoke the standard ["<key>"]
 		// & [<idx>] operators otherwise.
 		token, _ := part.GetToken()
-		hclType, diags := packages.PulumiTokenToHCL(token)
+		hclType, diags := packages.PulumiResourceTokenToHCL(resourceSchemaPackage(part.Schema), resourceSchemaToken(part.Schema, token))
 		if diags.HasErrors() {
 			return nil, diags
 		}

--- a/pkg/docs/doc.go
+++ b/pkg/docs/doc.go
@@ -139,16 +139,7 @@ func (d DocLanguageHelper) GetResourceName(r *schema.Resource) string {
 // HCL emitter strips during program generation; routing through TokenToModule
 // matches that behavior so doc names line up with generated examples.
 func tokenToHCLName(pkg schema.PackageReference, token string) string {
-	if pkg != nil {
-		parts := strings.SplitN(token, ":", 3)
-		if len(parts) == 3 {
-			normalized := parts[0] + ":" + pkg.TokenToModule(token) + ":" + parts[2]
-			if hclName, diags := packages.PulumiTokenToHCL(normalized); !diags.HasErrors() {
-				return hclName
-			}
-		}
-	}
-	hclName, _ := packages.PulumiTokenToHCL(token)
+	hclName, _ := packages.PulumiResourceTokenToHCL(pkg, token)
 	return hclName
 }
 

--- a/pkg/docs/doc_test.go
+++ b/pkg/docs/doc_test.go
@@ -181,7 +181,7 @@ func TestGetResourceName(t *testing.T) {
 	}{
 		{"aws:s3:Bucket", "aws_s3_bucket"},
 		{"aws:index:Provider", "aws_provider"},
-		{"pulumi:pulumi:StackReference", "pulumi_stackreference"},
+		{"pulumi:pulumi:StackReference", "pulumi_stack_reference"},
 	}
 	for _, c := range cases {
 		t.Run(c.token, func(t *testing.T) {
@@ -196,14 +196,14 @@ func TestGetFunctionName(t *testing.T) {
 	t.Parallel()
 
 	got := helper.GetFunctionName(&schema.Function{Token: "aws:s3:getBucket"})
-	assert.Equal(t, "aws_s3_getbucket", got)
+	assert.Equal(t, "aws_s3_get_bucket", got)
 }
 
 // TestTokenNormalization_ViaPackage verifies that names are normalized through
 // the package's TokenToModule mapping. Schemas that use a moduleFormat regex
 // (such as pulumi-random's "(.*)(?:/[^/]*)") emit tokens like
 // "random:index/randomString:RandomString" but expect the HCL form to collapse
-// to "random_randomstring" — matching what GenerateProgram actually emits.
+// to "random_random_string" — matching what GenerateProgram actually emits.
 func TestTokenNormalization_ViaPackage(t *testing.T) {
 	t.Parallel()
 
@@ -229,9 +229,9 @@ func TestTokenNormalization_ViaPackage(t *testing.T) {
 		r, ok, err := pkg.Resources().Get("random:index/randomString:RandomString")
 		require.NoError(t, err)
 		require.True(t, ok)
-		assert.Equal(t, "random_randomstring", helper.GetResourceName(r))
+		assert.Equal(t, "random_random_string", helper.GetResourceName(r))
 		typ := &schema.ResourceType{Token: r.Token, Resource: r}
-		assert.Equal(t, "random_randomstring", helper.GetTypeName(pkg, typ, false, ""))
+		assert.Equal(t, "random_random_string", helper.GetTypeName(pkg, typ, false, ""))
 	})
 
 	t.Run("function", func(t *testing.T) {
@@ -239,11 +239,11 @@ func TestTokenNormalization_ViaPackage(t *testing.T) {
 		f, ok, err := pkg.Functions().Get("random:index/getRandom:getRandom")
 		require.NoError(t, err)
 		require.True(t, ok)
-		assert.Equal(t, "random_getrandom", helper.GetFunctionName(f))
+		assert.Equal(t, "random_get_random", helper.GetFunctionName(f))
 	})
 }
 
-// TestGetTypeName_ResourceWithoutPackage falls back to the raw PulumiTokenToHCL
+// TestGetTypeName_ResourceWithoutPackage falls back to the raw PulumiResourceTokenToHCL
 // when no package is provided to resolve the module via TokenToModule.
 func TestGetTypeName_ResourceWithoutPackage(t *testing.T) {
 	t.Parallel()
@@ -251,7 +251,7 @@ func TestGetTypeName_ResourceWithoutPackage(t *testing.T) {
 	typ := &schema.ResourceType{Token: "random:index/randomString:RandomString"}
 	// Without a package to consult TokenToModule, the raw token's submodule is
 	// preserved.
-	assert.Equal(t, "random_index_randomstring_randomstring",
+	assert.Equal(t, "random_index_random_string_random_string",
 		helper.GetTypeName(nil, typ, false, ""))
 }
 

--- a/pkg/hcl/packages/packages.go
+++ b/pkg/hcl/packages/packages.go
@@ -67,19 +67,50 @@ func (err InvalidToken) Error() string {
 	return b.String()
 }
 
-func PulumiTokenToHCL(token string) (string, hcl.Diagnostics) {
+// PulumiResourceTokenToHCL converts a Pulumi resource token to its canonical HCL form.
+func PulumiResourceTokenToHCL(pkg schema.PackageReference, token string) (string, hcl.Diagnostics) {
+	return pulumiTokenToHCL(pkg, token, false)
+}
+
+// PulumiFunctionTokenToHCL converts a Pulumi function token to its canonical HCL form.
+func PulumiFunctionTokenToHCL(pkg schema.PackageReference, token string) (string, hcl.Diagnostics) {
+	return pulumiTokenToHCL(pkg, token, true)
+}
+
+// isPulumiProvidersToken matches the schema's own special case for
+// "pulumi:providers:*" tokens, where TokenToModule returns "" regardless of
+// any configured ModuleFormat. Callers that derive an HCL name from the module
+// need the "providers" segment preserved to round-trip through the resolver.
+func isPulumiProvidersToken(pkgName, mod string) bool {
+	return pkgName == "pulumi" && (mod == "providers" || mod == "pulumi")
+}
+
+func pulumiTokenToHCL(pkg schema.PackageReference, token string, isFunction bool) (string, hcl.Diagnostics) {
 	if token == "pulumi:pulumi:StackReference" {
-		return "pulumi_stackreference", nil
+		return "pulumi_stack_reference", nil
 	}
-	pkg, mod, name, diag := pcl.DecomposeToken(token, hcl.Range{})
+	pkgName, mod, name, diag := pcl.DecomposeToken(token, hcl.Range{})
 	if diag.HasErrors() {
 		return "", diag
 	}
-	hclToken := pkg
-	if mod != "index" && mod != "" {
-		hclToken += "_" + strings.ToLower(strings.ReplaceAll(mod, "/", "_"))
+	// Apply the schema's ModuleFormat regex when available. TokenToModule
+	// collapses [pulumi:providers:*] tokens to the empty string by special-case,
+	// but we want to preserve the "providers" segment so the resolver can route
+	// the token back to a provider resource.
+	if pkg != nil && !isPulumiProvidersToken(pkgName, mod) {
+		mod = pkg.TokenToModule(token)
 	}
-	return hclToken + "_" + strings.ToLower(strings.ReplaceAll(name, "/", "_")), nil
+	if isFunction && len(name) > 3 && strings.HasPrefix(name, "get") {
+		r := rune(name[3])
+		if r >= 'A' && r <= 'Z' {
+			name = name[3:]
+		}
+	}
+	hclToken := pkgName
+	if mod != "index" && mod != "" {
+		hclToken += "_" + camelToSnake(mod)
+	}
+	return hclToken + "_" + camelToSnake(name), nil
 }
 
 // packageFromToken determines the package name from an HCL token and the list of
@@ -120,8 +151,9 @@ func ResolveResource(ctx context.Context, loader schema.ReferenceLoader, knownPr
 		return pkg.Provider()
 	}
 
-	// Prevent users from needing to write pulumi_pulumi_stackreference
-	if token == "pulumi_stackreference" {
+	// Prevent users from needing to write pulumi_pulumi_stack_reference.
+	// Both the underscore-split form and the legacy collapsed form are accepted.
+	if token == "pulumi_stack_reference" || token == "pulumi_stackreference" {
 		pkg, err := resolvePackage(ctx, loader, &schema.PackageDescriptor{Name: "pulumi"})
 		if err != nil {
 			return nil, err

--- a/pkg/hcl/packages/suggest_test.go
+++ b/pkg/hcl/packages/suggest_test.go
@@ -142,3 +142,59 @@ func TestLevenshtein(t *testing.T) {
 		require.Equal(t, tt.want, got, "levenshtein(%q, %q)", tt.a, tt.b)
 	}
 }
+
+func TestPulumiResourceTokenToHCL(t *testing.T) {
+	t.Parallel()
+
+	loader := schemaloader.New(t, schema.PackageSpec{
+		Name: "aws",
+		Meta: &schema.MetadataSpec{
+			ModuleFormat: `(.*)(?:/[^/]*)`,
+		},
+		Resources: map[string]schema.ResourceSpec{
+			"aws:s3/bucketWebsiteConfiguration:BucketWebsiteConfiguration": {},
+			"aws:lb/loadBalancer:LoadBalancer":                             {},
+			"aws:s3/bucket:Bucket":                                         {},
+		},
+		Functions: map[string]schema.FunctionSpec{
+			"aws:s3/getBucket:getBucket": {},
+		},
+	})
+	pkg, err := loader.LoadPackageReferenceV2(t.Context(), &schema.PackageDescriptor{Name: "aws"})
+	require.NoError(t, err)
+
+	t.Run("camelCase resource splits", func(t *testing.T) {
+		t.Parallel()
+		got, diags := PulumiResourceTokenToHCL(pkg, "aws:s3/bucketWebsiteConfiguration:BucketWebsiteConfiguration")
+		require.False(t, diags.HasErrors())
+		require.Equal(t, "aws_s3_bucket_website_configuration", got)
+	})
+
+	t.Run("function strips get prefix", func(t *testing.T) {
+		t.Parallel()
+		got, diags := PulumiFunctionTokenToHCL(pkg, "aws:s3/getBucket:getBucket")
+		require.False(t, diags.HasErrors())
+		require.Equal(t, "aws_s3_bucket", got)
+	})
+
+	t.Run("stack reference", func(t *testing.T) {
+		t.Parallel()
+		got, diags := PulumiResourceTokenToHCL(nil, "pulumi:pulumi:StackReference")
+		require.False(t, diags.HasErrors())
+		require.Equal(t, "pulumi_stack_reference", got)
+	})
+
+	t.Run("providers token preserves providers segment", func(t *testing.T) {
+		t.Parallel()
+		got, diags := PulumiResourceTokenToHCL(pkg, "pulumi:providers:aws")
+		require.False(t, diags.HasErrors())
+		require.Equal(t, "pulumi_providers_aws", got)
+	})
+
+	t.Run("nil package falls back to source-form module", func(t *testing.T) {
+		t.Parallel()
+		got, diags := PulumiResourceTokenToHCL(nil, "aws:s3/bucketWebsiteConfiguration:BucketWebsiteConfiguration")
+		require.False(t, diags.HasErrors())
+		require.Equal(t, "aws_s3_bucket_website_configuration_bucket_website_configuration", got)
+	})
+}


### PR DESCRIPTION
Here we remove the optional `get` prefix from datasources and insert `_` in camelCase word breaks. We also change the special-cased stack reference resource to follow the new pattern. For example:

```patch
-data "test_getfiltered" "invoke_0" {
+data "test_filtered" "invoke_0" {
   name = "my-filter"
```

```patch
-resource "output_complexresource" "res" {
+resource "output_complex_resource" "res" {
   value = 1
```

```patch
-resource "pulumi_stackreference" "ref" {
+resource "pulumi_stack_reference" "ref" {
   name = "organization/other/dev"
```

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/154