### PR TITLE
Honor the IANA encoding in textencodebase64/textdecodebase64

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-174.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-174.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`textencodebase64` and `textdecodebase64` honor the named IANA encoding instead of always treating the bytes as UTF-8'
+time: 2026-06-01T15:30:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "174"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/apparentlymart/go-shquot v0.0.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-getter v1.8.6
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
@@ -28,6 +29,7 @@ require (
 	golang.org/x/crypto v0.51.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/text v0.37.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -169,7 +171,6 @@ require (
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.72 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.5.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
@@ -318,7 +319,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -55,6 +55,7 @@ import (
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/text/encoding/ianaindex"
 	"gopkg.in/yaml.v3"
 )
 
@@ -783,6 +784,8 @@ var base64GzipFunc = function.New(&function.Spec{
 	},
 })
 
+// textDecodeBase64Func base64-decodes a string and then reinterprets the bytes
+// using the named IANA character encoding.
 var textDecodeBase64Func = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{Name: "string", Type: cty.String},
@@ -790,14 +793,32 @@ var textDecodeBase64Func = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		enc, err := ianaindex.IANA.Encoding(args[1].AsString())
+		if err != nil || enc == nil {
+			return cty.NilVal, fmt.Errorf(
+				"%q is not a supported IANA encoding name or alias", args[1].AsString())
+		}
+
 		decoded, err := base64.StdEncoding.DecodeString(args[0].AsString())
 		if err != nil {
-			return cty.NilVal, err
+			return cty.NilVal, fmt.Errorf("invalid source string: %w", err)
 		}
-		return cty.StringVal(string(decoded)), nil
+
+		reinterpreted, err := enc.NewDecoder().Bytes(decoded)
+		if err != nil || bytes.ContainsRune(reinterpreted, '�') {
+			encName, err := ianaindex.IANA.Name(enc)
+			if err != nil {
+				encName = args[1].AsString()
+			}
+			return cty.NilVal, fmt.Errorf(
+				"the given string contains symbols that are not defined for %s", encName)
+		}
+		return cty.StringVal(string(reinterpreted)), nil
 	},
 })
 
+// textEncodeBase64Func re-encodes a UTF-8 string into the named IANA character
+// encoding and then base64-encodes the result.
 var textEncodeBase64Func = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{Name: "string", Type: cty.String},
@@ -805,8 +826,22 @@ var textEncodeBase64Func = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		encoded := base64.StdEncoding.EncodeToString([]byte(args[0].AsString()))
-		return cty.StringVal(encoded), nil
+		enc, err := ianaindex.IANA.Encoding(args[1].AsString())
+		if err != nil || enc == nil {
+			return cty.NilVal, fmt.Errorf(
+				"%q is not a supported IANA encoding name or alias", args[1].AsString())
+		}
+		encName, err := ianaindex.IANA.Name(enc)
+		if err != nil {
+			encName = args[1].AsString()
+		}
+
+		encoded, err := enc.NewEncoder().Bytes([]byte(args[0].AsString()))
+		if err != nil {
+			return cty.NilVal, fmt.Errorf(
+				"the given string contains characters that cannot be represented in %s", encName)
+		}
+		return cty.StringVal(base64.StdEncoding.EncodeToString(encoded)), nil
 	},
 })
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -361,6 +361,10 @@ func TestEncodingFunctions(t *testing.T) {
 		{"csvdecode length", `length(csvdecode("a,b\n1,2\n3,4"))`, cty.NumberIntVal(2)},
 		{"textencodebase64", `textencodebase64("hello", "UTF-8")`, cty.StringVal("aGVsbG8=")},
 		{"textdecodebase64", `textdecodebase64("aGVsbG8=", "UTF-8")`, cty.StringVal("hello")},
+		// The encoding argument is honored: UTF-16LE encodes each ASCII
+		// character as two bytes, so its base64 output differs from UTF-8.
+		{"textencodebase64 utf16le", `textencodebase64("hello", "UTF-16LE")`, cty.StringVal("aABlAGwAbABvAA==")},
+		{"textdecodebase64 utf16le", `textdecodebase64("aABlAGwAbABvAA==", "UTF-16LE")`, cty.StringVal("hello")},
 	}
 
 	for _, tt := range tests {

--- a/tests/tfcompat/l1_textencodebase64_test.go
+++ b/tests/tfcompat/l1_textencodebase64_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1TextEncodeBase64 exercises `textencodebase64` and `textdecodebase64`:
+// both paths must honor the named IANA character encoding rather than always
+// treating the bytes as UTF-8.
+func TestL1TextEncodeBase64(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_textencodebase64", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_textencodebase64/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_textencodebase64/main.tf
@@ -1,0 +1,19 @@
+# Terraform's `textencodebase64` / `textdecodebase64` honor the named IANA
+# character encoding: the string is transcoded into (or out of) that encoding
+# around the base64 step. UTF-16LE encodes each ASCII character as two bytes, so
+# its base64 output differs from the UTF-8 encoding of the same string.
+output "utf16le" {
+  value = textencodebase64("hello", "UTF-16LE")
+}
+
+output "utf8" {
+  value = textencodebase64("hello", "UTF-8")
+}
+
+output "decode_utf16le" {
+  value = textdecodebase64("aABlAGwAbABvAA==", "UTF-16LE")
+}
+
+output "roundtrip" {
+  value = textdecodebase64(textencodebase64("café", "UTF-16LE"), "UTF-16LE")
+}


### PR DESCRIPTION
Match OpenTofu, which transcodes the string into (or out of) the named IANA character encoding around the base64 step (`golang.org/x/text/encoding/ianaindex`).

Both functions ignored their `encoding` argument and always treated the bytes as UTF-8, so any other encoding produced the wrong result. Unsupported encodings and unrepresentable characters now error rather than silently falling back to UTF-8.

| Expression | Before | After (matches tofu) |
|------------|--------|----------------------|
| `textencodebase64("hello", "UTF-16LE")` | `aGVsbG8=` | `aABlAGwAbABvAA==` |
| `textdecodebase64("aABlAGwAbABvAA==", "UTF-16LE")` | `h\x00e\x00l\x00l\x00o\x00` | `hello` |

```hcl
output "example" {
  value = textencodebase64("hello", "UTF-16LE")
}
```