### PR TITLE
Match OpenTofu's `lookup` behavior

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-218.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-218.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`lookup`: when a key is absent from a map, the returned default is converted to the map''s element type'
+time: 2026-06-03T12:00:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "217"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -457,7 +457,34 @@ var lookupFunc = function.New(&function.Spec{
 		AllowUnknown:     true,
 		AllowDynamicType: true,
 	},
-	Type: function.StaticReturnType(cty.DynamicPseudoType),
+	Type: func(args []cty.Value) (cty.Type, error) {
+		ty := args[0].Type()
+		switch {
+		case ty.IsObjectType():
+			if !args[1].IsKnown() {
+				return cty.DynamicPseudoType, nil
+			}
+			key := args[1].AsString()
+			if ty.HasAttribute(key) {
+				return args[0].GetAttr(key).Type(), nil
+			} else if len(args) == 3 {
+				// The default's own type is returned for objects, since an
+				// object's attributes need not share a single element type.
+				return args[2].Type(), nil
+			}
+			return cty.NilType, function.NewArgErrorf(0, "the given object has no attribute %q", key)
+		case ty.IsMapType():
+			if len(args) == 3 {
+				if _, err := convert.Convert(args[2], ty.ElementType()); err != nil {
+					return cty.NilType, function.NewArgErrorf(2,
+						"the default value must have the same type as the map elements")
+				}
+			}
+			return ty.ElementType(), nil
+		default:
+			return cty.NilType, function.NewArgErrorf(0, "lookup() requires a map as the first argument")
+		}
+	},
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		m := args[0]
 		key := args[1].AsString()
@@ -474,9 +501,12 @@ var lookupFunc = function.New(&function.Spec{
 			}
 		}
 
-		// Return the default value, if any
-		if len(args) > 2 {
-			return args[2], nil
+		// The key is absent. Return the default converted to the return type,
+		// matching OpenTofu: for a map this is the element type, so a default
+		// of a different type is coerced (e.g. 30 into a map(string) yields the
+		// string "30").
+		if len(args) == 3 {
+			return convert.Convert(args[2], retType)
 		}
 
 		return cty.NilVal, fmt.Errorf("key %q not found", key)

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -195,6 +195,13 @@ func TestCollectionFunctions(t *testing.T) {
 		// lookup
 		{"lookup found", `lookup({a = "x", b = "y"}, "a", "default")`, cty.StringVal("x")},
 		{"lookup default", `lookup({a = "x"}, "b", "default")`, cty.StringVal("default")},
+		// On the map path the default is converted to the element type, just
+		// like OpenTofu.
+		{"lookup map default num to string", `lookup(tomap({a = "1"}), "missing", 30)`, cty.StringVal("30")},
+		{"lookup map default string to num", `lookup(tomap({a = 1}), "missing", "80")`, cty.NumberIntVal(80)},
+		{"lookup map default bool to string", `lookup(tomap({a = "x"}), "missing", true)`, cty.StringVal("true")},
+		// On the object path the default keeps its own type.
+		{"lookup object default unconverted", `lookup({a = "x"}, "missing", 30)`, cty.NumberIntVal(30)},
 
 		// contains
 		{"contains true", `contains(["a", "b"], "a")`, cty.BoolVal(true)},

--- a/tests/tfcompat/l1_lookup_test.go
+++ b/tests/tfcompat/l1_lookup_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// OpenTofu's `lookup(map, key, default)` returns the map's element type, so a
+// returned default is converted to that element type. pulumi-hcl previously
+// returned the default verbatim, so `lookup(tomap({a="1"}), "missing", 30)`
+// produced the number 30 instead of the string "30".
+func TestL1Lookup(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_lookup", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_lookup/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_lookup/main.tf
@@ -1,0 +1,15 @@
+# OpenTofu's `lookup(map, key, default)` returns the map's element type: when
+# the key is absent the default is converted to that element type before it is
+# returned. A numeric default into a map(string) therefore comes back as a
+# string, and a string default into a map(number) comes back as a number.
+#
+# The results are wrapped in an object so the harness serializes them as JSON,
+# which preserves the scalar type (a bare top-level scalar would stringify and
+# hide the string-vs-number difference).
+output "results" {
+  value = {
+    num_default_into_string_map    = lookup(tomap({ a = "1" }), "missing", 30)
+    string_default_into_number_map = lookup(tomap({ a = 1 }), "missing", "80")
+    bool_default_into_string_map   = lookup(tomap({ a = "x" }), "missing", true)
+  }
+}


### PR DESCRIPTION
## Divergence

OpenTofu's `lookup(map, key, default)` returns the map's *element type*. When the key is absent, the default is converted to that element type before it is returned. pulumi-hcl returned the default verbatim, so the two runtimes disagreed whenever the default's type differed from the map's element type:

| expression | OpenTofu | pulumi-hcl (before) |
| --- | --- | --- |
| `lookup(tomap({a="1"}), "missing", 30)` | `"30"` (string) | `30` (number) |
| `lookup(tomap({a=1}), "missing", "80")` | `80` (number) | `"80"` (string) |
| `lookup(tomap({a="x"}), "missing", true)` | `"true"` (string) | `true` (bool) |

A migration that does e.g. `lookup(var.config, "timeout", 30)` against a `map(string)` would silently get a number from pulumi-hcl where OpenTofu produces a string.

## Fix

`pkg/hcl/eval/functions.go` — rework `lookupFunc` to mirror OpenTofu:

- The `Type` function reports the map's element type (validating that the default converts to it), or, for objects, the matched attribute's type or the default's own type.
- `Impl` converts the returned default to the function's return type.

The **object** path is intentionally left unconverted, matching OpenTofu, since an object's attributes need not share a single element type (verified with a `tofu` probe and locked in with a unit case).

## Proof

- `TestL1Lookup` (`tests/tfcompat/l1_lookup_test.go`) compares `tofu apply` against `pulumi up`; the defaults are wrapped in an object output so the harness serializes them as JSON, exposing the scalar type. It **fails on master** and **passes with this fix**.
- New unit cases in `pkg/hcl/eval/functions_test.go` cover map default num→string, string→num, bool→string, and the object path keeping its own type.
- Full `./tests/tfcompat/` and `./pkg/hcl/...` suites pass.

## Sweep

The object vs. map path is the only sibling and is covered. The reverse-direction tightening (a non-map first argument, or a default that cannot convert to the element type, now errors as OpenTofu does) is faithful to OpenTofu and not a new divergence.