### PR TITLE
Match OpenTofu's `tolist`/`toset`/`tomap` behavior

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-206.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-206.yaml
@@ -1,0 +1,7 @@
+kind: bug-fixes
+body: '`tolist`, `toset`, and `tomap` match OpenTofu: a tuple or object with differing
+    element types is unified to a common type instead of erroring.'
+time: 2026-06-02T14:30:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "206"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -38,6 +38,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -202,10 +203,10 @@ func Functions(baseDir string) map[string]function.Function {
 		"nonsensitive": nonsensitiveFunc,
 		"sensitive":    sensitiveFunc,
 		"tobool":       toBoolFunc,
-		"tolist":       toListFunc,
-		"tomap":        toMapFunc,
-		"tonumber":     toNumberFunc,
-		"toset":        toSetFunc,
+		"tolist":       makeToFunc(cty.List(cty.DynamicPseudoType)),
+		"tomap":        makeToFunc(cty.Map(cty.DynamicPseudoType)),
+		"tonumber":     makeToFunc(cty.Number),
+		"toset":        makeToFunc(cty.Set(cty.DynamicPseudoType)),
 		"tostring":     toStringFunc,
 		"try":          tryfunc.TryFunc,
 		"type":         typeFunc,
@@ -1638,115 +1639,69 @@ var toBoolFunc = function.New(&function.Spec{
 	},
 })
 
