### PR TITLE
Match OpenTofu's null handling for `tostring` and `tobool`

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-217.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-217.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`tostring` and `tobool` accept `null`, returning a null value instead of erroring, matching OpenTofu'
+time: 2026-06-03T16:30:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "217"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -209,7 +209,7 @@ func Functions(baseDir string) map[string]function.Function {
 		"issensitive":  issensitiveFunc,
 		"nonsensitive": nonsensitiveFunc,
 		"sensitive":    sensitiveFunc,
-		"tobool":       toBoolFunc,
+		"tobool":       makeToFunc(cty.Bool),
 		"tolist":       makeToFunc(cty.List(cty.DynamicPseudoType)),
 		"tomap":        makeToFunc(cty.Map(cty.DynamicPseudoType)),
 		"tonumber":     makeToFunc(cty.Number),
@@ -1737,31 +1737,6 @@ var issensitiveFunc = function.New(&function.Spec{
 	},
 })
 
-var toBoolFunc = function.New(&function.Spec{
-	Params: []function.Parameter{
-		{Name: "value", Type: cty.DynamicPseudoType},
-	},
-	Type: function.StaticReturnType(cty.Bool),
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		val := args[0]
-		if val.Type() == cty.Bool {
-			return val, nil
-		}
-		if val.Type() == cty.String {
-			s := val.AsString()
-			switch strings.ToLower(s) {
-			case "true", "1", "yes", "on":
-				return cty.True, nil
-			case "false", "0", "no", "off":
-				return cty.False, nil
-			default:
-				return cty.NilVal, fmt.Errorf("cannot convert %q to bool", s)
-			}
-		}
-		return cty.NilVal, fmt.Errorf("cannot convert %s to bool", val.Type().FriendlyName())
-	},
-})
-
 // makeToFunc constructs a "to..." conversion function like OpenTofu's
 // MakeToFunc. The argument passes through verbatim as cty.DynamicPseudoType and
 // the conversion to wantTy happens inside Type and Impl via the cty convert
@@ -1828,11 +1803,14 @@ func makeToFunc(wantTy cty.Type) function.Function {
 
 var toStringFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
-		{Name: "value", Type: cty.DynamicPseudoType},
+		{Name: "value", Type: cty.DynamicPseudoType, AllowNull: true, AllowDynamicType: true},
 	},
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		val := args[0]
+		if val.IsNull() {
+			return cty.NullVal(cty.String), nil
+		}
 		switch val.Type() {
 		case cty.String:
 			return val, nil

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -620,6 +620,8 @@ func TestTypeFunctions(t *testing.T) {
 		{"tonumber", `tonumber("42")`, cty.NumberIntVal(42)},
 		{"tobool true", `tobool("true")`, cty.BoolVal(true)},
 		{"tobool false", `tobool("false")`, cty.BoolVal(false)},
+		{"tobool null", `tobool(null)`, cty.NullVal(cty.Bool)},
+		{"tostring null", `tostring(null)`, cty.NullVal(cty.String)},
 		{"tolist", `length(tolist(toset(["a", "b"])))`, cty.NumberIntVal(2)},
 		{"toset", `length(toset(["a", "b", "a"]))`, cty.NumberIntVal(2)},
 		{"tomap", `tomap({a = "x"}).a`, cty.StringVal("x")},

--- a/tests/tfcompat/l1_to_null_test.go
+++ b/tests/tfcompat/l1_to_null_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1ToNull exercises `tostring` and `tobool` with a null argument. OpenTofu
+// builds both from MakeToFunc, which permits null and returns a null of the
+// target type, so `tostring(null)` and `tobool(null)` succeed. pulumi-hcl
+// hand-rolled these two without allowing null, so it errored where OpenTofu
+// produced a value.
+func TestL1ToNull(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_to_null", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_to_null/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_to_null/main.tf
@@ -1,0 +1,2 @@
+output "tostring_null_is_null" { value = tostring(null) == null }
+output "tobool_null_is_null" { value = tobool(null) == null }


### PR DESCRIPTION
## What

`tostring(null)` and `tobool(null)` now return a null value instead of erroring, matching OpenTofu.

## The divergence

OpenTofu builds every `to*` conversion function from `MakeToFunc`, whose argument is declared with `AllowNull` / `AllowDynamicType` and which returns a null of the target type when handed null. So in OpenTofu:

```hcl
output "a" { value = tostring(null) }  # => null
output "b" { value = tobool(null) }    # => null
```

pulumi-hcl delegates `tonumber`, `tolist`, `tomap`, and `toset` to an equivalent `makeToFunc` helper, but `tostring` and `tobool` were hand-rolled with an argument that allowed neither null nor a dynamic type. Passing `null` to either tripped the cty function framework before the implementation ran:

```
Invalid value for "value" parameter: argument must not be null.
```

A user migrating real OpenTofu configuration that funnels a possibly-null value through `tostring`/`tobool` hit an error where OpenTofu produced a value.

## The fix

Set `AllowNull: true` (and `AllowDynamicType: true`, so the bare `null` literal — typed `DynamicPseudoType` — reaches the implementation rather than short-circuiting to unknown) on both functions, and return a null of the target type for a null argument. This mirrors OpenTofu's `MakeToFunc` exactly for the null case. The extra leniency these two hand-rolled functions already offered over OpenTofu (e.g. `tobool("yes")`, `tostring` of a complex value) is intentionally left untouched.

## Sibling sweep

The root cause is the hand-rolled members of the `to*` family diverging from `MakeToFunc`. The other four — `tonumber`, `tolist`, `tomap`, `toset` — already delegate to `makeToFunc`, which carries `AllowNull`/`AllowDynamicType`; both an OpenTofu probe and their construction confirm they already return null for null input, so nothing else needed changing.

## Verification

- New `tfcompat` case `l1_to_null` runs `tostring(null) == null` and `tobool(null) == null` through both `tofu apply` and `pulumi up`. It fails on `master` (pulumi errors with "argument must not be null") and passes with this change.
- Unit cases `tobool(null)` / `tostring(null)` added to `TestTypeFunctions` in `pkg/hcl/eval/functions_test.go`.
- Full `pkg/hcl/eval` package passes, including the existing complex-type `tostring` coverage.