### PR TITLE
Support `terraform_remote_state` with the local backend

### DIFF
--- a/.changes/unreleased/runtime-Improvements-196.yaml
+++ b/.changes/unreleased/runtime-Improvements-196.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: '`terraform_remote_state` with the `local` backend is now supported, read via the pulumi-terraform `getLocalReference` invoke (no installable TF provider plugin required)'
+time: 2026-06-01T20:30:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "196"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       - uses: opentofu/setup-opentofu@v2
+      # terraform_remote_state lowers to the pulumi-terraform getLocalReference
+      # invoke; the tfcompat harness disables plugin acquisition, so pre-install it.
+      - run: pulumi plugin install resource terraform 6.0.2
       - run: make test_cover
       - uses: codecov/codecov-action@v6
         with:

--- a/pkg/hcl/run/mapping.go
+++ b/pkg/hcl/run/mapping.go
@@ -94,6 +94,9 @@ func (e *Engine) resolveResource(ctx context.Context, tfType string) (*pulumisch
 
 // resolveFunction mirrors resolveResource for TF data sources and functions.
 func (e *Engine) resolveFunction(ctx context.Context, tfType string) (*pulumischema.Function, error) {
+	if tfType == remoteStateType {
+		return terraformRemoteStateSchema(), nil
+	}
 	if info := e.providerInfoForType(ctx, tfType); info != nil {
 		if d, ok := info.DataSources[tfType]; ok && d != nil && string(d.Tok) != "" {
 			fn, err := e.loadFunctionByToken(ctx, info.Name, string(d.Tok))

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2144,7 +2144,7 @@ func (e *Engine) invokeDataSourceOnce(
 	var outputs property.Map
 	if !e.dryRun || !property.New(inputs).HasComputed() {
 		var err error
-		outputs, err = e.invokeFunction(ctx, invokeReq)
+		outputs, err = e.invokeFunction(ctx, ds.Type, invokeReq)
 		if err != nil {
 			return cty.NilVal, fmt.Errorf("invoking data source: %w", err)
 		}
@@ -2326,7 +2326,12 @@ func (e *Engine) callMethod(ctx context.Context, req CallRequest) (property.Map,
 }
 
 // invokeFunction invokes a Pulumi function (data source).
-func (e *Engine) invokeFunction(ctx context.Context, req InvokeRequest) (property.Map, error) {
+func (e *Engine) invokeFunction(ctx context.Context, tfType string, req InvokeRequest) (property.Map, error) {
+	req, err := lowerRemoteStateInvoke(tfType, req)
+	if err != nil {
+		return property.Map{}, err
+	}
+
 	if e.resmon == nil { // TODO: Remove this check
 		// No resource monitor - return empty outputs for testing
 		return property.Map{}, nil

--- a/pkg/hcl/run/terraform_remote_state.go
+++ b/pkg/hcl/run/terraform_remote_state.go
@@ -1,0 +1,86 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+const (
+	remoteStateType     = "terraform_remote_state"
+	localReferenceToken = "terraform:state:getLocalReference"
+
+	// TerraformStatePackage / TerraformStatePackageVersion is the external
+	// pulumi-terraform package that provides the state-reference invokes.
+	TerraformStatePackage        = "terraform"
+	TerraformStatePackageVersion = "6.0.2"
+)
+
+// terraformRemoteStateSchema is the synthetic schema terraform_remote_state
+// resolves to: the TF data source surface as inputs, backed by the
+// getLocalReference token. lowerRemoteStateInvoke translates the inputs to the
+// invoke's arguments.
+func terraformRemoteStateSchema() *schema.Function {
+	opt := func(t schema.Type) schema.Type { return &schema.OptionalType{ElementType: t} }
+	return &schema.Function{
+		Token: localReferenceToken,
+		Inputs: &schema.ObjectType{
+			Properties: []*schema.Property{
+				{Name: "backend", Type: opt(schema.StringType)},
+				{Name: "config", Type: opt(schema.AnyType)},
+				{Name: "workspace", Type: opt(schema.StringType)},
+				{Name: "defaults", Type: opt(schema.AnyType)},
+			},
+		},
+		ReturnType: &schema.ObjectType{
+			Properties: []*schema.Property{{Name: "outputs", Type: schema.AnyType}},
+		},
+	}
+}
+
+// lowerRemoteStateInvoke rewrites a terraform_remote_state invoke into the
+// pulumi-terraform getLocalReference invoke, mapping config.path and
+// config.workspace_dir onto path/workspaceDir. Only the local backend is
+// supported. It is a no-op for any other type.
+func lowerRemoteStateInvoke(tfType string, req InvokeRequest) (InvokeRequest, error) {
+	if tfType != remoteStateType {
+		return req, nil
+	}
+
+	backend := ""
+	if b, ok := req.Args.GetOk("backend"); ok && b.IsString() {
+		backend = b.AsString()
+	}
+	if backend != "local" {
+		return req, fmt.Errorf(
+			"terraform_remote_state: only the %q backend is currently supported, got %q", "local", backend)
+	}
+
+	args := map[string]property.Value{}
+	if cfg, ok := req.Args.GetOk("config"); ok && cfg.IsMap() {
+		config := cfg.AsMap()
+		if p, ok := config.GetOk("path"); ok {
+			args["path"] = p
+		}
+		if w, ok := config.GetOk("workspace_dir"); ok {
+			args["workspaceDir"] = w
+		}
+	}
+	req.Args = property.NewMap(args)
+	return req, nil
+}

--- a/pkg/hcl/run/terraform_remote_state_test.go
+++ b/pkg/hcl/run/terraform_remote_state_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLowerRemoteStateInvoke(t *testing.T) {
+	t.Parallel()
+
+	localReq := InvokeRequest{
+		Token: localReferenceToken,
+		Args: property.NewMap(map[string]property.Value{
+			"backend": property.New("local"),
+			"config": property.New(map[string]property.Value{
+				"path":          property.New("state.tfstate"),
+				"workspace_dir": property.New("envs"),
+			}),
+		}),
+	}
+
+	t.Run("local backend translates config to invoke args", func(t *testing.T) {
+		t.Parallel()
+		got, err := lowerRemoteStateInvoke(remoteStateType, localReq)
+		require.NoError(t, err)
+		assert.Equal(t, InvokeRequest{
+			Token: localReferenceToken,
+			Args: property.NewMap(map[string]property.Value{
+				"path":         property.New("state.tfstate"),
+				"workspaceDir": property.New("envs"),
+			}),
+		}, got)
+	})
+
+	t.Run("unsupported backend is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+			Args: property.NewMap(map[string]property.Value{"backend": property.New("s3")}),
+		})
+		require.EqualError(t, err,
+			`terraform_remote_state: only the "local" backend is currently supported, got "s3"`)
+	})
+
+	t.Run("other data sources are untouched", func(t *testing.T) {
+		t.Parallel()
+		got, err := lowerRemoteStateInvoke("some_other_source", localReq)
+		require.NoError(t, err)
+		assert.Equal(t, localReq, got)
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -455,6 +455,11 @@ func collectRequirementsRec(
 	}
 	for _, d := range config.DataSources {
 		addType(d.Type)
+		// terraform_remote_state is served by the external pulumi-terraform
+		// package, not the builtin `terraform` provider that add() skips.
+		if d.Type == "terraform_remote_state" {
+			pulumi[run.TerraformStatePackage] = run.TerraformStatePackageVersion
+		}
 	}
 
 	if loader == nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/run"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
@@ -516,4 +517,80 @@ terraform {
 	assert.Equal(t,
 		[]string{"awscc"},
 		missingNonPulumiSDKs(t.Context(), cfg, nil, dir))
+}
+
+// terraform_remote_state is served by the external pulumi-terraform package, so
+// it must be emitted as an installable dependency even though the `terraform`
+// alias is otherwise a builtin provider.
+func TestGetRequiredPackages_TerraformRemoteState(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	program := `data "terraform_remote_state" "rs" {
+  backend = "local"
+  config = {
+    path = "remote.tfstate"
+  }
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "main.tf"), []byte(program), 0o600))
+
+	host := &LanguageHost{}
+	resp, err := host.GetRequiredPackages(t.Context(), &pulumirpc.GetRequiredPackagesRequest{
+		Info: &pulumirpc.ProgramInfo{
+			ProgramDirectory: projectDir,
+			RootDirectory:    projectDir,
+			EntryPoint:       ".",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, resp.Specs)
+	require.Len(t, resp.Packages, 1)
+	assert.Equal(t, &pulumirpc.PackageDependency{
+		Name:    run.TerraformStatePackage,
+		Version: run.TerraformStatePackageVersion,
+		Kind:    "resource",
+	}, resp.Packages[0])
+}
+
+// terraform_remote_state nested in a module is still detected, so the
+// pulumi-terraform package is emitted.
+func TestGetRequiredPackages_TerraformRemoteStateInModule(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+module "child" {
+  source = "./child"
+}
+`), 0o600))
+
+	childDir := filepath.Join(dir, "child")
+	require.NoError(t, os.MkdirAll(childDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(childDir, "main.tf"), []byte(`
+data "terraform_remote_state" "rs" {
+  backend = "local"
+  config = {
+    path = "remote.tfstate"
+  }
+}
+`), 0o600))
+
+	host := &LanguageHost{}
+	resp, err := host.GetRequiredPackages(t.Context(), &pulumirpc.GetRequiredPackagesRequest{
+		Info: &pulumirpc.ProgramInfo{
+			ProgramDirectory: dir,
+			RootDirectory:    dir,
+			EntryPoint:       ".",
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, resp.Packages, 1)
+	assert.Equal(t, &pulumirpc.PackageDependency{
+		Name:    run.TerraformStatePackage,
+		Version: run.TerraformStatePackageVersion,
+		Kind:    "resource",
+	}, resp.Packages[0])
 }

--- a/tests/tfcompat/l2_terraform_remote_state_test.go
+++ b/tests/tfcompat/l2_terraform_remote_state_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2TerraformRemoteState reads a local Terraform state file through the
+// builtin `terraform` provider's terraform_remote_state data source. OpenTofu
+// handles it internally; pulumi-language-hcl lowers the `local` backend onto the
+// pulumi-terraform getLocalReference invoke. Both paths read the same
+// remote.tfstate fixture and must surface identical `.outputs`. No TF providers
+// are declared.
+func TestL2TerraformRemoteState(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_terraform_remote_state", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_remote_state/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_remote_state/main.tf
@@ -1,0 +1,23 @@
+# The builtin `terraform` provider's terraform_remote_state data source has no
+# installable plugin. OpenTofu reads it internally; pulumi-language-hcl lowers
+# the `local` backend onto the pulumi-terraform package's getLocalReference
+# invoke. Both read the same on-disk state fixture (remote.tfstate) and must
+# expose identical outputs.
+data "terraform_remote_state" "rs" {
+  backend = "local"
+  config = {
+    path = "remote.tfstate"
+  }
+}
+
+output "greeting" {
+  value = data.terraform_remote_state.rs.outputs.greeting
+}
+
+output "number" {
+  value = data.terraform_remote_state.rs.outputs.number
+}
+
+output "items" {
+  value = data.terraform_remote_state.rs.outputs.items
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_remote_state/remote.tfstate
+++ b/tests/tfcompat/testdata/cases/l2_terraform_remote_state/remote.tfstate
@@ -1,0 +1,32 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 1,
+  "lineage": "3d6f6d7b-4429-46cb-d10f-10ab291859f7",
+  "outputs": {
+    "greeting": {
+      "value": "hello",
+      "type": "string"
+    },
+    "items": {
+      "value": [
+        "a",
+        "b"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string",
+          "string"
+        ]
+      ]
+    },
+    "number": {
+      "value": 42,
+      "type": "number"
+    }
+  },
+  "resources": [],
+  "check_results": null
+}
+


### PR DESCRIPTION
## What

The builtin `terraform` provider's `terraform_remote_state` data source has no installable plugin — OpenTofu reads it internally. After #187 made `terraform` a builtin provider, `terraform_remote_state` fell through to an "unknown data source" error. This implements the **`local` backend** by lowering it onto the [pulumi-terraform](https://www.pulumi.com/registry/packages/terraform/) package's [`getLocalReference`](https://www.pulumi.com/registry/packages/terraform/api-docs/state/getlocalreference/) invoke, which reads a local Terraform state file and exposes its outputs.

```hcl
data "terraform_remote_state" "rs" {
  backend = "local"
  config  = { path = "remote.tfstate" }
}

output "vpc_id" { value = data.terraform_remote_state.rs.outputs.vpc_id }
```

## How

- **`resolveFunction`** returns a synthetic function schema for `terraform_remote_state`, backed by the `terraform:state:getLocalReference` token, so it flows through the normal data-source path.
- **At the schemaless `invokeFunction` boundary**, `lowerRemoteStateInvoke` translates the data source's `backend`/`config` into the invoke's args (`config.path` → `path`, `config.workspace_dir` → `workspaceDir`). Backends other than `local` — including `remote` — are rejected with a clear error.
- **`GetRequiredPackages`** emits the external pulumi-terraform package (`terraform` v6.0.2) when `terraform_remote_state` is used, so `pulumi install` fetches it. The `terraform` alias otherwise stays builtin (it backs the internal `terraform_data`), so this check runs first.

All `terraform_remote_state` logic is contained in `pkg/hcl/run/terraform_remote_state.go`; the generic data-source path gains only a forwarded `tfType` argument.

## Tests

- **`l2_terraform_remote_state`** (tfcompat): reads an on-disk `remote.tfstate` fixture through both `tofu apply` (builtin) and `pulumi up` (`getLocalReference`); asserts identical string/number/list outputs.
- **`TestLowerRemoteStateInvoke`** (unit): config→args translation, the unsupported-backend error, and the no-op-for-other-types invariant.
- **`TestGetRequiredPackages_TerraformRemoteState`** (unit): the pulumi-terraform package is emitted as an install dependency.

## Scope / not included

Per discussion, this covers **`local` only** — the cleanly tfcompat-testable backend. `remote` (Terraform Cloud/Enterprise, via `getRemoteReference`) and all other backends (`s3`, `gcs`, …) remain unsupported and error clearly. The `defaults` field and module-nested usage in `GetRequiredPackages` are also out of scope. Issue #189 stays open for the remaining backends.

Towards https://github.com/pulumi-labs/pulumi-hcl/issues/189