### PR TITLE
Match OpenTofu's `yamlencode` behavior

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-202.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-202.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`yamlencode` matches OpenTofu: keys and string scalars are quoted and block sequences stay un-indented under their key.'
+time: 2026-06-01T21:00:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "202"

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/xanzy/ssh-agent v0.3.3
 	github.com/zclconf/go-cty v1.18.1
+	github.com/zclconf/go-cty-yaml v1.0.3
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.51.0

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	ctyyaml "github.com/zclconf/go-cty-yaml"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/function"
@@ -154,7 +155,7 @@ func Functions(baseDir string) map[string]function.Function {
 		"textencodebase64": textEncodeBase64Func,
 		"urlencode":        urlEncodeFunc,
 		"yamldecode":       yamlDecodeFunc,
-		"yamlencode":       yamlEncodeFunc,
+		"yamlencode":       ctyyaml.YAMLEncodeFunc,
 
 		// Filesystem functions
 		"abspath":    abspathFunc(baseDir),
@@ -848,24 +849,6 @@ var yamlDecodeFunc = function.New(&function.Spec{
 			return cty.NilVal, err
 		}
 		return goToCty(data), nil
-	},
-})
-
-var yamlEncodeFunc = function.New(&function.Spec{
-	Params: []function.Parameter{
-		{Name: "value", Type: cty.DynamicPseudoType},
-	},
-	Type: function.StaticReturnType(cty.String),
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		if !args[0].IsWhollyKnown() {
-			return cty.UnknownVal(retType), nil
-		}
-		data := ctyToGo(args[0])
-		out, err := yaml.Marshal(data)
-		if err != nil {
-			return cty.NilVal, err
-		}
-		return cty.StringVal(string(out)), nil
 	},
 })
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -1031,12 +1031,10 @@ func TestYAMLFunctions(t *testing.T) {
 	t.Parallel()
 	t.Run("yamlencode", func(t *testing.T) {
 		t.Parallel()
-		result := evalExpr(t, "/tmp", `yamlencode({a = "x", b = 2})`)
-		s := result.AsString()
-		// YAML encoding should produce valid output
-		if len(s) == 0 {
-			t.Error("Expected non-empty YAML output")
-		}
+		result := evalExpr(t, "/tmp", `yamlencode({a = "x", b = 2, c = [1, 2]})`)
+		// Like OpenTofu's go-cty-yaml encoder: keys and string scalars are
+		// quoted and block sequences stay un-indented under their key.
+		assert.Equal(t, "\"a\": \"x\"\n\"b\": 2\n\"c\":\n- 1\n- 2\n", result.AsString())
 	})
 
 	t.Run("yamldecode", func(t *testing.T) {

--- a/tests/tfcompat/l1_yamlencode_test.go
+++ b/tests/tfcompat/l1_yamlencode_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1YamlEncode exercises the `yamlencode` built-in: both paths must quote
+// mapping keys and string scalars, keep block sequences un-indented under their
+// key, and render booleans and nulls as bare tokens.
+func TestL1YamlEncode(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_yamlencode", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_yamlencode/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_yamlencode/main.tf
@@ -1,0 +1,14 @@
+# OpenTofu's `yamlencode` delegates to the go-cty-yaml encoder, which quotes
+# every mapping key and string scalar, keeps block sequences at the same
+# indentation as their key, and renders booleans and nulls as bare tokens.
+output "scalars" {
+  value = yamlencode({ a = 1, b = "two", c = [1, 2, 3] })
+}
+
+output "nested" {
+  value = yamlencode({ obj = { x = true, y = null }, list = ["p", "q"] })
+}
+
+output "top_level_list" {
+  value = yamlencode(["one", "two", "three"])
+}


### PR DESCRIPTION
## Divergence

`yamlencode` is hand-rolled in pulumi-hcl on top of `gopkg.in/yaml.v3`: it lowers the cty value to a Go value with `ctyToGo` and calls `yaml.Marshal`. OpenTofu instead binds `yamlencode` directly to [`go-cty-yaml`'s `YAMLEncodeFunc`](https://github.com/zclconf/go-cty-yaml), and the two encoders produce different YAML for the same input — a difference any migrating configuration that feeds `yamlencode` output into a file, a config map, or another tool will observe.

Probing `yamlencode({ a = 1, b = "two", c = [1, 2, 3] })`:

| | OpenTofu (`tofu apply`) | pulumi-hcl (before) |
|---|---|---|
| mapping keys | quoted — `"a":` | bare — `a:` |
| string scalars | quoted — `"two"` | bare — `two` |
| block sequences | un-indented under key | indented 4 spaces |
| bool-like keys (`y`) | bare | spuriously quoted by yaml.v3 |

```
# OpenTofu                 # pulumi-hcl (before)
"a": 1                     a: 1
"b": "two"                 b: two
"c":                       c:
- 1                            - 1
- 2                            - 2
- 3                            - 3
```

Direction: OpenTofu succeeds and pulumi-hcl returns a *different* value, which is the migration-affecting direction.

## Fix

Delegate `yamlencode` to `ctyyaml.YAMLEncodeFunc` — the exact implementation OpenTofu uses — and drop the hand-rolled `yamlEncodeFunc`. `YAMLEncodeFunc` also handles `null` and unknown inputs through the cty function framework, matching OpenTofu there too. `yamldecode` is untouched.

## Proof

- `tests/tfcompat/l1_yamlencode` — fails on master (outputs differ between `tofu apply` and `pulumi up`), passes after the fix.
- Strengthened the `yamlencode` unit test in `pkg/hcl/eval/functions_test.go` to assert the exact ctyyaml-formatted output.

```
$ PATH="$PWD/bin:$PATH" go test ./tests/tfcompat/ -run TestL1YamlEncode -count=1
ok  github.com/pulumi-labs/pulumi-hcl/tests/tfcompat
$ PATH="$PWD/bin:$PATH" go test ./pkg/hcl/eval/ -count=1
ok  github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval
```