### PR TITLE
Fix Coalesce behavior to skip empty strings

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-170.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-170.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: coelesce now treats the empty string like null
+time: 2026-06-01T14:14:39.375293+02:00
+custom:
+    Component: runtime
+    PR: "170"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -110,7 +110,7 @@ func Functions(baseDir string) map[string]function.Function {
 		"alltrue":         allTrueFunc,
 		"anytrue":         anyTrueFunc,
 		"chunklist":       stdlib.ChunklistFunc,
-		"coalesce":        stdlib.CoalesceFunc,
+		"coalesce":        coalesceFunc,
 		"coalescelist":    stdlib.CoalesceListFunc,
 		"compact":         stdlib.CompactFunc,
 		"concat":          stdlib.ConcatFunc,
@@ -586,6 +586,49 @@ var oneFunc = function.New(&function.Spec{
 			return v, nil
 		}
 		return cty.NullVal(retType), nil
+	},
+})
+
+// coalesceFunc returns the first argument that is neither null nor an empty
+// string. cty's stdlib.CoalesceFunc only skips null, so it would return an empty
+// string where Terraform skips it. Other "zero" values (the number 0, empty
+// collections) are values in their own right and are returned as-is.
+var coalesceFunc = function.New(&function.Spec{
+	Params: []function.Parameter{},
+	VarParam: &function.Parameter{
+		Name:             "vals",
+		Type:             cty.DynamicPseudoType,
+		AllowUnknown:     true,
+		AllowDynamicType: true,
+		AllowNull:        true,
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		argTypes := make([]cty.Type, len(args))
+		for i, val := range args {
+			argTypes[i] = val.Type()
+		}
+		retType, _ := convert.UnifyUnsafe(argTypes)
+		if retType == cty.NilType {
+			return cty.NilType, fmt.Errorf("all arguments must have the same type")
+		}
+		return retType, nil
+	},
+	RefineResult: func(b *cty.RefinementBuilder) *cty.RefinementBuilder { return b.NotNull() },
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		for _, argVal := range args {
+			argVal, _ = convert.Convert(argVal, retType)
+			if !argVal.IsKnown() {
+				return cty.UnknownVal(retType), nil
+			}
+			if argVal.IsNull() {
+				continue
+			}
+			if retType == cty.String && argVal.RawEquals(cty.StringVal("")) {
+				continue
+			}
+			return argVal, nil
+		}
+		return cty.NilVal, fmt.Errorf("no non-null, non-empty-string arguments")
 	},
 })
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -235,8 +235,11 @@ func TestCollectionFunctions(t *testing.T) {
 			cty.StringVal("a"), cty.StringVal("b"),
 		})},
 
-		// coalesce (coalesce returns first non-empty, "" is technically a value so it's returned)
+		// coalesce returns the first non-null, non-empty-string argument.
 		{"coalesce", `coalesce("a", "b")`, cty.StringVal("a")},
+		{"coalesce skips empty string", `coalesce("", "b")`, cty.StringVal("b")},
+		{"coalesce skips null then empty", `coalesce(null, "", "w")`, cty.StringVal("w")},
+		{"coalesce keeps zero", `coalesce(0, 5)`, cty.NumberIntVal(0)},
 
 		// coalescelist (returns tuple type not list)
 		{"coalescelist", `length(coalescelist([], ["a"]))`, cty.NumberIntVal(1)},
@@ -607,6 +610,32 @@ func TestTypeFunctions(t *testing.T) {
 			if !result.RawEquals(tt.expected) {
 				t.Errorf("Expected %s, got %s", tt.expected.GoString(), result.GoString())
 			}
+		})
+	}
+}
+
+// TestCoalesceErrors pins that `coalesce` errors when every argument is skipped.
+// Both null and empty-string arguments are skipped, so an all-null or
+// all-empty-string call has no value to return and must fail rather than yield
+// null or an empty string.
+func TestCoalesceErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []cty.Value
+	}{
+		{"both null", []cty.Value{
+			cty.NullVal(cty.DynamicPseudoType), cty.NullVal(cty.DynamicPseudoType),
+		}},
+		{"all empty string", []cty.Value{cty.StringVal(""), cty.StringVal("")}},
+		{"null then empty string", []cty.Value{
+			cty.NullVal(cty.String), cty.StringVal(""),
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := coalesceFunc.Call(tt.args)
+			assert.EqualError(t, err, "no non-null, non-empty-string arguments")
 		})
 	}
 }

--- a/tests/tfcompat/l1_coalesce_test.go
+++ b/tests/tfcompat/l1_coalesce_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1Coalesce exercises the `coalesce` built-in: both paths must skip null
+// and empty-string arguments while preserving other "zero" values such as 0.
+func TestL1Coalesce(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_coalesce", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_coalesce/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_coalesce/main.tf
@@ -1,0 +1,44 @@
+# Terraform's `coalesce` returns the first argument that is neither null nor an
+# empty string. Empty strings are skipped, while other "zero" values such as the
+# number 0 are values in their own right and are returned as-is.
+output "empty_first" {
+  value = coalesce("", "b")
+}
+
+output "all_empty_but_last" {
+  value = coalesce("", "", "x")
+}
+
+output "first_nonempty" {
+  value = coalesce("a", "b")
+}
+
+output "null_skipped" {
+  value = coalesce(null, "z")
+}
+
+output "null_then_empty" {
+  value = coalesce(null, "", "w")
+}
+
+output "zero_is_value" {
+  value = coalesce(0, 5)
+}
+
+# Empty collections are values in their own right: only null and empty strings
+# are skipped, so an empty list or map is returned as-is.
+output "empty_list" {
+  value = coalesce(tolist([]), tolist(["y"]))
+}
+
+output "nonempty_list" {
+  value = coalesce(tolist(["a"]), tolist(["y"]))
+}
+
+output "empty_map" {
+  value = coalesce(tomap({}), tomap({ k = "v" }))
+}
+
+output "nonempty_map" {
+  value = coalesce(tomap({ a = "b" }), tomap({ k = "v" }))
+}


### PR DESCRIPTION
Match OpenTofu's `coalesce` behavior.

Before the change, this would emit `""`, now it correctly emits `"default"`.

```hcl
output "example" {
  value = coalesce("", "default")
}
```