### PR TITLE
Match OpenTofu's `cidrnetmask` rejection of IPv6 prefixes

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-194.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-194.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`cidrnetmask` matches OpenTofu: an IPv6 prefix is rejected with an error rather than rendering a mask, since a netmask is an IPv4-only concept'
+time: 2026-06-01T20:15:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "194"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -1518,6 +1518,10 @@ var cidrNetmaskFunc = function.New(&function.Spec{
 			return cty.NilVal, fmt.Errorf("invalid CIDR: %s", err)
 		}
 
+		if network.IP.To4() == nil {
+			return cty.NilVal, fmt.Errorf("IPv6 addresses cannot have a netmask: %s", prefix)
+		}
+
 		mask := net.IP(network.Mask)
 		return cty.StringVal(mask.String()), nil
 	},

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -724,6 +724,15 @@ func TestCidrHostOutOfRange(t *testing.T) {
 	assert.EqualError(t, err, "prefix of 24 does not accommodate a host numbered 256")
 }
 
+// TestCidrNetmaskIPv6 pins that `cidrnetmask` rejects an IPv6 prefix, as
+// OpenTofu does, rather than rendering the mask: a netmask is an IPv4-only
+// concept.
+func TestCidrNetmaskIPv6(t *testing.T) {
+	t.Parallel()
+	_, err := cidrNetmaskFunc.Call([]cty.Value{cty.StringVal("2001:db8::/32")})
+	assert.EqualError(t, err, "IPv6 addresses cannot have a netmask: 2001:db8::/32")
+}
+
 // TestToSetToListPreserveEmptyElementType pins that `toset` / `tolist` over a
 // typed-but-empty collection preserves the element type rather than collapsing
 // to `dynamic`.

--- a/tests/tfcompat/l1_cidrnetmask_test.go
+++ b/tests/tfcompat/l1_cidrnetmask_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1CidrNetmask_IPv6 pins that `cidrnetmask` rejects an IPv6 prefix on both
+// runtimes: a netmask is an IPv4-only concept, so OpenTofu errors rather than
+// rendering the IPv6 mask.
+func TestL1CidrNetmask_IPv6(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_cidrnetmask_ipv6", tfcompat.Case{
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{"main.tf": `
+output "mask" {
+  value = cidrnetmask("2001:db8::/32")
+}
+`},
+			// OpenTofu line-wraps the diagnostic after "have a", so match only the
+		// portion that stays on a single rendered line in both runtimes.
+		ExpectErr: "IPv6 addresses cannot have a",
+		}},
+	})
+}


### PR DESCRIPTION
## Divergence

`cidrnetmask` was hand-rolled to render `net.IP(network.Mask).String()` for any
prefix. A netmask is an IPv4-only concept, and OpenTofu rejects an IPv6 prefix:

```
cidrnetmask("2001:db8::/32")
# OpenTofu: Error — IPv6 addresses cannot have a netmask: 2001:db8::/32
# pulumi-hcl (before): "ffff:ffff::"  (no error)
```

Probed against `tofu` 1.12.0 to confirm OpenTofu errors.

## Fix

Reject an IPv6 prefix (`network.IP.To4() == nil`) with the same error message
OpenTofu uses, matching its `CidrNetmaskFunc`.

## Proof

- `tests/tfcompat/l1_cidrnetmask_ipv6` — an `ExpectErr` stage that requires both
  runtimes to fail. Fails on master (pulumi succeeds), passes after the fix.
- `pkg/hcl/eval/functions_test.go` — added `TestCidrNetmaskIPv6` asserting the
  OpenTofu error message via `cidrNetmaskFunc.Call`.

```
PATH="$PWD/bin:$PATH" go test ./pkg/hcl/eval/ -run 'TestCidrNetmaskIPv6|TestIPFunctions' -count=1
PATH="$PWD/bin:$PATH" go test ./tests/tfcompat/ -run TestL1CidrNetmask_IPv6 -count=1
```

Both pass.