### PR TITLE
Resolve module sources that include a registry host

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-176.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-176.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Resolve module sources that include a registry host (e.g. `registry.terraform.io/cloudposse/label/null`) via service discovery, matching OpenTofu and Terraform
+time: 2026-06-01T17:10:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "176"

--- a/.changes/unreleased/runtime-bug-fixes-186.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-186.yaml
@@ -3,4 +3,4 @@ body: Resolve module sources that include a registry host (e.g. `registry.terraf
 time: 2026-06-01T17:10:00.000000+02:00
 custom:
     Component: runtime
-    PR: "176"
+    PR: "186"

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-mux v0.23.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
+	github.com/opentofu/registry-address/v2 v2.0.0-20250611143131-d0a99bd8acdd
+	github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8
 	github.com/pulumi/providertest v0.7.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.129.2
 	github.com/pulumi/pulumi/pkg/v3 v3.242.1-0.20260522090831-62878b4ed028

--- a/go.sum
+++ b/go.sum
@@ -3853,6 +3853,10 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/opentofu/registry-address/v2 v2.0.0-20250611143131-d0a99bd8acdd h1:YAAnzmyOoMvm5SuGXL4hhlfBgqz92XDfORGPV3kmQFc=
+github.com/opentofu/registry-address/v2 v2.0.0-20250611143131-d0a99bd8acdd/go.mod h1:7M92SvuJm1WBriIpa4j0XmruU9pxkgPXmRdc6FfAvAk=
+github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8 h1:J3pmsVB+nGdfNp5HWdEAC96asYgc7S6J724ICrYDCTk=
+github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8/go.mod h1:0kKTcD9hUrbAz41GWp8USa/+OuI8QKirU3qdCWNa3jI=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/basictracer-go v1.1.0 h1:Oa1fTSBvAl8pa3U+IJYqrKm0NALwH9OsgwOqDv4xJW0=

--- a/pkg/hcl/modules/loader.go
+++ b/pkg/hcl/modules/loader.go
@@ -33,13 +33,14 @@ import (
 	"sync"
 
 	version "github.com/hashicorp/go-version"
+	regaddr "github.com/opentofu/registry-address/v2"
+	"github.com/opentofu/svchost"
+	"github.com/opentofu/svchost/disco"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi-labs/pulumi-hcl/vendored/getmodules"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
-
-const defaultRegistryBaseURL = "https://registry.opentofu.org/v1/modules"
 
 // fetchMu serializes every PackageFetcher.FetchPackage call in the process.
 // The vendored getmodules package builds each PackageFetcher from a shallow
@@ -61,8 +62,9 @@ type Loader struct {
 
 	fetcher *getmodules.PackageFetcher
 
-	// registryBaseURL is overridable so tests can use an httptest.Server.
-	registryBaseURL string
+	// disco resolves a registry host to its modules.v1 endpoint via service
+	// discovery. Tests pre-seed it with an httptest.Server via ForceHostServices.
+	disco *disco.Disco
 }
 
 // LoadedModule represents a loaded and parsed module.
@@ -74,11 +76,11 @@ type LoadedModule struct {
 // NewLoader creates a new module loader.
 func NewLoader(ctx context.Context) *Loader {
 	return &Loader{
-		parser:          parser.NewParser(),
-		cache:           make(map[string]*LoadedModule),
-		cacheDir:        defaultCacheDir(),
-		fetcher:         getmodules.NewPackageFetcher(ctx, nil),
-		registryBaseURL: defaultRegistryBaseURL,
+		parser:   parser.NewParser(),
+		cache:    make(map[string]*LoadedModule),
+		cacheDir: defaultCacheDir(),
+		fetcher:  getmodules.NewPackageFetcher(ctx, nil),
+		disco:    disco.New(),
 	}
 }
 
@@ -253,7 +255,7 @@ func dirHasFiles(dir string) bool {
 }
 
 // resolveRegistrySource downloads a module via modules.v1. source is
-// namespace/name/provider with an optional ?version=…; versionConstraint
+// `[host/]namespace/name/provider` with an optional ?version=…; versionConstraint
 // takes precedence over the query string.
 func (l *Loader) resolveRegistrySource(source, versionConstraint string) (string, error) {
 	baseSource := source
@@ -266,19 +268,34 @@ func (l *Loader) resolveRegistrySource(source, versionConstraint string) (string
 		}
 	}
 
-	parts := strings.Split(baseSource, "/")
-	if len(parts) != 3 {
-		return "", fmt.Errorf("invalid registry source format: %s", source)
+	mod, err := regaddr.ParseModuleSource(baseSource)
+	if err != nil {
+		return "", fmt.Errorf("invalid registry source format %q: %w", source, err)
 	}
-	namespace, name, provider := parts[0], parts[1], parts[2]
+	pkg := mod.Package
 
-	downloadURL, err := l.getRegistryDownloadURL(namespace, name, provider, versionConstraint)
+	baseURL, err := l.registryBaseURLForHost(pkg.Host)
+	if err != nil {
+		return "", err
+	}
+
+	downloadURL, err := l.getRegistryDownloadURL(baseURL, pkg.Namespace, pkg.Name, pkg.TargetSystem, versionConstraint)
 	if err != nil {
 		return "", err
 	}
 
 	// Cache by the resolved URL so different version constraints don't collide.
 	return l.fetchRemote(downloadURL, "registry")
+}
+
+// registryBaseURLForHost resolves a registry host to its modules.v1 base URL
+// via service discovery.
+func (l *Loader) registryBaseURLForHost(host svchost.Hostname) (string, error) {
+	u, err := l.disco.DiscoverServiceURL(context.Background(), host, "modules.v1")
+	if err != nil {
+		return "", fmt.Errorf("discovering registry %q: %w", host, err)
+	}
+	return strings.TrimSuffix(u.String(), "/"), nil
 }
 
 type registryModuleVersion struct {
@@ -293,12 +310,7 @@ type registryModuleVersions struct {
 
 // getRegistryDownloadURL resolves a concrete download URL via the modules.v1
 // protocol. Empty versionConstraint means "highest published version".
-func (l *Loader) getRegistryDownloadURL(namespace, name, provider, versionConstraint string) (string, error) {
-	baseURL := l.registryBaseURL
-	if baseURL == "" {
-		baseURL = defaultRegistryBaseURL
-	}
-
+func (l *Loader) getRegistryDownloadURL(baseURL, namespace, name, provider, versionConstraint string) (string, error) {
 	chosen, err := l.selectRegistryVersion(baseURL, namespace, name, provider, versionConstraint)
 	if err != nil {
 		return "", err
@@ -406,23 +418,17 @@ func (l *Loader) selectRegistryVersion(baseURL, namespace, name, provider, versi
 	return candidates[0].Original(), nil
 }
 
-// isRegistrySource checks if a source looks like a Terraform Registry address
-// (namespace/name/provider). Subdomains/hostnames are filtered out by the
-// `.` check on the first segment.
+// isRegistrySource reports whether source is a Terraform Registry address
+// (`[host/]namespace/name/provider`). Detection is delegated to
+// opentofu/registry-address, which also rejects version-control hosts like
+// github.com so they fall through to the remote getter. The query string
+// (`?version=…`) is stripped first because registry addresses don't permit it.
 func isRegistrySource(source string) bool {
 	if idx := strings.Index(source, "?"); idx != -1 {
 		source = source[:idx]
 	}
-	parts := strings.Split(source, "/")
-	if len(parts) != 3 {
-		return false
-	}
-	for _, part := range parts {
-		if part == "" || strings.Contains(part, ":") {
-			return false
-		}
-	}
-	return !strings.Contains(parts[0], ".")
+	_, err := regaddr.ParseModuleSource(source)
+	return err == nil
 }
 
 func hashSource(source string) string {

--- a/pkg/hcl/modules/loader_test.go
+++ b/pkg/hcl/modules/loader_test.go
@@ -24,6 +24,9 @@ import (
 	"strings"
 	"testing"
 
+	regaddr "github.com/opentofu/registry-address/v2"
+	"github.com/opentofu/svchost"
+	"github.com/opentofu/svchost/disco"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi-labs/pulumi-hcl/vendored/getmodules"
 	"github.com/stretchr/testify/require"
@@ -88,14 +91,48 @@ func versionsPayload(vs []string) []map[string]string {
 	return out
 }
 
-func newTestLoader(t *testing.T, registryBaseURL string) *Loader {
+// newTestLoader builds a Loader whose default registry host resolves to
+// modulesV1BaseURL, standing in for the real modules.v1 endpoint.
+func newTestLoader(t *testing.T, modulesV1BaseURL string) *Loader {
 	t.Helper()
+	d := disco.New()
+	d.ForceHostServices(regaddr.DefaultModuleRegistryHost, map[string]any{
+		"modules.v1": modulesV1BaseURL + "/",
+	})
 	return &Loader{
-		parser:          parser.NewParser(),
-		cache:           map[string]*LoadedModule{},
-		cacheDir:        t.TempDir(),
-		fetcher:         getmodules.NewPackageFetcher(t.Context(), nil),
-		registryBaseURL: registryBaseURL,
+		parser:   parser.NewParser(),
+		cache:    map[string]*LoadedModule{},
+		cacheDir: t.TempDir(),
+		fetcher:  getmodules.NewPackageFetcher(t.Context(), nil),
+		disco:    d,
+	}
+}
+
+func TestIsRegistrySource(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		source string
+		want   bool
+	}{
+		{"cloudposse/label/null", true},
+		{"registry.terraform.io/cloudposse/label/null", true},
+		// Query strings are stripped before delegating to the parser.
+		{"app.terraform.io/my-org/vpc/aws?version=1.2.3", true},
+		// Reserved version-control hosts fall through to the remote getter.
+		{"github.com/hashicorp/consul/aws", false},
+		// A bare github address: "github.com" is not a valid namespace.
+		{"github.com/org/repo", false},
+		// A host without a dot is not a valid registry host.
+		{"localhost/org/name/aws", false},
+		{"too/many/slashes/here/now", false},
+		{"only/two", false},
+		{"bad ns/name/aws", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.source, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isRegistrySource(tc.source))
+		})
 	}
 }
 
@@ -107,7 +144,7 @@ func TestGetRegistryDownloadURL_NoConstraintPicksLatest(t *testing.T) {
 		map[string]string{"4.2.0": "https://example.com/v420.tar.gz"})
 	l := newTestLoader(t, srv.URL)
 
-	got, err := l.getRegistryDownloadURL("acme", "thing", "aws", "")
+	got, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "")
 	require.NoError(t, err)
 	require.Equal(t, "https://example.com/v420.tar.gz", got)
 	require.Equal(t, 1, reg.versionsHits)
@@ -121,7 +158,7 @@ func TestGetRegistryDownloadURL_ConstraintPicksHighestMatching(t *testing.T) {
 		map[string]string{"4.1.0": "https://example.com/v410.tar.gz"})
 	l := newTestLoader(t, srv.URL)
 
-	got, err := l.getRegistryDownloadURL("acme", "thing", "aws", "~> 4.0")
+	got, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "~> 4.0")
 	require.NoError(t, err)
 	require.Equal(t, "https://example.com/v410.tar.gz", got)
 	require.Equal(t, 1, reg.downloadHits["4.1.0"])
@@ -134,7 +171,7 @@ func TestGetRegistryDownloadURL_ExactVersionPin(t *testing.T) {
 		map[string]string{"2.0.0": "https://example.com/v200.tar.gz"})
 	l := newTestLoader(t, srv.URL)
 
-	got, err := l.getRegistryDownloadURL("acme", "thing", "aws", "2.0.0")
+	got, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "2.0.0")
 	require.NoError(t, err)
 	require.Equal(t, "https://example.com/v200.tar.gz", got)
 }
@@ -146,7 +183,7 @@ func TestGetRegistryDownloadURL_NoMatchingVersionErrors(t *testing.T) {
 		map[string]string{})
 	l := newTestLoader(t, srv.URL)
 
-	_, err := l.getRegistryDownloadURL("acme", "thing", "aws", "~> 99.0")
+	_, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "~> 99.0")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no published version")
 	require.Contains(t, err.Error(), "~> 99.0")
@@ -181,7 +218,7 @@ func TestGetRegistryDownloadURL_OpenTofuStyle_JSONBody(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	l := newTestLoader(t, srv.URL)
-	got, err := l.getRegistryDownloadURL("acme", "thing", "aws", "")
+	got, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "")
 	require.NoError(t, err)
 	require.Equal(t, wantURL, got)
 }
@@ -193,7 +230,7 @@ func TestGetRegistryDownloadURL_InvalidConstraintErrors(t *testing.T) {
 		map[string]string{"1.0.0": "https://example.com/x.tar.gz"})
 	l := newTestLoader(t, srv.URL)
 
-	_, err := l.getRegistryDownloadURL("acme", "thing", "aws", "not-a-constraint")
+	_, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "not-a-constraint")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "parsing version constraint")
 }
@@ -249,6 +286,57 @@ func TestLoadModule_VersionQueryStringStillSupported(t *testing.T) {
 	_, err := l.LoadModule("acme/thing/aws?version=3.0.0", "", t.TempDir())
 	require.NoError(t, err)
 	require.Equal(t, 1, reg.downloadHits["3.0.0"])
+}
+
+// TestLoadModule_HostQualifiedRegistrySource verifies that a source carrying an
+// explicit registry host (e.g. registry.terraform.io/...) is resolved against
+// that host's discovered modules.v1 endpoint rather than the hardcoded default
+// registry. ForceHostServices stands in for network service discovery.
+func TestLoadModule_HostQualifiedRegistrySource(t *testing.T) {
+	t.Parallel()
+
+	modTar := buildModuleTarGz(t, map[string]string{
+		"main.tf": `output "ok" { value = "host-qualified" }`,
+	})
+
+	tarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(modTar)
+	}))
+	t.Cleanup(tarSrv.Close)
+	tarURL := tarSrv.URL + "/m.tar.gz?archive=tar.gz"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/modules/myorg/widget/aws/versions", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"modules": []map[string]any{{"versions": versionsPayload([]string{"1.0.0"})}},
+		})
+	})
+	mux.HandleFunc("/v1/modules/myorg/widget/aws/1.0.0/download", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Terraform-Get", tarURL)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	const host = "registry.example.com"
+	hostname, err := svchost.ForComparison(host)
+	require.NoError(t, err)
+	d := disco.New()
+	d.ForceHostServices(hostname, map[string]any{"modules.v1": srv.URL + "/v1/modules/"})
+
+	l := &Loader{
+		parser:   parser.NewParser(),
+		cache:    map[string]*LoadedModule{},
+		cacheDir: t.TempDir(),
+		fetcher:  getmodules.NewPackageFetcher(t.Context(), nil),
+		disco:    d,
+	}
+
+	loaded, err := l.LoadModule(host+"/myorg/widget/aws", "", t.TempDir())
+	require.NoError(t, err)
+	require.NotNil(t, loaded.Config)
+	require.Contains(t, loaded.Config.Outputs, "ok")
 }
 
 // buildModuleTarGz packs `files` (name → content) into a gzipped tar archive


### PR DESCRIPTION
## What

A module `source` that includes the registry hostname — e.g.
`registry.terraform.io/cloudposse/label/null`, and registry hosts generally —
previously failed at source normalization:

> OpenTofu cannot detect a supported external module source type for
> registry.terraform.io/cloudposse/label/null

The registry detector only accepted bare `namespace/name/provider` addresses,
so a module published only to the Terraform registry (which must be addressed
with the explicit `registry.terraform.io/` host) could not be referenced at all.

## How

- Address parsing is delegated to `opentofu/registry-address`, which accepts the
  optional `[<HOST>/]<NAMESPACE>/<NAME>/<PROVIDER>` form and rejects
  version-control hosts (`github.com`, `bitbucket.org`) so they fall through to
  the remote getter.
- The host's `modules.v1` endpoint is resolved via `opentofu/svchost` service
  discovery, matching OpenTofu/Terraform. Host-less sources resolve against the
  default registry, now discovered live like any other host.

## Tests

- `TestIsRegistrySource` — detection across bare, host-qualified, query-string,
  and reserved-VCS-host inputs.
- `TestLoadModule_HostQualifiedRegistrySource` — end-to-end resolution of a
  host-qualified source through discovery (`disco.ForceHostServices`).

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/176