### PR TITLE
Match OpenTofu's `cidrhost` behavior

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-192.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-192.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`cidrhost` matches OpenTofu: a negative host number counts back from the end of the prefix''s address range, and a host number that exceeds the available host bits is rejected rather than silently overflowing into the network portion'
+time: 2026-06-01T19:30:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "192"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -1489,17 +1489,16 @@ var cidrHostFunc = function.New(&function.Spec{
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		prefix := args[0].AsString()
-		hostnum, _ := args[1].AsBigFloat().Int64()
+		hostnum, _ := args[1].AsBigFloat().Int(nil)
 
 		_, network, err := net.ParseCIDR(prefix)
 		if err != nil {
 			return cty.NilVal, fmt.Errorf("invalid CIDR: %s", err)
 		}
 
-		ip := network.IP
-		for i := len(ip) - 1; i >= 0 && hostnum > 0; i-- {
-			ip[i] += byte(hostnum & 0xff)
-			hostnum >>= 8
+		ip, err := cidr.HostBig(network, hostnum)
+		if err != nil {
+			return cty.NilVal, err
 		}
 
 		return cty.StringVal(ip.String()), nil

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -715,6 +715,15 @@ func TestSumEmptyList(t *testing.T) {
 	assert.EqualError(t, err, "cannot sum an empty list")
 }
 
+// TestCidrHostOutOfRange pins that `cidrhost` errors when the host number does
+// not fit within the prefix's host bits, as OpenTofu does, rather than silently
+// overflowing into the network portion of the address.
+func TestCidrHostOutOfRange(t *testing.T) {
+	t.Parallel()
+	_, err := cidrHostFunc.Call([]cty.Value{cty.StringVal("10.0.0.0/24"), cty.NumberIntVal(256)})
+	assert.EqualError(t, err, "prefix of 24 does not accommodate a host numbered 256")
+}
+
 // TestToSetToListPreserveEmptyElementType pins that `toset` / `tolist` over a
 // typed-but-empty collection preserves the element type rather than collapsing
 // to `dynamic`.
@@ -938,6 +947,8 @@ func TestIPFunctions(t *testing.T) {
 		expected cty.Value
 	}{
 		{"cidrhost", `cidrhost("10.0.0.0/8", 5)`, cty.StringVal("10.0.0.5")},
+		{"cidrhost neg one", `cidrhost("10.0.0.0/24", -1)`, cty.StringVal("10.0.0.255")},
+		{"cidrhost neg two", `cidrhost("10.0.0.0/24", -2)`, cty.StringVal("10.0.0.254")},
 		{"cidrnetmask", `cidrnetmask("10.0.0.0/8")`, cty.StringVal("255.0.0.0")},
 		{"cidrsubnet v4", `cidrsubnet("10.0.0.0/8", 8, 2)`, cty.StringVal("10.2.0.0/16")},
 		{"cidrsubnet v6", `cidrsubnet("2600:1f14:315a:f400::/56", 8, 2)`,

--- a/tests/tfcompat/l1_cidrhost_test.go
+++ b/tests/tfcompat/l1_cidrhost_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1CidrHost exercises `cidrhost` with negative host numbers: OpenTofu
+// counts them back from the end of the network's address range, so -1 is the
+// last host in the prefix rather than the network address.
+func TestL1CidrHost(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_cidrhost", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_cidrhost/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_cidrhost/main.tf
@@ -1,0 +1,16 @@
+# OpenTofu's `cidrhost` delegates to cidr.HostBig, which counts a negative
+# hostnum back from the end of the network's address range. A negative offset
+# of -1 is therefore the last host address in the prefix, -2 the second to
+# last, and so on. A naive forward-only byte addition would instead ignore the
+# sign and return the network address.
+output "neg_one" {
+  value = cidrhost("10.0.0.0/24", -1)
+}
+
+output "neg_two" {
+  value = cidrhost("10.0.0.0/24", -2)
+}
+
+output "pos" {
+  value = cidrhost("10.0.0.0/24", 5)
+}


### PR DESCRIPTION
## Divergence

`cidrhost` was hand-rolled as a forward-only byte addition over the network
address, diverging from OpenTofu (which delegates to `cidr.HostBig`) in two ways:

- **Negative host numbers.** OpenTofu counts a negative `hostnum` back from the
  end of the prefix's address range, so `cidrhost("10.0.0.0/24", -1)` is the
  last host `10.0.0.255`. The hand-rolled version fell through the `hostnum > 0`
  loop guard and returned the network address `10.0.0.0` unchanged.
- **Out-of-range host numbers.** A `hostnum` larger than the available host bits
  silently carried into the network portion of the address (e.g.
  `cidrhost("10.0.0.0/24", 256)` → `10.0.1.0`). OpenTofu rejects it with
  `prefix of 24 does not accommodate a host numbered 256`.

Probed against `tofu` 1.12.0 to confirm both behaviors.

## Fix

Delegate to `cidr.HostBig` (already imported), matching OpenTofu's
implementation exactly.

## Proof

- `tests/tfcompat/l1_cidrhost` — fails on master (pulumi returns `10.0.0.0` for
  the negative offsets), passes after the fix.
- `pkg/hcl/eval/functions_test.go` — added success cases for `-1`/`-2` and an
  error-path case `TestCidrHostOutOfRange` asserting the OpenTofu error message.

```
PATH="$PWD/bin:$PATH" go test ./pkg/hcl/eval/ -run 'TestIPFunctions|TestCidrHostOutOfRange' -count=1
PATH="$PWD/bin:$PATH" go test ./tests/tfcompat/ -run TestL1CidrHost -count=1
```

Both pass.