### PR TITLE
Match OpenTofu's `uuidv5` namespace keyword handling

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-198.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-198.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`uuidv5` matches OpenTofu: only the lower-case namespace keywords (`dns`, `url`, `oid`, `x500`) are recognized, so an upper-case keyword like `DNS` is parsed as a literal UUID and rejected rather than aliasing to the namespace'
+time: 2026-06-01T20:30:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "198"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -1411,19 +1411,19 @@ var uuidv5Func = function.New(&function.Spec{
 
 		var ns uuid.UUID
 		switch nsStr {
-		case "dns", "DNS":
+		case "dns":
 			ns = uuid.NameSpaceDNS
-		case "url", "URL":
+		case "url":
 			ns = uuid.NameSpaceURL
-		case "oid", "OID":
+		case "oid":
 			ns = uuid.NameSpaceOID
-		case "x500", "X500":
+		case "x500":
 			ns = uuid.NameSpaceX500
 		default:
 			var err error
 			ns, err = uuid.Parse(nsStr)
 			if err != nil {
-				return cty.NilVal, fmt.Errorf("invalid namespace: %s", err)
+				return cty.NilVal, fmt.Errorf("uuidv5() doesn't support namespace %s (%w)", nsStr, err)
 			}
 		}
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -851,6 +851,15 @@ func TestUUIDV5Function(t *testing.T) {
 	}
 }
 
+// TestUUIDV5UppercaseNamespace pins that `uuidv5` rejects an upper-case
+// namespace keyword, as OpenTofu does: only the lower-case forms are recognized
+// as aliases, and `"DNS"` is instead parsed as a literal UUID and fails.
+func TestUUIDV5UppercaseNamespace(t *testing.T) {
+	t.Parallel()
+	_, err := uuidv5Func.Call([]cty.Value{cty.StringVal("DNS"), cty.StringVal("example.com")})
+	assert.EqualError(t, err, "uuidv5() doesn't support namespace DNS (invalid UUID length: 3)")
+}
+
 func TestFileFunctions(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/tests/tfcompat/l1_uuidv5_namespace_test.go
+++ b/tests/tfcompat/l1_uuidv5_namespace_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1UUIDV5Namespace pins that `uuidv5` rejects an upper-case namespace
+// keyword on both runtimes: OpenTofu only recognizes the lower-case forms
+// (`dns`, `url`, `oid`, `x500`) and otherwise tries to parse the argument as a
+// literal UUID, so `"DNS"` fails rather than aliasing to the DNS namespace.
+func TestL1UUIDV5Namespace(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_uuidv5_namespace", tfcompat.Case{
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{"main.tf": `
+output "id" {
+  value = uuidv5("DNS", "example.com")
+}
+`},
+			ExpectErr: `uuidv5() doesn't support namespace DNS`,
+		}},
+	})
+}


### PR DESCRIPTION
## Divergence

OpenTofu's `uuidv5` recognizes only the **lower-case** namespace keywords
`dns`, `url`, `oid`, and `x500` as aliases for the well-known UUID namespaces.
Anything else — including an upper-case variant like `DNS` — is handed to
`uuid.Parse` as a literal UUID and rejected when it does not parse:

```
$ tofu apply   # output { value = uuidv5("DNS", "example.com") }
Call to function "uuidv5" failed: uuidv5() doesn't support namespace DNS
(invalid UUID length: 3).
```

The pulumi-hcl runtime additionally accepted the upper-case forms (`DNS`,
`URL`, `OID`, `X500`) as aliases, so `uuidv5("DNS", "example.com")` produced a
value on `pulumi up` while OpenTofu errored.

## Fix

Drop the upper-case `case` arms in `uuidv5Func` so an upper-case keyword falls
through to `uuid.Parse` exactly as in OpenTofu, and adopt OpenTofu's error
message (`uuidv5() doesn't support namespace %s (%w)`). Both runtimes use
`github.com/google/uuid`, so the wrapped parse error is byte-identical.

## Proof

- `tests/tfcompat/l1_uuidv5_namespace_test.go` — `ExpectErr` case requiring
  both `tofu apply` and `pulumi up` to fail with
  `uuidv5() doesn't support namespace DNS`. Fails before the fix (pulumi
  succeeds); passes after.
- `TestUUIDV5UppercaseNamespace` unit test pins the error path, and the
  existing `TestUUIDV5Function` (`uuidv5("dns", ...)`) confirms the lower-case
  aliases still work.