### PR TITLE
Dedup child-module provider specs against resolved local SDKs

### DIFF
--- a/.changes/unreleased/language-host-bug-fixes-216.yaml
+++ b/.changes/unreleased/language-host-bug-fixes-216.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: A provider declared only in a child module no longer leaves an unresolved package spec after its local SDK is installed, so `pulumi preview` succeeds instead of reporting "unresolved package spec(s)"
+time: 2026-06-03T14:55:00.000000+02:00
+custom:
+    Component: language-host
+    PR: "216"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -180,11 +180,6 @@ func (host *LanguageHost) GetRequiredPackages(
 	var pkgs []*pulumirpc.PackageDependency
 	var specs []*pulumirpc.PackageSpec
 
-	required := map[string]*ast.RequiredProvider{}
-	if config.Terraform != nil {
-		required = config.Terraform.RequiredProviders
-	}
-
 	// Resolve every provider referenced anywhere in the module tree to its
 	// source, mirroring tofu: a provider declared in a child module is installed
 	// from its declared source (not the "hashicorp/<name>" default), providers
@@ -211,10 +206,10 @@ func (host *LanguageHost) GetRequiredPackages(
 			Kind:             "resource",
 			Parameterization: parameterizationProto(info.Parameterization),
 		})
-		root := required[alias]
-		delete(tfSpecs, tfProviderSource(alias, root))
-		if root.IsPulumi() {
-			delete(pulumiPkgs, pulumiPackageName(alias, root.Source))
+		req := aliases[alias]
+		delete(tfSpecs, tfProviderSource(alias, req))
+		if req.IsPulumi() {
+			delete(pulumiPkgs, pulumiPackageName(alias, req.Source))
 		}
 	}
 
@@ -381,10 +376,10 @@ func (v *versionSet) constraint() string { return strings.Join(sortedKeys(v.seen
 // declared only in a child module still resolves from its declared source.
 func collectRequirements(
 	ctx context.Context, config *ast.Config, workDir string,
-) (tf map[string]*versionSet, pulumi map[string]string, aliases map[string]struct{}) {
+) (tf map[string]*versionSet, pulumi map[string]string, aliases map[string]*ast.RequiredProvider) {
 	tf = map[string]*versionSet{}
 	pulumi = map[string]string{}
-	aliases = map[string]struct{}{}
+	aliases = map[string]*ast.RequiredProvider{}
 	var loader *modules.Loader
 	if workDir != "" && config != nil && len(config.Modules) > 0 {
 		loader = modules.NewLoader(ctx)
@@ -395,7 +390,7 @@ func collectRequirements(
 
 func collectRequirementsRec(
 	config *ast.Config, workDir string,
-	tf map[string]*versionSet, pulumi map[string]string, aliases map[string]struct{},
+	tf map[string]*versionSet, pulumi map[string]string, aliases map[string]*ast.RequiredProvider,
 	loader *modules.Loader, visited map[string]struct{},
 ) {
 	if config == nil {
@@ -419,11 +414,13 @@ func collectRequirementsRec(
 	}
 
 	add := func(alias string) {
-		aliases[alias] = struct{}{}
+		req := required[alias]
+		if _, seen := aliases[alias]; !seen || req != nil {
+			aliases[alias] = req
+		}
 		if isBuiltinProvider(alias) {
 			return
 		}
-		req := required[alias]
 		if req.IsPulumi() {
 			pulumi[pulumiPackageName(alias, req.Source)] = req.Version
 			return

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -271,6 +271,72 @@ terraform {
 	}}, resp.Specs)
 }
 
+func TestGetRequiredPackages_TransitiveModuleSourceResolvedSDK(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+module "child" {
+  source = "./child"
+}
+`), 0o600))
+
+	childDir := filepath.Join(dir, "child")
+	require.NoError(t, os.MkdirAll(childDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(childDir, "main.tf"), []byte(`
+terraform {
+  required_providers {
+    rollbar = {
+      source  = "rollbar/rollbar"
+      version = ">= 1.0"
+    }
+  }
+}
+`), 0o600))
+
+	// Mirror what `pulumi install` leaves behind: a local SDK resolving the
+	// rollbar spec to a parameterized terraform-provider package.
+	host := &LanguageHost{}
+	sdkDir := filepath.Join(dir, "sdks", "rollbar")
+	require.NoError(t, os.MkdirAll(sdkDir, 0o755))
+	_, err := host.GeneratePackage(t.Context(), &pulumirpc.GeneratePackageRequest{
+		Directory: sdkDir,
+		Schema: `{
+			"name": "rollbar",
+			"version": "1.17.0",
+			"parameterization": {
+				"baseProvider": {"name": "terraform-provider", "version": "0.0.1"},
+				"parameter": "aGVsbG8="
+			}
+		}`,
+	})
+	require.NoError(t, err)
+
+	resp, err := host.GetRequiredPackages(t.Context(), &pulumirpc.GetRequiredPackagesRequest{
+		Info: &pulumirpc.ProgramInfo{
+			ProgramDirectory: dir,
+			RootDirectory:    dir,
+			EntryPoint:       ".",
+		},
+	})
+	require.NoError(t, err)
+
+	// The local SDK resolves the provider, so it must be reported as a package
+	// and the now-redundant spec must be dropped — exactly as it is when the
+	// declaration lives in the root module.
+	assert.Equal(t, []*pulumirpc.PackageDependency{{
+		Name:    "terraform-provider",
+		Version: "0.0.1",
+		Kind:    "resource",
+		Parameterization: &pulumirpc.PackageParameterization{
+			Name:    "rollbar",
+			Version: "1.17.0",
+			Value:   []byte("hello"),
+		},
+	}}, resp.Packages)
+	assert.Empty(t, resp.Specs)
+}
+
 // TestGetRequiredPackages_SameSourceVersionIntersection mirrors tofu: two
 // modules requiring the same provider source are installed once, with their
 // version constraints unioned into one ", "-joined constraint. The


### PR DESCRIPTION
## Problem

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/214.

When a third-party Terraform provider is declared in a **child module's**
`required_providers` (a provider with no Pulumi package, e.g. `rollbar/rollbar`)
and `pulumi install` has resolved it to a local SDK, `pulumi preview` fails with:

```
error: language runtime "hcl" returned 1 unresolved package spec(s)
```

Declaring the identical provider in the **root** module previews cleanly — that
asymmetry is the tell.

## Root cause

`GetRequiredPackages` walks the whole module tree and, once a provider's local
SDK is resolved, drops the now-redundant `terraform-provider` spec so the engine
doesn't see an unresolved spec. But it computed the spec's source key from the
**root** config's `RequiredProviders` map. A provider declared only in a child
module has a nil entry there, so `tfProviderSource` fell back to
`hashicorp/<alias>`, the `delete` missed the real `<source>` key, and the
program returned **both** the resolved package and the stale, unresolvable spec.
`pulumi install` had in fact resolved it, so the suggested remedy looked like a
no-op.

## Fix

`collectRequirements` already recurses through every module, so it now records
the `RequiredProvider` each alias resolved to (preferring an explicit
declaration over an implicit type-prefix reference) and the dedup keys off that
tree-wide map instead of the root-only one. The child-declared case now matches
the root-declared case.

## Test

`TestGetRequiredPackages_TransitiveModuleSourceResolvedSDK` declares the
provider only in a child module, writes the local SDK that `pulumi install`
leaves behind, and asserts the resolved package is returned with **no** leftover
spec. It failed before the fix and passes after.