### PR TITLE
Sum numbers with arbitrary precision

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-173.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-173.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`sum` accumulates with arbitrary-precision numbers instead of float64, so large integers and decimals stay exact'
+time: 2026-06-01T15:05:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "173"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -638,13 +638,16 @@ var sumFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.Number),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		sum := 0.0
-		for it := args[0].ElementIterator(); it.Next(); {
-			_, v := it.Element()
-			f, _ := v.AsBigFloat().Float64()
-			sum += f
+		if args[0].LengthInt() == 0 {
+			// Matching OpenTofu's behavior, we error on an empty list
+			return cty.NilVal, fmt.Errorf("cannot sum an empty list")
 		}
-		return cty.NumberFloatVal(sum), nil
+		elements := args[0].AsValueSlice()
+		sum := elements[0]
+		for _, v := range elements[1:] {
+			sum = sum.Add(v)
+		}
+		return sum, nil
 	},
 })
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -262,8 +262,10 @@ func TestCollectionFunctions(t *testing.T) {
 		{"one single", `one(["hello"])`, cty.StringVal("hello")},
 		{"one empty", `one([])`, cty.NullVal(cty.DynamicPseudoType)},
 
-		// sum
+		// sum accumulates with arbitrary precision, so the exact result survives
+		// even when an input is not representable as a float64.
 		{"sum", `sum([1, 2, 3, 4])`, cty.NumberIntVal(10)},
+		{"sum precise", `sum([9007199254740993, 1])`, cty.NumberIntVal(9007199254740994)},
 
 		// min/max
 		{"min", `min(5, 2, 8)`, cty.NumberIntVal(2)},
@@ -638,6 +640,13 @@ func TestCoalesceErrors(t *testing.T) {
 			assert.EqualError(t, err, "no non-null, non-empty-string arguments")
 		})
 	}
+}
+
+// TestSumEmptyList pins that `sum` of an empty list errors, as Terraform does,
+// rather than returning zero.
+func TestSumEmptyList(t *testing.T) {
+	_, err := sumFunc.Call([]cty.Value{cty.ListValEmpty(cty.Number)})
+	assert.EqualError(t, err, "cannot sum an empty list")
 }
 
 // TestToSetToListPreserveEmptyElementType pins that `toset` / `tolist` over a

--- a/tests/tfcompat/l1_sum_test.go
+++ b/tests/tfcompat/l1_sum_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1Sum exercises the `sum` built-in: both paths must accumulate with
+// arbitrary-precision numbers so large integers and decimal fractions stay
+// exact rather than being rounded through float64.
+func TestL1Sum(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_sum", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_sum/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_sum/main.tf
@@ -1,0 +1,15 @@
+# Terraform's `sum` accumulates with arbitrary-precision numbers, so the
+# intermediate additions stay exact rather than being rounded through float64.
+# 9007199254740993 is not representable as a float64, but the exact sum
+# 9007199254740994 is, so a precise accumulation round-trips through the output.
+output "big_ints" {
+  value = sum([9007199254740993, 1])
+}
+
+output "decimals" {
+  value = sum([0.1, 0.2])
+}
+
+output "mixed" {
+  value = sum([1, 2, 3, 4])
+}


### PR DESCRIPTION
Match OpenTofu's `sum`, which accumulates with arbitrary-precision numbers (`cty.Value.Add` / `big.Float`).

The hand-rolled implementation converted each element to a `float64` and summed in `float64`, rounding large integers and decimal fractions. Accumulating with `cty.Value.Add` keeps the intermediate sums exact. An empty list now errors as Terraform does, since the accumulation has no first element to start from.

| Input | Before | After (matches tofu) |
|-------|--------|----------------------|
| `sum([9007199254740993, 1])` | `9007199254740992` | `9007199254740994` |
| `sum([0.1, 0.2])` | `0.30000000000000004` | `0.3` |
| `sum([])` | `0` | error: `cannot sum an empty list` |

```hcl
output "example" {
  value = sum([9007199254740993, 1])
}
```