### PR TITLE
Match OpenTofu's `tonumber` behavior

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-180.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-180.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`tonumber` matches OpenTofu: parses the whole decimal string rather than truncating at the first non-digit, so fractions, exponents, and negatives round-trip'
+time: 2026-06-01T16:40:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "180"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -1741,25 +1741,17 @@ var toNumberFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.Number),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		val := args[0]
-		if val.Type() == cty.Number {
-			return val, nil
-		}
-		if val.Type() == cty.String {
-			s := val.AsString()
-			// Try parsing as integer first
-			var i int64
-			if _, err := fmt.Sscanf(s, "%d", &i); err == nil {
-				return cty.NumberIntVal(i), nil
+		ret, err := convert.Convert(args[0], cty.Number)
+		if err != nil {
+			val, _ := args[0].UnmarkDeep()
+			if val.Type() == cty.String && !val.IsNull() {
+				return cty.NilVal, fmt.Errorf(
+					"cannot convert %q to number; given string must be a decimal representation of a number",
+					val.AsString())
 			}
-			// Try parsing as float
-			var f float64
-			if _, err := fmt.Sscanf(s, "%f", &f); err == nil {
-				return cty.NumberFloatVal(f), nil
-			}
-			return cty.NilVal, fmt.Errorf("cannot convert %q to number", s)
+			return cty.NilVal, fmt.Errorf("cannot convert %s to number", val.Type().FriendlyName())
 		}
-		return cty.NilVal, fmt.Errorf("cannot convert %s to number", val.Type().FriendlyName())
+		return ret, nil
 	},
 })
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -623,6 +623,38 @@ func TestTypeFunctions(t *testing.T) {
 	}
 }
 
+// TestToNumber pins that `tonumber` parses the whole string as a decimal
+// number rather than truncating at the first non-digit character. A `%d`-style
+// parse would stop at the '.' in "3.14" or the 'e' in "1e2" and silently return
+// a truncated integer.
+func TestToNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		expected cty.Value
+	}{
+		{"integer", `tonumber("42")`, cty.MustParseNumberVal("42")},
+		{"fraction", `tonumber("3.14")`, cty.MustParseNumberVal("3.14")},
+		{"exponent", `tonumber("1e2")`, cty.MustParseNumberVal("1e2")},
+		{"negative fraction", `tonumber("-2.5")`, cty.MustParseNumberVal("-2.5")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := evalExpr(t, "/tmp", tt.expr)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestToNumberError pins that `tonumber` of a string that is not a decimal
+// number errors rather than returning a truncated value.
+func TestToNumberError(t *testing.T) {
+	_, err := toNumberFunc.Call([]cty.Value{cty.StringVal("12abc")})
+	assert.EqualError(t, err,
+		`cannot convert "12abc" to number; given string must be a decimal representation of a number`)
+}
+
 // TestCoalesceErrors pins that `coalesce` errors when every argument is skipped.
 // Both null and empty-string arguments are skipped, so an all-null or
 // all-empty-string call has no value to return and must fail rather than yield

--- a/tests/tfcompat/l1_tonumber_test.go
+++ b/tests/tfcompat/l1_tonumber_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1ToNumber exercises the `tonumber` built-in: both paths must parse the
+// entire string as a decimal number rather than truncating at the first
+// non-digit, so fractional, exponential, and negative values round-trip.
+func TestL1ToNumber(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_tonumber", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_tonumber/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_tonumber/main.tf
@@ -1,0 +1,19 @@
+# Terraform's `tonumber` parses the whole string as a decimal number, so
+# fractional, exponential, and negative representations round-trip exactly. A
+# `%d`-style parse that stops at the first non-digit would truncate "3.14" to 3,
+# "1e2" to 1, and "-2.5" to -2.
+output "pi" {
+  value = tonumber("3.14")
+}
+
+output "exp" {
+  value = tonumber("1e2")
+}
+
+output "neg" {
+  value = tonumber("-2.5")
+}
+
+output "int" {
+  value = tonumber("42")
+}


### PR DESCRIPTION
## Divergence

`tonumber` was hand-rolled in `pkg/hcl/eval/functions.go` and used `fmt.Sscanf(s, "%d", &i)` as its first parse attempt. `%d` stops at the first non-digit character and reports success on the prefix it consumed, so any non-integer string was silently truncated:

| input | OpenTofu (`tofu apply`) | pulumi-hcl (before) |
|-------|-------------------------|---------------------|
| `tonumber("3.14")` | `3.14` | `3` |
| `tonumber("1e2")`  | `100`  | `1` |
| `tonumber("-2.5")` | `-2.5` | `-2` |

## Fix

OpenTofu binds `tonumber` to `MakeToFunc(cty.Number)`, which runs the value through cty's `convert` package and parses the whole string as a decimal number. The fix delegates to `convert.Convert(args[0], cty.Number)` so fractions, exponents, and negatives round-trip, and non-numeric strings are rejected with a matching error instead of being truncated.

## Proof

- New tfcompat case `l1_tonumber` (`tests/tfcompat/testdata/cases/l1_tonumber/main.tf`) runs the same program through both `tofu apply` and `pulumi up` and asserts identical stack outputs. It fails on master (`3, 1, -2` vs `3.14, 100, -2.5`) and passes with the fix.
- Unit tests `TestToNumber` / `TestToNumberError` in `pkg/hcl/eval/functions_test.go` pin the parsing and error behavior.

Both pass after a rebuild (`-count=1`).