### PR TITLE
Match OpenTofu's `matchkeys` behavior

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-207.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-207.yaml
@@ -1,0 +1,8 @@
+kind: bug-fixes
+body: '`matchkeys` matches OpenTofu: the `keys` and `searchset` element types are unified
+    before comparison, so a key matches a search-set element of a different but unifiable
+    type.'
+time: 2026-06-02T15:30:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "207"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -30,6 +30,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -51,6 +52,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	ctyyaml "github.com/zclconf/go-cty-yaml"
 	"github.com/zclconf/go-cty/cty"
@@ -506,34 +508,66 @@ var matchkeysFunc = function.New(&function.Spec{
 		{Name: "searchset", Type: cty.List(cty.DynamicPseudoType)},
 	},
 	Type: func(args []cty.Value) (cty.Type, error) {
+		ty, _ := convert.UnifyUnsafe([]cty.Type{args[1].Type(), args[2].Type()})
+		if ty == cty.NilType {
+			return cty.NilType, errors.New("keys and searchset must be of the same type")
+		}
 		return args[0].Type(), nil
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		if !args[0].IsKnown() {
+			return cty.UnknownVal(cty.List(retType.ElementType())), nil
+		}
+
+		if args[0].LengthInt() != args[1].LengthInt() {
+			return cty.ListValEmpty(retType.ElementType()), errors.New("length of keys and values should be equal")
+		}
+
 		values := args[0]
-		keys := args[1]
-		searchset := args[2]
 
-		searchMap := make(map[string]bool)
-		for it := searchset.ElementIterator(); it.Next(); {
-			_, v := it.Element()
-			searchMap[v.GoString()] = true
+		// keys and searchset must be unified to a common type before comparing,
+		// so that e.g. a numeric key can match a string search-set element. The
+		// Type function already verified that they unify, so converting each to
+		// the unified type cannot fail here.
+		ty, _ := convert.UnifyUnsafe([]cty.Type{args[1].Type(), args[2].Type()})
+		keys, err := convert.Convert(args[1], ty)
+		contract.AssertNoErrorf(err, "keys were verified to unify to %s in the type check", ty)
+		searchset, err := convert.Convert(args[2], ty)
+		contract.AssertNoErrorf(err, "searchset was verified to unify to %s in the type check", ty)
+
+		if searchset.LengthInt() == 0 {
+			return cty.ListValEmpty(retType.ElementType()), nil
 		}
 
-		var result []cty.Value
-		valIt := values.ElementIterator()
-		keyIt := keys.ElementIterator()
-		for valIt.Next() && keyIt.Next() {
-			_, v := valIt.Element()
-			_, k := keyIt.Element()
-			if searchMap[k.GoString()] {
-				result = append(result, v)
+		if !values.IsWhollyKnown() || !keys.IsWhollyKnown() {
+			return cty.UnknownVal(retType), nil
+		}
+
+		output := make([]cty.Value, 0)
+		i := 0
+		for it := keys.ElementIterator(); it.Next(); {
+			_, key := it.Element()
+			for iter := searchset.ElementIterator(); iter.Next(); {
+				_, search := iter.Element()
+				eq, err := stdlib.Equal(key, search)
+				if err != nil {
+					return cty.NilVal, err
+				}
+				if !eq.IsKnown() {
+					return cty.UnknownVal(retType), nil
+				}
+				if eq.True() {
+					output = append(output, values.Index(cty.NumberIntVal(int64(i))))
+					break
+				}
 			}
+			i++
 		}
 
-		if len(result) == 0 {
-			return cty.ListValEmpty(values.Type().ElementType()), nil
+		if len(output) == 0 {
+			return cty.ListValEmpty(retType.ElementType()), nil
 		}
-		return cty.ListVal(result), nil
+		return cty.ListVal(output), nil
 	},
 })
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -783,6 +783,39 @@ func TestToCollectionUnify(t *testing.T) {
 	}
 }
 
+// TestMatchkeysTypeUnify pins that `matchkeys` unifies the element types of
+// `keys` and `searchset` before comparing, as OpenTofu does, so a numeric key
+// matches a string search-set element rather than being missed.
+func TestMatchkeysTypeUnify(t *testing.T) {
+	t.Parallel()
+	got := evalExpr(t, "/tmp", `matchkeys(["a", "b", "c"], [1, 2, 3], ["2"])`)
+	assert.Equal(t, cty.ListVal([]cty.Value{cty.StringVal("b")}), got)
+}
+
+// TestMatchkeysLengthMismatch pins that `matchkeys` errors when `keys` and
+// `values` have different lengths, as OpenTofu does, rather than silently
+// zipping to the shorter of the two.
+func TestMatchkeysLengthMismatch(t *testing.T) {
+	t.Parallel()
+	_, err := matchkeysFunc.Call([]cty.Value{
+		cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+		cty.ListVal([]cty.Value{cty.StringVal("x")}),
+		cty.ListVal([]cty.Value{cty.StringVal("x")}),
+	})
+	assert.EqualError(t, err, "length of keys and values should be equal")
+}
+
+func TestMatchkeysUnknownSearchset(t *testing.T) {
+	t.Parallel()
+	got, err := matchkeysFunc.Call([]cty.Value{
+		cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+		cty.ListVal([]cty.Value{cty.StringVal("x"), cty.StringVal("y")}),
+		cty.ListVal([]cty.Value{cty.UnknownVal(cty.String)}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, cty.UnknownVal(cty.List(cty.String)), got)
+}
+
 func TestDateTimeFunctions(t *testing.T) {
 	t.Parallel()
 

--- a/tests/tfcompat/l1_matchkeys_test.go
+++ b/tests/tfcompat/l1_matchkeys_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1Matchkeys exercises `matchkeys` when `keys` and `searchset` have
+// differing but unifiable element types. Both paths must unify the types before
+// comparing so a numeric key matches its string search-set counterpart.
+func TestL1Matchkeys(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_matchkeys", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_matchkeys/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_matchkeys/main.tf
@@ -1,0 +1,12 @@
+# OpenTofu's matchkeys unifies the element types of `keys` and `searchset`
+# before comparing them, so a numeric key list can be matched against a string
+# search set: number and string unify to string, and "2" == "2". A faithful
+# implementation therefore returns the value whose key matches.
+output "type_unified" {
+  value = matchkeys(["a", "b", "c"], [1, 2, 3], ["2"])
+}
+
+# Same element types: the common case must keep working unchanged.
+output "same_type" {
+  value = matchkeys(["a", "b", "c"], ["x", "y", "x"], ["x"])
+}


### PR DESCRIPTION
## Divergence

OpenTofu's `matchkeys` unifies the element types of its `keys` and `searchset` arguments before comparing them (using `stdlib.Equal`). Because number and string unify to string, a numeric key list matches a string search set:

```hcl
matchkeys(["a", "b", "c"], [1, 2, 3], ["2"])   # OpenTofu => ["b"]
```

pulumi-hcl compared the raw internal `GoString()` representation of each key and search-set element. Those representations differ between a number (`cty.NumberIntVal(2)`) and a string (`cty.StringVal("2")`), so the cross-type match was silently missed:

```hcl
matchkeys(["a", "b", "c"], [1, 2, 3], ["2"])   # pulumi-hcl => []
```

This is the migration-affecting direction: OpenTofu produces `["b"]`, pulumi-hcl produces a different value (`[]`).

## Fix

Rewrite `matchkeys` to mirror OpenTofu's implementation:

- reject unmergeable `keys`/`searchset` types in the type check (`keys and searchset must be of the same type`),
- require `keys` and `values` to have equal length (`length of keys and values should be equal`),
- unify and convert `keys`/`searchset` to their common type, then compare with `stdlib.Equal`.

The common same-type usage (`matchkeys(["a","b","c"], ["x","y","x"], ["x"])` → `["a","c"]`) is unchanged.

## Sweep

The root cause is comparison without type unification. The neighbouring membership functions were checked and do **not** share the bug:

- `contains` is `stdlib.ContainsFunc` in both runtimes — already identical (and neither unifies cross-type, by design).
- `index` is hand-rolled in both and only diverges by being *more lenient* than OpenTofu (accepting a set argument), which is the non-migration direction.

## Proof

- `tests/tfcompat/l1_matchkeys` — fails on master (`type_unified` is `["b"]` in OpenTofu, `[]` in pulumi), passes after the fix; a same-type output guards the common case.
- `pkg/hcl/eval` unit tests `TestMatchkeysTypeUnify` and `TestMatchkeysLengthMismatch` pin the new behavior; the existing `matchkeys` case in `TestCollectionFunctions` continues to pass.