-var toListFunc = function.New(&function.Spec{
-	Params: []function.Parameter{
-		{Name: "value", Type: cty.DynamicPseudoType},
-	},
-	Type: func(args []cty.Value) (cty.Type, error) {
-		ty := args[0].Type()
-		if ty.IsSetType() {
-			return cty.List(ty.ElementType()), nil
-		}
-		if ty.IsTupleType() {
-			// Find common type
-			return cty.List(cty.DynamicPseudoType), nil
-		}
-		return cty.List(cty.DynamicPseudoType), nil
-	},
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		val := args[0]
-		if val.Type().IsListType() {
-			return val, nil
-		}
-		var vals []cty.Value
-		for it := val.ElementIterator(); it.Next(); {
-			_, v := it.Element()
-			vals = append(vals, v)
-		}
-		if len(vals) == 0 {
-			elemTy := cty.DynamicPseudoType
-			if retType.IsListType() {
-				elemTy = retType.ElementType()
+// makeToFunc constructs a "to..." conversion function like OpenTofu's
+// MakeToFunc. The argument passes through verbatim as cty.DynamicPseudoType and
+// the conversion to wantTy happens inside Type and Impl via the cty convert
+// package. Passing cty.List(cty.DynamicPseudoType) and friends means "list of
+// any single type", which causes cty to unify the element types of a tuple or
+// object rather than rejecting a mismatch.
+func makeToFunc(wantTy cty.Type) function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name:             "v",
+				Type:             cty.DynamicPseudoType,
+				AllowNull:        true,
+				AllowMarked:      true,
+				AllowDynamicType: true,
+			},
+		},
+		Type: func(args []cty.Value) (cty.Type, error) {
+			gotTy := args[0].Type()
+			if gotTy.Equals(wantTy) {
+				return wantTy, nil
 			}
-			return cty.ListValEmpty(elemTy), nil
-		}
-		return cty.ListVal(vals), nil
-	},
-})
-
-var toMapFunc = function.New(&function.Spec{
-	Params: []function.Parameter{
-		{Name: "value", Type: cty.DynamicPseudoType},
-	},
-	Type: function.StaticReturnType(cty.Map(cty.DynamicPseudoType)),
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		val := args[0]
-		if val.Type().IsMapType() {
-			return val, nil
-		}
-		m := make(map[string]cty.Value)
-		for it := val.ElementIterator(); it.Next(); {
-			k, v := it.Element()
-			m[k.AsString()] = v
-		}
-		if len(m) == 0 {
-			return cty.MapValEmpty(cty.DynamicPseudoType), nil
-		}
-		return cty.MapVal(m), nil
-	},
-})
-
-var toNumberFunc = function.New(&function.Spec{
-	Params: []function.Parameter{
-		{Name: "value", Type: cty.DynamicPseudoType},
-	},
-	Type: function.StaticReturnType(cty.Number),
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		ret, err := convert.Convert(args[0], cty.Number)
-		if err != nil {
-			val, _ := args[0].UnmarkDeep()
-			if val.Type() == cty.String && !val.IsNull() {
-				return cty.NilVal, fmt.Errorf(
-					"cannot convert %q to number; given string must be a decimal representation of a number",
-					val.AsString())
+			conv := convert.GetConversionUnsafe(args[0].Type(), wantTy)
+			if conv == nil {
+				switch {
+				case gotTy.IsTupleType() && wantTy.IsTupleType():
+					return cty.NilType, function.NewArgErrorf(0, "incompatible tuple type for conversion: %s", convert.MismatchMessage(gotTy, wantTy))
+				case gotTy.IsObjectType() && wantTy.IsObjectType():
+					return cty.NilType, function.NewArgErrorf(0, "incompatible object type for conversion: %s", convert.MismatchMessage(gotTy, wantTy))
+				default:
+					return cty.NilType, function.NewArgErrorf(0, "cannot convert %s to %s", gotTy.FriendlyName(), wantTy.FriendlyNameForConstraint())
+				}
 			}
-			return cty.NilVal, fmt.Errorf("cannot convert %s to number", val.Type().FriendlyName())
-		}
-		return ret, nil
-	},
-})
-
-var toSetFunc = function.New(&function.Spec{
-	Params: []function.Parameter{
-		{Name: "value", Type: cty.DynamicPseudoType},
-	},
-	Type: func(args []cty.Value) (cty.Type, error) {
-		ty := args[0].Type()
-		if ty.IsListType() {
-			return cty.Set(ty.ElementType()), nil
-		}
-		return cty.Set(cty.DynamicPseudoType), nil
-	},
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		val := args[0]
-		if val.Type().IsSetType() {
-			return val, nil
-		}
-		var vals []cty.Value
-		for it := val.ElementIterator(); it.Next(); {
-			_, v := it.Element()
-			vals = append(vals, v)
-		}
-		if len(vals) == 0 {
-			elemTy := cty.DynamicPseudoType
-			if retType.IsSetType() {
-				elemTy = retType.ElementType()
+			return wantTy, nil
+		},
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			ret, err := convert.Convert(args[0], retType)
+			if err != nil {
+				val, _ := args[0].UnmarkDeep()
+				gotTy := val.Type()
+				switch {
+				case args[0].HasMark(SensitiveMark):
+					return cty.NilVal, function.NewArgErrorf(0, "cannot convert this sensitive %s to %s", gotTy.FriendlyName(), wantTy.FriendlyNameForConstraint())
+				case gotTy == cty.String && wantTy == cty.Bool:
+					what := "string"
+					if !val.IsNull() {
+						what = strconv.Quote(val.AsString())
+					}
+					return cty.NilVal, function.NewArgErrorf(0, `cannot convert %s to bool; only the strings "true" or "false" are allowed`, what)
+				case gotTy == cty.String && wantTy == cty.Number:
+					what := "string"
+					if !val.IsNull() {
+						what = strconv.Quote(val.AsString())
+					}
+					return cty.NilVal, function.NewArgErrorf(0, `cannot convert %s to number; given string must be a decimal representation of a number`, what)
+				default:
+					return cty.NilVal, function.NewArgErrorf(0, "cannot convert %s to %s", gotTy.FriendlyName(), wantTy.FriendlyNameForConstraint())
+				}
 			}
-			return cty.SetValEmpty(elemTy), nil
-		}
-		return cty.SetVal(vals), nil
-	},
-})
+			return ret, nil
+		},
+	})
+}
 
 var toStringFunc = function.New(&function.Spec{
 	Params: []function.Parameter{

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -674,7 +674,7 @@ func TestToNumber(t *testing.T) {
 func TestToNumberError(t *testing.T) {
 	t.Parallel()
 
-	_, err := toNumberFunc.Call([]cty.Value{cty.StringVal("12abc")})
+	_, err := makeToFunc(cty.Number).Call([]cty.Value{cty.StringVal("12abc")})
 	assert.EqualError(t, err,
 		`cannot convert "12abc" to number; given string must be a decimal representation of a number`)
 }
@@ -740,17 +740,47 @@ func TestToSetToListPreserveEmptyElementType(t *testing.T) {
 	t.Parallel()
 	t.Run("toset of empty list(string)", func(t *testing.T) {
 		t.Parallel()
-		got, err := toSetFunc.Call([]cty.Value{cty.ListValEmpty(cty.String)})
-		require.NoError(t, err)
+		got := evalExpr(t, "/tmp", `toset(slice(tolist(["a"]), 0, 0))`)
 		assert.Equal(t, cty.SetValEmpty(cty.String), got)
 	})
 
 	t.Run("tolist of empty set(string)", func(t *testing.T) {
 		t.Parallel()
-		got, err := toListFunc.Call([]cty.Value{cty.SetValEmpty(cty.String)})
-		require.NoError(t, err)
+		got := evalExpr(t, "/tmp", `tolist(setsubtract(toset(["a"]), toset(["a"])))`)
 		assert.Equal(t, cty.ListValEmpty(cty.String), got)
 	})
+}
+
+// TestToCollectionUnify pins that `tolist` / `toset` / `tomap` unify the
+// element types of a tuple or object whose elements have differing types, as
+// OpenTofu does, rather than panicking on the mismatch. Number, string, and
+// bool all unify to string.
+func TestToCollectionUnify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		expr     string
+		expected cty.Value
+	}{
+		{"tolist mixed", `tolist([1, "a", true])`, cty.ListVal([]cty.Value{
+			cty.StringVal("1"), cty.StringVal("a"), cty.StringVal("true"),
+		})},
+		{"toset mixed", `toset([3, "1", 2])`, cty.SetVal([]cty.Value{
+			cty.StringVal("1"), cty.StringVal("2"), cty.StringVal("3"),
+		})},
+		{"tomap mixed", `tomap({ a = 1, b = "x", c = true })`, cty.MapVal(map[string]cty.Value{
+			"a": cty.StringVal("1"), "b": cty.StringVal("x"), "c": cty.StringVal("true"),
+		})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := evalExpr(t, "/tmp", tt.expr)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 func TestDateTimeFunctions(t *testing.T) {

--- a/tests/tfcompat/l1_to_collection_test.go
+++ b/tests/tfcompat/l1_to_collection_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1ToCollection exercises `tolist` / `toset` / `tomap` over tuples and
+// objects whose elements have differing types. Both paths must unify the
+// element types to a single common type rather than erroring on the mismatch.
+func TestL1ToCollection(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_to_collection", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_to_collection/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_to_collection/main.tf
@@ -1,0 +1,15 @@
+# OpenTofu's tolist / toset / tomap accept a tuple or object whose elements have
+# differing types and unify them to a single common element type before building
+# the collection. Here each input mixes numbers, strings, and bools, all of which
+# unify to string, so the result is a homogeneous string collection.
+output "to_list_mixed" {
+  value = tolist([1, "a", true])
+}
+
+output "to_set_mixed" {
+  value = toset([3, "1", 2])
+}
+
+output "to_map_mixed" {
+  value = tomap({ a = 1, b = "x", c = true })
+}


### PR DESCRIPTION
## Divergence

OpenTofu binds `tolist`, `toset`, and `tomap` to a single conversion helper (`MakeToFunc`) that delegates to the cty `convert` package with a `list`/`set`/`map` of `dynamic` target type. That target means "of any single type", so a tuple or object whose elements have differing types has its element types **unified to a common type** before the collection is built.

For example, in OpenTofu:

```hcl
tolist([1, "a", true])              # => ["1", "a", "true"]
toset([3, "1", 2])                  # => ["1", "2", "3"]
tomap({ a = 1, b = "x", c = true }) # => { a = "1", b = "x", c = "true" }
```

pulumi-hcl hand-rolled these three functions to collect the elements and call `cty.ListVal` / `cty.SetVal` / `cty.MapVal` directly. Those all require a **homogeneous** element type and panic otherwise, so a mixed-type tuple or object that OpenTofu happily accepts aborted the program:

```
Call to function "tolist" failed: panic in function implementation:
inconsistent list element types (cty.Number then cty.String)
```

This is the migration-affecting direction: OpenTofu produces a value, pulumi-hcl errors.

## Fix

Replace the three hand-rolled implementations with a shared `makeToFunc` that mirrors OpenTofu's `MakeToFunc`, delegating the conversion to `convert.Convert`. This adds element-type unification while preserving the existing empty-collection element-type behavior (`toset(list(string)[])` stays `set(string)`).

## Sweep

The panic root cause is shared by exactly these three collection converters; all are fixed here. The remaining `to*` siblings were checked and are deliberately left unchanged:

- `tonumber` already delegates to `convert.Convert`, so it never panicked.
- `tobool` (`"yes"`/`"on"`/`"1"` …) and `tostring` (JSON-encodes complex types) only diverge by being *more lenient* than OpenTofu — the non-migration direction — so tightening them removes capability without helping any migration.

## Proof

- `tests/tfcompat/l1_to_collection` — fails on master with the panic above, passes after the fix; both runtimes now produce identical unified outputs.
- `pkg/hcl/eval` unit test `TestToCollectionUnify` pins the unification for all three functions; `TestToSetToListPreserveEmptyElementType` and `TestTypeFunctions` continue to pass.