### PR TITLE
Match OpenTofu's `templatefile` rendering

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-200.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-200.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`templatefile` matches OpenTofu: the file is rendered as a full HCL template, so interpolations may call functions and use `%{ for }` / `%{ if }` directives, rather than performing a naive `${name}` string substitution'
+time: 2026-06-01T21:00:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "200"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -157,15 +157,14 @@ func Functions(baseDir string) map[string]function.Function {
 		"yamlencode":       yamlEncodeFunc,
 
 		// Filesystem functions
-		"abspath":      abspathFunc(baseDir),
-		"dirname":      dirnameFunc,
-		"pathexpand":   pathExpandFunc,
-		"basename":     basenameFunc,
-		"file":         fileFunc(baseDir),
-		"fileexists":   fileExistsFunc(baseDir),
-		"fileset":      filesetFunc(baseDir),
-		"filebase64":   fileBase64Func(baseDir),
-		"templatefile": templateFileFunc(baseDir),
+		"abspath":    abspathFunc(baseDir),
+		"dirname":    dirnameFunc,
+		"pathexpand": pathExpandFunc,
+		"basename":   basenameFunc,
+		"file":       fileFunc(baseDir),
+		"fileexists": fileExistsFunc(baseDir),
+		"fileset":    filesetFunc(baseDir),
+		"filebase64": fileBase64Func(baseDir),
 
 		// Date and time functions
 		"formatdate": stdlib.FormatDateFunc,
@@ -224,9 +223,9 @@ func Functions(baseDir string) map[string]function.Function {
 		"remoteArchive": remoteArchiveFunc(),
 	}
 
-	// templatestring renders an arbitrary string as a template. The functions
-	// available inside that template are every function except the template
-	// functions themselves, which keeps a template from invoking itself
+	// templatefile and templatestring render a file or string as a template. The
+	// functions available inside that template are every function except the
+	// template functions themselves, which keeps a template from invoking itself
 	// recursively without bound.
 	nestedTemplateFuncs := make(map[string]function.Function, len(funcs))
 	for name, fn := range funcs {
@@ -235,6 +234,7 @@ func Functions(baseDir string) map[string]function.Function {
 		}
 		nestedTemplateFuncs[name] = fn
 	}
+	funcs["templatefile"] = templateFileFunc(baseDir, nestedTemplateFuncs)
 	funcs["templatestring"] = templateStringFunc(nestedTemplateFuncs)
 
 	return funcs
@@ -1016,7 +1016,13 @@ func fileBase64Func(baseDir string) function.Function {
 	})
 }
 
-func templateFileFunc(baseDir string) function.Function {
+// templateFileFunc reads the file at its first argument and renders it as an HCL
+// template using the variables in its second argument, just like OpenTofu: the
+// file's interpolations may call functions and use `%{ for }` / `%{ if }`
+// directives. nestedFuncs is the function table made available inside the
+// template; it omits the template functions themselves to prevent unbounded
+// recursion.
+func templateFileFunc(baseDir string, nestedFuncs map[string]function.Function) function.Function {
 	return function.New(&function.Spec{
 		Params: []function.Parameter{
 			{Name: "path", Type: cty.String},
@@ -1025,31 +1031,15 @@ func templateFileFunc(baseDir string) function.Function {
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			path := args[0].AsString()
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(baseDir, path)
+			fullPath := path
+			if !filepath.IsAbs(fullPath) {
+				fullPath = filepath.Join(baseDir, fullPath)
 			}
-			content, err := os.ReadFile(path)
+			content, err := os.ReadFile(fullPath)
 			if err != nil {
 				return cty.NilVal, err
 			}
-
-			// Simple template substitution for ${var} patterns
-			vars := args[1]
-			result := string(content)
-			if vars.Type().IsObjectType() || vars.Type().IsMapType() {
-				for it := vars.ElementIterator(); it.Next(); {
-					k, v := it.Element()
-					key := k.AsString()
-					var val string
-					if v.Type() == cty.String {
-						val = v.AsString()
-					} else {
-						val = v.GoString()
-					}
-					result = strings.ReplaceAll(result, "${"+key+"}", val)
-				}
-			}
-			return cty.StringVal(result), nil
+			return renderTemplate(path, cty.StringVal(string(content)), args[1], nestedFuncs)
 		},
 	})
 }
@@ -1065,21 +1055,22 @@ func templateStringFunc(nestedFuncs map[string]function.Function) function.Funct
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			return renderTemplate(args[0], args[1], nestedFuncs)
+			return renderTemplate("<templatestring>", args[0], args[1], nestedFuncs)
 		},
 	})
 }
 
 // renderTemplate parses templateVal as an HCL template and evaluates it with
 // varsVal's entries in scope plus the supplied functions, returning the
