### PR TITLE
Match Terraform's formatdate behavior

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-175.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-175.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`formatdate` matches Terraform: correct 24-hour vs 12-hour tokens, timezone tokens, and single-quoted literals'
+time: 2026-06-01T16:05:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "175"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -167,7 +167,7 @@ func Functions(baseDir string) map[string]function.Function {
 		"templatefile": templateFileFunc(baseDir),
 
 		// Date and time functions
-		"formatdate": formatDateFunc,
+		"formatdate": stdlib.FormatDateFunc,
 		"timeadd":    timeAddFunc,
 		"timecmp":    timeCmpFunc,
 		"timestamp":  timestampFunc,
@@ -1075,59 +1075,6 @@ func renderTemplate(
 }
 
 // Date and time functions
-
-var formatDateFunc = function.New(&function.Spec{
-	Params: []function.Parameter{
-		{Name: "spec", Type: cty.String},
-		{Name: "timestamp", Type: cty.String},
-	},
-	Type: function.StaticReturnType(cty.String),
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		spec := args[0].AsString()
-		ts := args[1].AsString()
-
-		t, err := time.Parse(time.RFC3339, ts)
-		if err != nil {
-			return cty.NilVal, fmt.Errorf("invalid timestamp: %s", err)
-		}
-
-		// Convert Terraform's date format spec to Go format
-		// Order matters - longer patterns must come before shorter ones
-		replacements := []struct {
-			from, to string
-		}{
-			{"YYYY", "2006"},
-			{"YY", "06"},
-			{"MMMM", "January"},
-			{"MMM", "Jan"},
-			{"MM", "01"},
-			{"DD", "02"},
-			{"EEEE", "Monday"},
-			{"EEE", "Mon"},
-			{"HH", "15"},
-			{"hh", "03"},
-			{"mm", "04"},
-			{"ss", "05"},
-			{"AA", "PM"},
-			{"aa", "pm"},
-			{"ZZZZ", "-07:00"},
-			{"ZZZ", "MST"},
-			{"Z", "-0700"},
-			// Single character replacements must come last
-			{"M", "1"},
-			{"D", "2"},
-			{"h", "3"},
-			{"m", "4"},
-			{"s", "5"},
-		}
-		result := spec
-		for _, r := range replacements {
-			result = strings.ReplaceAll(result, r.from, r.to)
-		}
-
-		return cty.StringVal(t.Format(result)), nil
-	},
-})
 
 var timeAddFunc = function.New(&function.Spec{
 	Params: []function.Parameter{

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -670,6 +670,14 @@ func TestToSetToListPreserveEmptyElementType(t *testing.T) {
 }
 
 func TestDateTimeFunctions(t *testing.T) {
+	t.Parallel()
+
+	is := func(v cty.Value) func(cty.Value) bool {
+		return func(o cty.Value) bool {
+			return v.Equals(o).True()
+		}
+	}
+
 	tests := []struct {
 		name  string
 		expr  string
@@ -687,39 +695,46 @@ func TestDateTimeFunctions(t *testing.T) {
 		{
 			"timeadd",
 			`timeadd("2023-01-01T00:00:00Z", "24h")`,
-			func(v cty.Value) bool {
-				return v.AsString() == "2023-01-02T00:00:00Z"
-			},
+			is(cty.StringVal("2023-01-02T00:00:00Z")),
 		},
 		{
 			"timecmp equal",
 			`timecmp("2023-01-01T00:00:00Z", "2023-01-01T00:00:00Z")`,
-			func(v cty.Value) bool {
-				bf := v.AsBigFloat()
-				i, _ := bf.Int64()
-				return i == 0
-			},
+			is(cty.NumberIntVal(0)),
 		},
 		{
 			"timecmp less",
 			`timecmp("2023-01-01T00:00:00Z", "2023-01-02T00:00:00Z")`,
-			func(v cty.Value) bool {
-				bf := v.AsBigFloat()
-				i, _ := bf.Int64()
-				return i == -1
-			},
+			is(cty.NumberIntVal(-1)),
 		},
 		{
 			"formatdate",
 			`formatdate("YYYY-MM-DD", "2023-06-15T12:30:00Z")`,
-			func(v cty.Value) bool {
-				return v.AsString() == "2023-06-15"
-			},
+			is(cty.StringVal("2023-06-15")),
+		},
+		{
+			// Lowercase h/hh is the 24-hour clock.
+			"formatdate 24-hour",
+			`formatdate("hh:mm:ss", "2023-06-15T13:05:07Z")`,
+			is(cty.StringVal("13:05:07")),
+		},
+		{
+			// Uppercase H/HH is the 12-hour clock.
+			"formatdate 12-hour",
+			`formatdate("HH AA", "2023-06-15T13:05:07Z")`,
+			is(cty.StringVal("01 PM")),
+		},
+		{
+			// ZZZZZ keeps the colon, ZZZZ drops it, and 'at' is a literal.
+			"formatdate timezone and literal",
+			`formatdate("ZZZZZ 'at' ZZZZ", "2023-06-15T13:05:07Z")`,
+			is(cty.StringVal("+00:00 at +0000")),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := evalExpr(t, "/tmp", tt.expr)
 			if !tt.check(result) {
 				t.Errorf("Check failed for %s, got %s", tt.name, result.GoString())

--- a/tests/tfcompat/l1_formatdate_test.go
+++ b/tests/tfcompat/l1_formatdate_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1FormatDate exercises the `formatdate` built-in: both paths must agree on
+// the 24-hour (`h`/`hh`) vs 12-hour (`H`/`HH`) tokens, the timezone tokens, and
+// single-quoted literals.
+func TestL1FormatDate(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_formatdate", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_formatdate/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_formatdate/main.tf
@@ -1,0 +1,42 @@
+# Terraform's `formatdate` uses lowercase `h`/`hh` for the 24-hour clock and
+# uppercase `H`/`HH` for the 12-hour clock, and supports the `Z`/`ZZZZ`/`ZZZZZ`
+# timezone tokens and single-quoted literals.
+locals {
+  t = "2018-01-02T13:05:07Z"
+}
+
+output "hh_24" {
+  value = formatdate("hh", local.t)
+}
+
+output "h_24" {
+  value = formatdate("h", local.t)
+}
+
+output "cap_hh_12" {
+  value = formatdate("HH", local.t)
+}
+
+output "cap_h_12" {
+  value = formatdate("H", local.t)
+}
+
+output "tz_long" {
+  value = formatdate("ZZZZZ", local.t)
+}
+
+output "tz_mid" {
+  value = formatdate("ZZZZ", local.t)
+}
+
+output "tz_short" {
+  value = formatdate("Z", local.t)
+}
+
+output "human" {
+  value = formatdate("EEE, DD MMM YYYY hh:mm:ss", local.t)
+}
+
+output "literal" {
+  value = formatdate("DD 'of' MMMM", local.t)
+}


### PR DESCRIPTION
Match OpenTofu, which binds `formatdate` to cty's `stdlib.FormatDateFunc`.

The hand-rolled implementation translated the format spec to a Go time layout with sequential string replacements, which was wrong in several ways:
- lowercase `h`/`hh` (24-hour) and uppercase `H`/`HH` (12-hour) had their meanings swapped;
- the `H` (12-hour, unpadded) and `ZZZZZ` tokens were missing entirely;
- timezone tokens produced the wrong delimiters;
- single-quoted literals were not unwrapped;
- replacements re-applied to earlier output (e.g. the `M` in a generated `Mon` became `1on`).

For `2018-01-02T13:05:07Z`:

| Format | Before | After (matches tofu) |
|--------|--------|----------------------|
| `hh` | `01` | `13` |
| `HH` | `13` | `01` |
| `H` | `H` | `1` |
| `ZZZZZ` | `+00:00+0000` | `+00:00` |
| `ZZZZ` | `+00:00` | `+0000` |
| `Z` | `+0000` | `Z` |
| `EEE, DD MMM YYYY hh:mm:ss` | `1on, 02 Jan 2018 01:05:07` | `Tue, 02 Jan 2018 13:05:07` |
| `DD 'of' MMMM` | `02 'of' January` | `02 of January` |

```hcl
output "example" {
  value = formatdate("EEE, DD MMM YYYY hh:mm:ss", "2018-01-02T13:05:07Z")
}
```