### PR TITLE
Match OpenTofu's `base64gzip` sync-flush output

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-217.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-217.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: 'Match OpenTofu''s `base64gzip` sync-flush output'
+time: 2026-06-03T16:30:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "217"

--- a/.changes/unreleased/runtime-bug-fixes-219.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-219.yaml
@@ -3,4 +3,4 @@ body: 'Match OpenTofu''s `base64gzip` sync-flush output'
 time: 2026-06-03T16:30:00.000000+02:00
 custom:
     Component: runtime
-    PR: "217"
+    PR: "219"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -799,6 +799,11 @@ var base64GzipFunc = function.New(&function.Spec{
 		if _, err := w.Write([]byte(args[0].AsString())); err != nil {
 			return cty.NilVal, err
 		}
+		// OpenTofu flushes before closing, emitting an empty sync-flush block;
+		// matching it keeps the base64 output byte-for-byte identical.
+		if err := w.Flush(); err != nil {
+			return cty.NilVal, err
+		}
 		if err := w.Close(); err != nil {
 			return cty.NilVal, err
 		}

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -372,6 +372,13 @@ func TestEncodingFunctions(t *testing.T) {
 		{"urlencode unicode", `urlencode("café")`, cty.StringVal("caf%C3%A9")},
 		// base64gzip - check it returns non-empty string
 		{"base64gzip", `base64gzip("hello") != ""`, cty.BoolVal(true)},
+		// base64gzip pins OpenTofu's exact byte-for-byte output: OpenTofu flushes
+		// the gzip writer before closing, emitting an empty sync-flush block.
+		{
+			"base64gzip exact",
+			`base64gzip("hello world this is a test string")`,
+			cty.StringVal("H4sIAAAAAAAA/8pIzcnJVyjPL8pJUSjJyCxWyCxWSFQoSS0uUSguKcrMSwcAAAD//wEAAP//d4eoGCEAAAA="),
+		},
 		// base64gunzip is the inverse of base64gzip, so the round trip is identity.
 		{"base64gunzip roundtrip", `base64gunzip(base64gzip("hello"))`, cty.StringVal("hello")},
 		// urldecode reverses urlencode; QueryUnescape also maps "+" to a space.

--- a/tests/tfcompat/testdata/cases/l1_text_function/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_text_function/main.tf
@@ -85,6 +85,13 @@ output "base64gunzip_roundtrip" {
   value = base64gunzip(base64gzip("Hello, OpenTofu!"))
 }
 
+# The raw `base64gzip` output is itself observable: OpenTofu flushes the gzip
+# writer before closing it, which emits an empty sync-flush block, so the exact
+# base64 string must match byte for byte rather than only round-tripping.
+output "base64gzip_raw" {
+  value = base64gzip("hello world this is a test string")
+}
+
 # `cidrcontains` reports whether the IP address or prefix in its second argument
 # falls within the containing prefix in its first. An IP argument is contained
 # when it lies inside the prefix; a prefix argument is contained only when both


### PR DESCRIPTION
## Divergence

OpenTofu's `base64gzip` flushes the gzip writer with `gz.Flush()` before `gz.Close()`. The flush emits an empty deflate sync-flush block into the stream, so the resulting base64 string differs **byte-for-byte** from a stream that is only closed.

pulumi-hcl closed the writer without flushing, so for the same input its `base64gzip` output diverged from OpenTofu's:

| | `base64gzip("hello world this is a test string")` |
|---|---|
| OpenTofu | `H4sIAAAAAAAA/8pIzcnJVyjPL8pJUSjJyCxWyCxWSFQoSS0uUSguKcrMSwcAAAD//wEAAP//d4eoGCEAAAA=` |
| pulumi-hcl (before) | `H4sIAAAAAAAA/8pIzcnJVyjPL8pJUSjJyCxWyCxWSFQoSS0uUSguKcrMSwcEAAD//3eHqBghAAAA` |

Both strings gunzip to identical bytes, so any `base64gunzip` round trip hid the difference. But the raw `base64gzip` string is itself observable, and a configuration that pins, hashes, or compares that string (e.g. as an etag or a user-data payload) produces a different value migrating from `tofu apply` to pulumi-hcl.

## Fix

Add `gz.Flush()` before the close in `base64GzipFunc`, matching OpenTofu's `Base64GzipFunc`.

## Tests

- Extended the `l1_text_function` tfcompat case with a raw `base64gzip` output that pins the exact string against `tofu apply` (failing before, passing after).
- Pinned the same byte-for-byte output in a `functions_test.go` unit case.

## Sweep

The inverse `base64gunzip` reads the gzip stream regardless of sync-flush blocks and already round-trips correctly, so no sibling fix is needed. `base64GzipFunc` is the only gzip writer in `pkg/hcl/`.