-// rendered string. Marks on the inputs propagate to the result.
+// rendered string. filename labels the template in any diagnostics. Marks on the
+// inputs propagate to the result.
 func renderTemplate(
-	templateVal, varsVal cty.Value, funcs map[string]function.Function,
+	filename string, templateVal, varsVal cty.Value, funcs map[string]function.Function,
 ) (cty.Value, error) {
 	templateVal, tmplMarks := templateVal.Unmark()
 
 	expr, diags := hclsyntax.ParseTemplate(
-		[]byte(templateVal.AsString()), "<templatestring>", hcl.InitialPos)
+		[]byte(templateVal.AsString()), filename, hcl.InitialPos)
 	if diags.HasErrors() {
 		return cty.NilVal, diags
 	}

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -927,6 +927,23 @@ func TestFileFunctions(t *testing.T) {
 		}
 	})
 
+	// Create a template file exercising a function call and a `for` directive,
+	// which a naive ${var} substitution cannot render.
+	richTmpl := filepath.Join(tmpDir, "rich.tpl")
+	if err := os.WriteFile(richTmpl,
+		[]byte(`Hello ${upper(name)}, you have %{ for n in nums }${n} %{ endfor }items`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("templatefile renders functions and directives", func(t *testing.T) {
+		t.Parallel()
+		result := evalExpr(t, tmpDir, `templatefile("rich.tpl", {name = "ada", nums = [1, 2, 3]})`)
+		expected := cty.StringVal("Hello ADA, you have 1 2 3 items")
+		if !result.RawEquals(expected) {
+			t.Errorf("Expected %s, got %s", expected.GoString(), result.GoString())
+		}
+	})
+
 	// Create subdirectory with files
 	subDir := filepath.Join(tmpDir, "subdir")
 	if err := os.Mkdir(subDir, 0o755); err != nil {

--- a/tests/tfcompat/l1_templatefile_test.go
+++ b/tests/tfcompat/l1_templatefile_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1TemplateFile pins that `templatefile` renders its file as a full HCL
+// template — interpolations may call functions and use `%{ for }` / `%{ if }`
+// directives — exactly as OpenTofu does, rather than performing a naive
+// `${name}` string substitution that leaves function calls and directives
+// untouched.
+func TestL1TemplateFile(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_templatefile", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_templatefile/greeting.tmpl
+++ b/tests/tfcompat/testdata/cases/l1_templatefile/greeting.tmpl
@@ -1,0 +1,1 @@
+Hello ${upper(name)}, you have %{ for n in nums }${n} %{ endfor }items

--- a/tests/tfcompat/testdata/cases/l1_templatefile/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_templatefile/main.tf
@@ -1,0 +1,3 @@
+output "rendered" {
+  value = templatefile("${path.module}/greeting.tmpl", { name = "ada", nums = [1, 2, 3] })
+}


### PR DESCRIPTION
## Divergence

OpenTofu renders a `templatefile` argument as a full HCL template — interpolations may
call functions and use `%{ for }` / `%{ if }` directives:

```hcl
# greeting.tmpl: Hello ${upper(name)}, you have %{ for n in nums }${n} %{ endfor }items
output "rendered" {
  value = templatefile("${path.module}/greeting.tmpl", { name = "ada", nums = [1, 2, 3] })
}
```

```
# tofu apply
rendered = "Hello ADA, you have 1 2 3 items"
```

The pulumi-hcl runtime performed a naive `${name}` string substitution over the file
contents, replacing only bare variable references and leaving function calls and
directives untouched. The same program on `pulumi up` produced the template verbatim:

```
rendered = "Hello ${upper(name)}, you have %{ for n in nums }${n} %{ endfor }items"
```

This is the migration-affecting direction: a real OpenTofu config renders, and the
equivalent pulumi-hcl program does not.

## Fix

Route `templatefile` through the same `renderTemplate` path that already backs
`templatestring`, binding it after the nested function table is built so the template
sees every function except the template functions themselves (preventing unbounded
recursion). `renderTemplate` gains a `filename` parameter so diagnostics name the
template file.

## Proof

- `tests/tfcompat/testdata/cases/l1_templatefile/` (+ `l1_templatefile_test.go`) — a disk
  fixture whose template calls `upper` and uses a `for` directive. Fails before the fix
  (pulumi renders the template literally); passes after.
- `pkg/hcl/eval/functions_test.go` — a new `templatefile renders functions and
  directives` subtest pins the behavior; the existing simple `${name}` subtest still
  passes.