### PR TITLE
Handle the builtin `terraform` provider's `terraform_data` internally

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-187.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-187.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`terraform_data` from the builtin `terraform` provider is handled internally (lowered onto the engine''s builtin `Stash` resource) instead of being resolved to a non-existent external plugin'
+time: 2026-06-01T17:30:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "187"

--- a/pkg/hcl/run/mapping.go
+++ b/pkg/hcl/run/mapping.go
@@ -77,6 +77,9 @@ func (e *Engine) providerInfoForType(ctx context.Context, tfType string) *tfbrid
 // Pulumi has organised the type into modules) and falls back to the
 // convention-based resolver in pkg/hcl/packages when no mapping is available.
 func (e *Engine) resolveResource(ctx context.Context, tfType string) (*pulumischema.Resource, error) {
+	if tfType == terraformDataType {
+		return terraformDataSchema(), nil
+	}
 	if info := e.providerInfoForType(ctx, tfType); info != nil {
 		if r, ok := info.Resources[tfType]; ok && r != nil && string(r.Tok) != "" {
 			res, err := e.loadResourceByToken(ctx, info.Name, string(r.Tok))

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1254,7 +1254,7 @@ func (e *Engine) registerResourceInstanceInContext(
 
 	resourceName := e.extractModuleResourceName(res.Name, instance.Key, node.ModuleInfo, modInst)
 
-	urn, id, outputs, err := e.registerResource(ctx, resSchema.Token, resourceName, resourceInputs, opts)
+	urn, id, outputs, err := e.registerResource(ctx, res.Type, resSchema.Token, resourceName, resourceInputs, opts)
 	if err != nil {
 		e.failedNodes.Set(instance.Key, fmt.Errorf("registering resource: %w", err))
 		return nil
@@ -1854,14 +1854,19 @@ type ResourceOptions struct {
 	Hooks                   *ResourceHookBinding
 }
 
-// registerResource registers a resource with the Pulumi engine.
+// registerResource registers a resource with the Pulumi engine. tfType is the
+// HCL resource type, used only to detect builtins (like terraform_data) that are
+// lowered onto a different engine resource at this schemaless boundary.
 func (e *Engine) registerResource(
 	ctx context.Context,
+	tfType string,
 	typeToken string,
 	name string,
 	inputs property.Map,
 	opts *ResourceOptions,
 ) (string, string, property.Map, error) {
+	inputs = lowerTerraformDataInputs(tfType, inputs, opts)
+
 	// Register with the resource monitor
 	resp, err := e.resmon.RegisterResource(ctx, RegisterResourceRequest{
 		Type:                    typeToken,
@@ -1898,7 +1903,7 @@ func (e *Engine) registerResource(
 		return "", "", property.Map{}, err
 	}
 
-	return resp.URN, resp.ID, resp.Outputs, nil
+	return resp.URN, resp.ID, lowerTerraformDataOutputs(tfType, resp.Outputs, opts), nil
 }
 
 // processDataSource processes a data source definition.

--- a/pkg/hcl/run/terraform_data.go
+++ b/pkg/hcl/run/terraform_data.go
@@ -1,0 +1,93 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+const (
+	// terraformDataType is Terraform's builtin `terraform_data` managed
+	// resource. Its provider (`terraform`) ships no installable plugin;
+	// Terraform/OpenTofu implement it internally.
+	terraformDataType = "terraform_data"
+	// stashToken is the Pulumi engine's builtin resource we lower onto.
+	stashToken = "pulumi:index:Stash"
+)
+
+// terraformDataSchema is the synthetic schema terraform_data resolves to, so it
+// flows through the generic registration path like any other resource. It is
+// backed by the engine's builtin Stash resource (hence the Stash token) but
+// described in terraform_data's own terms; the lowerTerraformData* hooks bridge
+// the two property surfaces around the Stash registration:
+//
+//   - `input` is the value Stash stores.
+//   - `output` mirrors `input`. It is read back from Stash's `input` output,
+//     which tracks the current input across updates (Stash's own `output`
+//     property is frozen at create time and is not used).
+//   - `triggers_replace` is declared so it is evaluated from config, but it is
+//     not sent to Stash; lowerTerraformDataInputs moves it to the engine's
+//     replacement trigger so a change to it forces replacement (and a new id).
+//
+// `id` is the Stash resource id and is attached by the registration machinery,
+// so it is not declared here.
+func terraformDataSchema() *schema.Resource {
+	// All of terraform_data's attributes are optional/nullable, so the property
+	// types are wrapped in OptionalType (an un-wrapped type reads as required).
+	anyProp := func(name string) *schema.Property {
+		return &schema.Property{Name: name, Type: &schema.OptionalType{ElementType: schema.AnyType}}
+	}
+	return &schema.Resource{
+		Token:           stashToken,
+		InputProperties: []*schema.Property{anyProp("input"), anyProp("triggers_replace")},
+		Properties: []*schema.Property{
+			anyProp("input"), anyProp("output"), anyProp("triggers_replace"),
+		},
+	}
+}
+
+// lowerTerraformDataInputs adapts evaluated terraform_data inputs to Stash's
+// input surface just before registration. It is a no-op for every other type.
+//
+// triggers_replace is not a Stash input: a change to it must force replacement
+// (yielding a new id), which the engine's replacement trigger does — while a
+// plain input change is an in-place update with a stable id. Its dependencies
+// are already folded into DependsOn, so the property-level entry is dropped too.
+func lowerTerraformDataInputs(resType string, inputs property.Map, opts *ResourceOptions) property.Map {
+	if resType != terraformDataType {
+		return inputs
+	}
+	if t, ok := inputs.GetOk("triggers_replace"); ok {
+		opts.ReplacementTrigger = t
+		inputs = inputs.Delete("triggers_replace")
+	}
+	delete(opts.PropertyDependencies, "triggers_replace")
+	return inputs
+}
+
+// lowerTerraformDataOutputs adapts Stash's outputs back to terraform_data's
+// surface just after registration. It is a no-op for every other type.
+//
+// terraform_data's `output` mirrors `input`, read back from Stash's tracking
+// `input` output; `triggers_replace` is not a Stash output, so it is echoed
+// from the replacement trigger captured by lowerTerraformDataInputs.
+func lowerTerraformDataOutputs(resType string, outputs property.Map, opts *ResourceOptions) property.Map {
+	if resType != terraformDataType {
+		return outputs
+	}
+	outputs = outputs.Set("output", outputs.Get("input"))
+	return outputs.Set("triggers_replace", opts.ReplacementTrigger)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -293,7 +293,7 @@ func missingNonPulumiSDKs(
 	return missing
 }
 
-func isBuiltinProvider(alias string) bool { return alias == "pulumi" }
+func isBuiltinProvider(alias string) bool { return alias == "pulumi" || alias == "terraform" }
 
 // usedProviders returns the sorted provider local names referenced by config
 // (required_providers, provider blocks, resource/data type prefixes). A

--- a/tests/tfcompat/l2_terraform_data_lifecycle_test.go
+++ b/tests/tfcompat/l2_terraform_data_lifecycle_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2TerraformDataLifecycle drives terraform_data across its full lifecycle —
+// create, an in-place update (input changes, id stable), and a replacement
+// (triggers_replace changes, id rolls) — over three stages on one stack.
+//
+// terraform_data's id is a random uuid that differs between the tofu and pulumi
+// paths, and its builtin provider records no CRUD ops, so the id can't be
+// compared directly. Instead simple_resource.dependent's replace_triggered_by
+// watches terraform_data.t.id: the dependent is replaced exactly when the id
+// changes. Both paths must therefore produce the same simple-provider op trace —
+// a create, no replacement on the input-only change, and a replacement on the
+// triggers_replace change.
+func TestL2TerraformDataLifecycle(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_terraform_data_lifecycle", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_terraform_data_test.go
+++ b/tests/tfcompat/l2_terraform_data_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2TerraformData covers the issue repro: the builtin `terraform` provider
+// (terraform_data) has no installable plugin, so both tofu and pulumi-language-hcl
+// must handle it internally and produce the same `output`. No providers are
+// declared — terraform_data is a builtin on both paths.
+func TestL2TerraformData(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_terraform_data", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_data/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_data/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+resource "terraform_data" "example" {
+  input = "hello"
+}
+
+output "value" {
+  value = terraform_data.example.output
+}
+
+output "input_echo" {
+  value = terraform_data.example.input
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_data_lifecycle/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_data_lifecycle/0/main.tf
@@ -1,0 +1,31 @@
+# Stage 0: create. terraform_data.t holds input="a" with triggers_replace="x".
+# simple_resource.dependent is replaced whenever terraform_data.t.id changes, so
+# its provider-op trace witnesses terraform_data's id lifecycle across stages
+# (the id itself is a random uuid and can't be compared cross-path directly).
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = "x"
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" {
+  value = terraform_data.t.output
+}
+
+output "dependent_result" {
+  value = simple_resource.dependent.result
+}
+
+output "input_echo" {
+  value = terraform_data.t.input
+}
+
+output "triggers_echo" {
+  value = terraform_data.t.triggers_replace
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_data_lifecycle/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_data_lifecycle/1/main.tf
@@ -1,0 +1,30 @@
+# Stage 1: input changes "a" -> "b" while triggers_replace stays "x". This is an
+# in-place update: terraform_data.t.id is stable, so simple_resource.dependent is
+# NOT replaced. output follows the new input.
+resource "terraform_data" "t" {
+  input            = "b"
+  triggers_replace = "x"
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" {
+  value = terraform_data.t.output
+}
+
+output "dependent_result" {
+  value = simple_resource.dependent.result
+}
+
+output "input_echo" {
+  value = terraform_data.t.input
+}
+
+output "triggers_echo" {
+  value = terraform_data.t.triggers_replace
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_data_lifecycle/2/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_data_lifecycle/2/main.tf
@@ -1,0 +1,30 @@
+# Stage 2: triggers_replace changes "x" -> "y" (input stays "b"). This forces a
+# replacement of terraform_data.t, so terraform_data.t.id changes and
+# simple_resource.dependent is replaced (Delete+Create on the simple provider).
+resource "terraform_data" "t" {
+  input            = "b"
+  triggers_replace = "y"
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" {
+  value = terraform_data.t.output
+}
+
+output "dependent_result" {
+  value = simple_resource.dependent.result
+}
+
+output "input_echo" {
+  value = terraform_data.t.input
+}
+
+output "triggers_echo" {
+  value = terraform_data.t.triggers_replace
+}


### PR DESCRIPTION
## What

Terraform and OpenTofu implement the builtin `terraform` provider — which backs `terraform_data` and `terraform_remote_state` — internally, with no downloadable plugin. Pulumi HCL was treating it as an external provider, so:

- `pulumi install` failed trying to fetch a non-existent `hashicorp/terraform` plugin, and
- `pulumi preview` failed with `missing local SDK for non-Pulumi provider(s) [terraform]`.

This lowers `terraform_data` onto the engine's builtin `pulumi:index:Stash` resource so it works with no plugin to install.

## How

- **`terraform` is now a builtin provider** (`isBuiltinProvider`), so it is never resolved to an installable plugin — fixing both the `pulumi install` and `pulumi preview` failures in one place.
- **`resolveResource` returns a synthetic schema** for `terraform_data` (backed by the `pulumi:index:Stash` token), so it flows through the normal resource-registration path like any other resource.
- **The `terraform_data` → `Stash` transform lives entirely at the schemaless `registerResource` boundary** (two small `lowerTerraformData*` hooks, no-op for every other type):
  - `input` is sent to Stash; `output` and `input` are read back from Stash's `input` output, which tracks the current input across updates (Stash's own `output` is frozen at create).
  - `triggers_replace` is routed to the engine's replacement trigger: a change forces a replacement (new `id`), while a plain `input` change is an in-place update with a stable `id`.
  - `id` is the Stash resource id (a uuid, stable across updates, regenerated on replace).

All `terraform_data`-specific code is contained in `pkg/hcl/run/terraform_data.go`; the generic registration path gains only a forwarded `tfType` argument.

## Tests

`tfcompat` runs each program through both `tofu apply` and `pulumi up` and asserts identical outputs and provider-op traces:

- **`l2_terraform_data`** — the issue's exact repro (no providers declared); asserts `output` and `input` parity.
- **`l2_terraform_data_lifecycle`** — three stages on one stack: create → in-place update (input change, **stable id**) → replacement (`triggers_replace` change, **id rolls**). Because the id is a random uuid and the builtin records no ops, a downstream `simple_resource` with `replace_triggered_by = [terraform_data.t.id]` witnesses the id lifecycle as a comparable provider-op trace; also asserts `output`/`input`/`triggers_replace` parity.

## Not included

`terraform_remote_state`, `terraform_data` import / `null_resource` state-move, and `pulumi convert` support are out of scope here (runtime path only).

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/178