### PR TITLE
Match Terraform's urlencode behavior

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-171.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-171.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`urlencode` matches Terraform: spaces become `+` and non-ASCII characters are percent-encoded as UTF-8 bytes'
+time: 2026-06-01T14:26:43.000000+02:00
+custom:
+    Component: runtime
+    PR: "171"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -32,6 +32,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -773,18 +774,7 @@ var urlEncodeFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		// Simple URL encoding
-		s := args[0].AsString()
-		var result strings.Builder
-		for _, r := range s {
-			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
-				r == '-' || r == '_' || r == '.' || r == '~' {
-				result.WriteRune(r)
-			} else {
-				fmt.Fprintf(&result, "%%%02X", r)
-			}
-		}
-		return cty.StringVal(result.String()), nil
+		return cty.StringVal(url.QueryEscape(args[0].AsString())), nil
 	},
 })
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -351,8 +351,10 @@ func TestEncodingFunctions(t *testing.T) {
 		{"base64decode", `base64decode("aGVsbG8=")`, cty.StringVal("hello")},
 		{"jsonencode map", `jsonencode({a = 1})`, cty.StringVal(`{"a":1}`)},
 		{"jsondecode", `jsondecode("{\"a\":1}").a`, cty.NumberIntVal(1)},
-		// urlencode uses %20 for spaces (not + which is form-encoded)
-		{"urlencode", `urlencode("hello world")`, cty.StringVal("hello%20world")},
+		// urlencode applies query-string encoding: spaces become + and non-ASCII
+		// characters are percent-encoded as their UTF-8 bytes.
+		{"urlencode", `urlencode("hello world")`, cty.StringVal("hello+world")},
+		{"urlencode unicode", `urlencode("café")`, cty.StringVal("caf%C3%A9")},
 		// base64gzip - check it returns non-empty string
 		{"base64gzip", `base64gzip("hello") != ""`, cty.BoolVal(true)},
 		{"csvdecode length", `length(csvdecode("a,b\n1,2\n3,4"))`, cty.NumberIntVal(2)},

--- a/tests/tfcompat/l1_urlencode_test.go
+++ b/tests/tfcompat/l1_urlencode_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1URLEncode exercises the `urlencode` built-in: both paths must apply
+// query-string encoding, turning spaces into `+` and percent-encoding non-ASCII
+// characters as their UTF-8 bytes.
+func TestL1URLEncode(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_urlencode", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_urlencode/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_urlencode/main.tf
@@ -1,0 +1,22 @@
+# Terraform's `urlencode` applies query-string URL encoding (Go's
+# url.QueryEscape): spaces become `+` and non-ASCII characters are first encoded
+# as UTF-8 and then percent-encoded byte by byte.
+output "space" {
+  value = urlencode("a b c")
+}
+
+output "reserved" {
+  value = urlencode("a/b?c=d&e")
+}
+
+output "plus" {
+  value = urlencode("a+b")
+}
+
+output "unicode" {
+  value = urlencode("café")
+}
+
+output "emoji" {
+  value = urlencode("hi 😀")
+}


### PR DESCRIPTION
Match OpenTofu's `urlencode` behavior, which is Go's `url.QueryEscape`.

The hand-rolled implementation diverged in two ways: it percent-encoded spaces as `%20` instead of `+`, and it iterated over runes formatting each codepoint with `%02X`, so non-ASCII characters were not encoded as their UTF-8 bytes (codepoints above `0xFF` overflowed the format entirely).

| Input | Before | After (matches tofu) |
|-------|--------|----------------------|
| `"a b c"` | `a%20b%20c` | `a+b+c` |
| `"café"` | `caf%E9` | `caf%C3%A9` |
| `"hi 😀"` | `hi%20%1F600` | `hi+%F0%9F%98%80` |

```hcl
output "example" {
  value = urlencode("a b c")
}
```