### PR TITLE
Honor `nullable = false` default substitution for module inputs

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-185.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-185.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: A module input variable declared `nullable = false` now substitutes its default when the caller passes `null`, matching Terraform and OpenTofu
+time: 2026-06-01T18:00:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "185"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2466,6 +2466,20 @@ func (e *Engine) processModuleVariable(node *graph.Node) error {
 			}
 		}
 
+		// A `nullable = false` variable rejects an explicit null argument: the
+		// default is substituted when one is declared, otherwise it is an
+		// error. Matches Terraform/OpenTofu.
+		if val.IsNull() && !v.Nullable {
+			if v.Default == nil {
+				return fmt.Errorf("variable %q must not be set to null: it is declared with nullable = false and has no default", varName)
+			}
+			var diags hcl.Diagnostics
+			val, diags = v.Default.Value(inst.EvalCtx.HCLContext())
+			if diags.HasErrors() {
+				return fmt.Errorf("evaluating variable default for %s: %s", varName, diags.Error())
+			}
+		}
+
 		// Fill in optional()-attribute defaults before type conversion so
 		// the result satisfies the declared object shape.
 		if v.TypeDefaults != nil && !val.IsNull() && val.IsKnown() {

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -762,6 +762,87 @@ variable "required_var" {
 	}
 }
 
+// TestEngine_ModuleNullableFalseNullInput covers a `nullable = false` child
+// module variable that receives `null` from its caller. With a default,
+// Terraform/OpenTofu substitute the default; without one, it is an error.
+func TestEngine_ModuleNullableFalseNullInput(t *testing.T) {
+	t.Parallel()
+
+	const childWithDefault = `
+variable "items" {
+  type     = list(string)
+  default  = ["a", "b"]
+  nullable = false
+}
+
+output "count" {
+  value = length(var.items)
+}
+`
+	const childNoDefault = `
+variable "items" {
+  type     = list(string)
+  nullable = false
+}
+
+output "count" {
+  value = length(var.items)
+}
+`
+	const rootMain = `
+module "child" {
+  source = "./modules/child"
+  items  = null
+}
+
+output "item_count" {
+  value = module.child.count
+}
+`
+
+	run := func(t *testing.T, childMain string) (*testutil.MockResourceMonitor, error) {
+		tmpDir := t.TempDir()
+		moduleDir := tmpDir + "/modules/child"
+		require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+		require.NoError(t, os.WriteFile(moduleDir+"/main.tf", []byte(childMain), 0o644))
+		require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(rootMain), 0o644))
+
+		p := parser.NewParser()
+		config, diags := p.ParseDirectory(tmpDir)
+		require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+		mock := &testutil.MockResourceMonitor{}
+		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: mock,
+			WorkDir:         tmpDir,
+			RootDir:         tmpDir,
+			SchemaLoader:    schemaloader.New(t, schema.PackageSpec{Name: "empty"}),
+		})
+		return mock, engine.Run(t.Context())
+	}
+
+	t.Run("with_default", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := run(t, childWithDefault)
+		require.NoError(t, err)
+
+		output, ok := mock.StackOutputs.GetOk("item_count")
+		require.True(t, ok, "expected item_count output")
+		assert.Equal(t, float64(2), output.AsNumber())
+	})
+
+	t.Run("no_default", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := run(t, childNoDefault)
+		assert.EqualError(t, err, `variable "items" must not be set to null: `+
+			`it is declared with nullable = false and has no default`+"\ncontext canceled")
+	})
+}
+
 func TestEngine_VariableValidationPass(t *testing.T) {
 	t.Parallel()
 

--- a/tests/tfcompat/l1_nullable_false_default_test.go
+++ b/tests/tfcompat/l1_nullable_false_default_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// A child module declares `items` with `nullable = false` and a default. The
+// caller passes `items = null`, which Terraform/OpenTofu replace with the
+// variable's default, so `length(var.items)` evaluates to 2. Both paths must
+// agree. See https://github.com/pulumi-labs/pulumi-hcl/issues/183.
+func TestL1NullableFalseDefault(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_nullable_false_default", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_nullable_false_default/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_nullable_false_default/child/main.tf
@@ -1,0 +1,24 @@
+# Assigning `null` to a `nullable = false` variable must substitute the
+# variable's default, so `length(var.items)` sees ["a", "b"] rather than null.
+variable "items" {
+  type     = list(string)
+  default  = ["a", "b"]
+  nullable = false
+}
+
+# Only null triggers default substitution. An empty string is a real value, so
+# `var.name` stays "" rather than falling back to the default — unlike coalesce,
+# which skips empty strings.
+variable "name" {
+  type     = string
+  default  = "default-name"
+  nullable = false
+}
+
+output "count" {
+  value = length(var.items)
+}
+
+output "name" {
+  value = var.name
+}

--- a/tests/tfcompat/testdata/cases/l1_nullable_false_default/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_nullable_false_default/main.tf
@@ -1,0 +1,13 @@
+module "child" {
+  source = "./child"
+  items  = null
+  name   = ""
+}
+
+output "item_count" {
+  value = module.child.count
+}
+
+output "name" {
+  value = module.child.name
+}


### PR DESCRIPTION
## What

When a module input variable is declared `nullable = false` with a default and
the caller passes `null`, OpenTofu/Terraform substitute the variable's
**default** for the `null`. pulumi-hcl instead kept the value as `null`, so any
downstream use that rejects null — e.g. `length(var.items)` — failed at
evaluation, before any provider was involved.

This substitutes the default when a `nullable = false` variable receives `null`.

## Related behavior covered

- **No default + `null`:** previously the `null` leaked downstream and only
  failed incidentally (and would pass silently if the use accepted null). Now it
  errors at variable preparation, matching Terraform's *"required variable may
  not be set to null"*.
- **Empty string:** `""` is a real value, so it is preserved rather than
  replaced by the default. A tfcompat case asserts this against `tofu` to
  document that the behavior is distinct from `coalesce`, which skips empty
  strings.

## Testing

- `tests/tfcompat/l1_nullable_false_default` — runs the repro through both
  `tofu apply` and `pulumi up` and asserts they agree (`item_count = 2`,
  `name = ""`).
- `TestEngine_ModuleNullableFalseNullInput` — unit coverage for the
  default-substituted and no-default-error cases.

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/183.