### PR TITLE
Match Terraform's indent behavior

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-172.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-172.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`indent` matches Terraform: the first line is left unindented and blank lines are still padded'
+time: 2026-06-01T14:45:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "172"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -87,7 +87,7 @@ func Functions(baseDir string) map[string]function.Function {
 		"chomp":       stdlib.ChompFunc,
 		"format":      stdlib.FormatFunc,
 		"formatlist":  stdlib.FormatListFunc,
-		"indent":      indentFunc,
+		"indent":      stdlib.IndentFunc,
 		"join":        stdlib.JoinFunc,
 		"lower":       stdlib.LowerFunc,
 		"regex":       stdlib.RegexFunc,
@@ -270,27 +270,6 @@ var canFunc = function.New(&function.Spec{
 })
 
 // String functions
-
-var indentFunc = function.New(&function.Spec{
-	Params: []function.Parameter{
-		{Name: "spaces", Type: cty.Number},
-		{Name: "string", Type: cty.String},
-	},
-	Type: function.StaticReturnType(cty.String),
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		spaces := args[0].AsBigFloat()
-		spacesInt, _ := spaces.Int64()
-		str := args[1].AsString()
-		indent := strings.Repeat(" ", int(spacesInt))
-		lines := strings.Split(str, "\n")
-		for i := range lines {
-			if lines[i] != "" {
-				lines[i] = indent + lines[i]
-			}
-		}
-		return cty.StringVal(strings.Join(lines, "\n")), nil
-	},
-})
 
 var startsWithFunc = function.New(&function.Spec{
 	Params: []function.Parameter{

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -87,8 +87,9 @@ func TestStringFunctions(t *testing.T) {
 		// chomp
 		{"chomp", `chomp("hello\n")`, cty.StringVal("hello")},
 
-		// indent
-		{"indent", `indent(2, "hello\nworld")`, cty.StringVal("  hello\n  world")},
+		// indent pads after each newline, leaving the first line untouched.
+		{"indent", `indent(2, "hello\nworld")`, cty.StringVal("hello\n  world")},
+		{"indent pads blank line", `indent(2, "a\n\nb")`, cty.StringVal("a\n  \n  b")},
 
 		// title
 		{"title", `title("hello world")`, cty.StringVal("Hello World")},

--- a/tests/tfcompat/l1_indent_test.go
+++ b/tests/tfcompat/l1_indent_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1Indent exercises the `indent` built-in: both paths must add spaces after
+// every newline, leaving the first line unindented while still padding blank
+// lines.
+func TestL1Indent(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_indent", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_indent/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_indent/main.tf
@@ -1,0 +1,19 @@
+# Terraform's `indent` adds the given number of spaces after every newline,
+# which leaves the first line untouched and still pads otherwise-blank lines.
+# The surrounding brackets make the leading whitespace of each line visible in
+# the stack output.
+output "two_lines" {
+  value = "[${indent(2, "hello\nworld")}]"
+}
+
+output "blank_line" {
+  value = "[${indent(2, "a\n\nb")}]"
+}
+
+output "list_block" {
+  value = "items: ${indent(4, "[\n  a,\n  b,\n]")}"
+}
+
+output "single_line" {
+  value = "[${indent(4, "no newline")}]"
+}


### PR DESCRIPTION
Match OpenTofu's `indent` behavior, which is cty's `stdlib.IndentFunc`.

The hand-rolled implementation split on newlines and prefixed every non-empty line, which indented the first line and dropped the padding on blank lines. Terraform adds the spaces *after each newline*, so the first line is left untouched and blank lines are still padded.

| Input | Before | After (matches tofu) |
|-------|--------|----------------------|
| `indent(2, "hello\nworld")` | `  hello\n  world` | `hello\n  world` |
| `indent(2, "a\n\nb")` | `  a\n\n  b` | `a\n  \n  b` |
| `indent(4, "no newline")` | `    no newline` | `no newline` |

```hcl
output "example" {
  value = "[${indent(2, "hello\nworld")}]"
}
```