### PR TITLE
Support the `defaults` argument on `terraform_remote_state`

### DIFF
--- a/.changes/unreleased/runtime-Improvements-208.yaml
+++ b/.changes/unreleased/runtime-Improvements-208.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: '`terraform_remote_state` now supports the `defaults` argument, filling in outputs the referenced state omits'
+time: 2026-06-02T12:00:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "207"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2327,7 +2327,7 @@ func (e *Engine) callMethod(ctx context.Context, req CallRequest) (property.Map,
 
 // invokeFunction invokes a Pulumi function (data source).
 func (e *Engine) invokeFunction(ctx context.Context, tfType string, req InvokeRequest) (property.Map, error) {
-	req, err := lowerRemoteStateInvoke(tfType, req)
+	req, defaults, err := lowerRemoteStateInvoke(tfType, req)
 	if err != nil {
 		return property.Map{}, err
 	}
@@ -2347,7 +2347,7 @@ func (e *Engine) invokeFunction(ctx context.Context, tfType string, req InvokeRe
 		return property.Map{}, fmt.Errorf("function invocation failed: %v", resp.Failures)
 	}
 
-	return resp.Return, nil
+	return applyRemoteStateDefaults(defaults, resp.Return), nil
 }
 
 func (e *Engine) getResourceState(ctx context.Context, ref property.ResourceReference) (property.Map, error) {

--- a/pkg/hcl/run/terraform_remote_state.go
+++ b/pkg/hcl/run/terraform_remote_state.go
@@ -38,8 +38,8 @@ const (
 // terraformRemoteStateSchema is the synthetic schema terraform_remote_state
 // resolves to: the TF data source surface as inputs. lowerRemoteStateInvoke
 // selects the concrete pulumi-terraform invoke (local or remote) by backend and
-// translates the inputs to its arguments. The placeholder Token is always
-// overridden there.
+// translates the inputs to its arguments, and applyRemoteStateDefaults overlays
+// `defaults` on the result. The placeholder Token is always overridden there.
 func terraformRemoteStateSchema() *schema.Function {
 	opt := func(t schema.Type) schema.Type { return &schema.OptionalType{ElementType: t} }
 	return &schema.Function{
@@ -69,14 +69,21 @@ func terraformRemoteStateSchema() *schema.Function {
 // `<prefix><workspace>` (combined into the invoke's `workspaces.name`); with
 // config.workspaces.name only the implicit "default" workspace exists, so
 // `workspace` must be "default". It is unsupported on the local backend
-// (getLocalReference has no workspace input). `defaults` is unsupported.
-func lowerRemoteStateInvoke(tfType string, req InvokeRequest) (InvokeRequest, error) {
+// (getLocalReference has no workspace input).
+//
+// `defaults` is returned for applyRemoteStateDefaults to overlay on the invoke
+// result; it is the zero Map when absent.
+func lowerRemoteStateInvoke(tfType string, req InvokeRequest) (InvokeRequest, property.Map, error) {
 	if tfType != remoteStateType {
-		return req, nil
+		return req, property.Map{}, nil
 	}
 
+	var defaults property.Map
 	if v, ok := req.Args.GetOk("defaults"); ok && !v.IsNull() {
-		return req, fmt.Errorf("terraform_remote_state: %q is not supported", "defaults")
+		if !v.IsMap() {
+			return req, property.Map{}, fmt.Errorf("terraform_remote_state: %q must be an object", "defaults")
+		}
+		defaults = v.AsMap()
 	}
 
 	backend := ""
@@ -94,7 +101,7 @@ func lowerRemoteStateInvoke(tfType string, req InvokeRequest) (InvokeRequest, er
 	switch backend {
 	case "local":
 		if hasWorkspace {
-			return req, fmt.Errorf("terraform_remote_state: the local backend does not support the workspace attribute")
+			return req, property.Map{}, fmt.Errorf("terraform_remote_state: the local backend does not support the workspace attribute")
 		}
 		token = localReferenceToken
 		desc = "the local backend"
@@ -109,7 +116,7 @@ func lowerRemoteStateInvoke(tfType string, req InvokeRequest) (InvokeRequest, er
 			"workspaces":   "workspaces",
 		}
 	default:
-		return req, fmt.Errorf(
+		return req, property.Map{}, fmt.Errorf(
 			"terraform_remote_state: backend %q is not supported (supported backends: local, remote)", backend,
 		)
 	}
@@ -127,7 +134,7 @@ func lowerRemoteStateInvoke(tfType string, req InvokeRequest) (InvokeRequest, er
 	}
 	if len(unexpected) > 0 {
 		slices.Sort(unexpected)
-		return req, fmt.Errorf(
+		return req, property.Map{}, fmt.Errorf(
 			"terraform_remote_state: %s does not read config field(s) %v (supported: %s)",
 			desc, unexpected, strings.Join(slices.Sorted(maps.Keys(fields)), ", "),
 		)
@@ -140,23 +147,38 @@ func lowerRemoteStateInvoke(tfType string, req InvokeRequest) (InvokeRequest, er
 	if hasWorkspace {
 		ws, ok := args["workspaces"]
 		if !ok || !ws.IsMap() {
-			return req, fmt.Errorf("terraform_remote_state: workspace requires config.workspaces.prefix")
+			return req, property.Map{}, fmt.Errorf("terraform_remote_state: workspace requires config.workspaces.prefix")
 		}
 		switch wsMap := ws.AsMap(); {
 		case wsMap.Get("name").IsString():
 			if workspace != "default" {
-				return req, fmt.Errorf(
+				return req, property.Map{}, fmt.Errorf(
 					"terraform_remote_state: workspace %q is invalid with config.workspaces.name (only \"default\" is)", workspace,
 				)
 			}
 		case wsMap.Get("prefix").IsString():
 			args["workspaces"] = property.New(map[string]property.Value{"name": property.New(wsMap.Get("prefix").AsString() + workspace)})
 		default:
-			return req, fmt.Errorf("terraform_remote_state: workspace requires config.workspaces.prefix")
+			return req, property.Map{}, fmt.Errorf("terraform_remote_state: workspace requires config.workspaces.prefix")
 		}
 	}
 
 	req.Token = token
 	req.Args = property.NewMap(args)
-	return req, nil
+	return req, defaults, nil
+}
+
+// applyRemoteStateDefaults overlays the data source's `defaults` beneath the
+// outputs returned by the state-reference invoke: each default supplies the
+// value for an output the referenced state does not define, matching OpenTofu's
+// per-output fallback. ret is returned unchanged when there are no defaults.
+func applyRemoteStateDefaults(defaults, ret property.Map) property.Map {
+	if defaults.Len() == 0 {
+		return ret
+	}
+	merged := maps.Collect(defaults.All)
+	if out, ok := ret.GetOk("outputs"); ok && out.IsMap() {
+		maps.Insert(merged, out.AsMap().All)
+	}
+	return ret.Set("outputs", property.New(merged))
 }

--- a/pkg/hcl/run/terraform_remote_state_test.go
+++ b/pkg/hcl/run/terraform_remote_state_test.go
@@ -38,7 +38,7 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 
 	t.Run("local backend translates config to invoke args", func(t *testing.T) {
 		t.Parallel()
-		got, err := lowerRemoteStateInvoke(remoteStateType, localReq)
+		got, _, err := lowerRemoteStateInvoke(remoteStateType, localReq)
 		require.NoError(t, err)
 		assert.Equal(t, InvokeRequest{
 			Token: localReferenceToken,
@@ -51,7 +51,7 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 
 	t.Run("remote backend defers to getRemoteReference", func(t *testing.T) {
 		t.Parallel()
-		got, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+		got, _, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
 			Token: localReferenceToken,
 			Args: property.NewMap(map[string]property.Value{
 				"backend": property.New("remote"),
@@ -73,7 +73,7 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 
 	t.Run("unsupported backend is rejected", func(t *testing.T) {
 		t.Parallel()
-		_, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+		_, _, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
 			Args: property.NewMap(map[string]property.Value{"backend": property.New("s3")}),
 		})
 		require.EqualError(t, err,
@@ -82,7 +82,7 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 
 	t.Run("config fields the local backend ignores are rejected", func(t *testing.T) {
 		t.Parallel()
-		_, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+		_, _, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
 			Args: property.NewMap(map[string]property.Value{
 				"backend": property.New("local"),
 				"config": property.New(map[string]property.Value{
@@ -97,7 +97,7 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 
 	t.Run("config fields the remote backend ignores are rejected", func(t *testing.T) {
 		t.Parallel()
-		_, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+		_, _, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
 			Args: property.NewMap(map[string]property.Value{
 				"backend": property.New("remote"),
 				"config": property.New(map[string]property.Value{
@@ -111,20 +111,34 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 				`(supported: hostname, organization, token, workspaces)`)
 	})
 
-	t.Run("defaults is rejected", func(t *testing.T) {
+	t.Run("defaults is returned for the result overlay", func(t *testing.T) {
 		t.Parallel()
-		_, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+		defaultsVal := map[string]property.Value{"number": property.New(99.0)}
+		_, defaults, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
 			Args: property.NewMap(map[string]property.Value{
 				"backend":  property.New("local"),
-				"defaults": property.New(map[string]property.Value{"x": property.New("y")}),
+				"config":   property.New(map[string]property.Value{"path": property.New("state.tfstate")}),
+				"defaults": property.New(defaultsVal),
 			}),
 		})
-		require.EqualError(t, err, `terraform_remote_state: "defaults" is not supported`)
+		require.NoError(t, err)
+		assert.Equal(t, property.NewMap(defaultsVal), defaults)
+	})
+
+	t.Run("non-object defaults is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+			Args: property.NewMap(map[string]property.Value{
+				"backend":  property.New("local"),
+				"defaults": property.New("oops"),
+			}),
+		})
+		require.EqualError(t, err, `terraform_remote_state: "defaults" must be an object`)
 	})
 
 	t.Run("workspace combines with the workspaces prefix", func(t *testing.T) {
 		t.Parallel()
-		got, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+		got, _, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
 			Args: property.NewMap(map[string]property.Value{
 				"backend":   property.New("remote"),
 				"workspace": property.New("prod"),
@@ -146,7 +160,7 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 
 	t.Run("workspace without a prefix is rejected", func(t *testing.T) {
 		t.Parallel()
-		_, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+		_, _, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
 			Args: property.NewMap(map[string]property.Value{
 				"backend":   property.New("remote"),
 				"workspace": property.New("prod"),
@@ -159,7 +173,7 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 
 	t.Run("workspace=default with workspaces.name is allowed", func(t *testing.T) {
 		t.Parallel()
-		got, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+		got, _, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
 			Args: property.NewMap(map[string]property.Value{
 				"backend":   property.New("remote"),
 				"workspace": property.New("default"),
@@ -181,7 +195,7 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 
 	t.Run("non-default workspace with workspaces.name is rejected", func(t *testing.T) {
 		t.Parallel()
-		_, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+		_, _, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
 			Args: property.NewMap(map[string]property.Value{
 				"backend":   property.New("remote"),
 				"workspace": property.New("prod"),
@@ -197,7 +211,7 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 
 	t.Run("workspace is rejected on the local backend", func(t *testing.T) {
 		t.Parallel()
-		_, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
+		_, _, err := lowerRemoteStateInvoke(remoteStateType, InvokeRequest{
 			Args: property.NewMap(map[string]property.Value{
 				"backend":   property.New("local"),
 				"workspace": property.New("staging"),
@@ -209,8 +223,37 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 
 	t.Run("other data sources are untouched", func(t *testing.T) {
 		t.Parallel()
-		got, err := lowerRemoteStateInvoke("some_other_source", localReq)
+		got, _, err := lowerRemoteStateInvoke("some_other_source", localReq)
 		require.NoError(t, err)
 		assert.Equal(t, localReq, got)
+	})
+}
+
+func TestApplyRemoteStateDefaults(t *testing.T) {
+	t.Parallel()
+
+	ret := property.NewMap(map[string]property.Value{
+		"outputs": property.New(map[string]property.Value{
+			"greeting": property.New("hello"),
+		}),
+	})
+
+	t.Run("no defaults returns the result unchanged", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, ret, applyRemoteStateDefaults(property.Map{}, ret))
+	})
+
+	t.Run("defaults fill absent outputs and state wins on overlap", func(t *testing.T) {
+		t.Parallel()
+		defaults := property.NewMap(map[string]property.Value{
+			"greeting": property.New("DEFAULT"),
+			"number":   property.New(99.0),
+		})
+		assert.Equal(t, property.NewMap(map[string]property.Value{
+			"outputs": property.New(map[string]property.Value{
+				"greeting": property.New("hello"),
+				"number":   property.New(99.0),
+			}),
+		}), applyRemoteStateDefaults(defaults, ret))
 	})
 }

--- a/tests/tfcompat/l2_terraform_remote_state_test.go
+++ b/tests/tfcompat/l2_terraform_remote_state_test.go
@@ -30,3 +30,12 @@ func TestL2TerraformRemoteState(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_terraform_remote_state", tfcompat.Case{})
 }
+
+// TestL2TerraformRemoteStateDefaults checks that terraform_remote_state's
+// `defaults` fills in outputs the referenced state omits while a present output
+// keeps its state value. OpenTofu merges defaults internally; pulumi-language-hcl
+// overlays them on the getLocalReference result. Both paths must agree.
+func TestL2TerraformRemoteStateDefaults(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_terraform_remote_state_defaults", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_remote_state_defaults/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_remote_state_defaults/main.tf
@@ -1,0 +1,28 @@
+# terraform_remote_state's `defaults` supplies a value for any output the
+# referenced state does not define, while a present output wins over its
+# default. The fixture state defines only `greeting`, so `number` and `missing`
+# come from defaults and `greeting` keeps its state value. pulumi-language-hcl
+# overlays `defaults` on the getLocalReference result the same way.
+data "terraform_remote_state" "rs" {
+  backend = "local"
+  config = {
+    path = "remote.tfstate"
+  }
+  defaults = {
+    greeting = "default-greeting"
+    number   = 99
+    missing  = "fallback"
+  }
+}
+
+output "greeting" {
+  value = data.terraform_remote_state.rs.outputs.greeting
+}
+
+output "number" {
+  value = data.terraform_remote_state.rs.outputs.number
+}
+
+output "missing" {
+  value = data.terraform_remote_state.rs.outputs.missing
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_remote_state_defaults/remote.tfstate
+++ b/tests/tfcompat/testdata/cases/l2_terraform_remote_state_defaults/remote.tfstate
@@ -1,0 +1,14 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 1,
+  "lineage": "3d6f6d7b-4429-46cb-d10f-10ab291859f7",
+  "outputs": {
+    "greeting": {
+      "value": "hello",
+      "type": "string"
+    }
+  },
+  "resources": [],
+  "check_results": null
+}


### PR DESCRIPTION
## What

OpenTofu's `terraform_remote_state` data source accepts a [`defaults`](https://opentofu.org/docs/language/state/remote-state-data/) object: it supplies a value for any root output the referenced state does not define, while an output the state *does* define keeps its own value (per-output, state wins). The pulumi-terraform `getLocalReference` / `getRemoteReference` invokes we lower onto have no such input, so this implements `defaults` in the runtime.

This brings `terraform_remote_state` to parity with OpenTofu on the backends we support.

## How

- `lowerRemoteStateInvoke` now returns the `defaults` map (and rejects a non-object `defaults`) instead of rejecting the argument outright.
- `applyRemoteStateDefaults` overlays `defaults` beneath the invoke's `outputs` with per-output, state-wins precedence, applied to the invoke result in `invokeFunction`. It is backend-independent, so it covers both the `local` and `remote` backends.

Semantics were confirmed against the docs, the [OpenTofu source](https://github.com/opentofu/opentofu/blob/main/internal/builtin/providers/tf/data_source_state.go), and a live `tofu apply`.

## Tests

- Unit tests for the lowering (defaults returned for the overlay; non-object rejected) and for `applyRemoteStateDefaults` (no-defaults passthrough; fill-absent + state-wins-on-overlap).
- A `tfcompat` case (`l2_terraform_remote_state_defaults`) drives a state defining only one of three outputs through both `tofu apply` and `pulumi up` and asserts the two absent outputs come from `defaults` while the present one is untouched.

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/189