### PR TITLE
Match OpenTofu's `one` on a set of unknown length

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-222.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-222.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Defer `one` to an unknown value when given a set of unknown length
+time: 2026-06-03T16:00:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "222"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -626,10 +626,19 @@ var oneFunc = function.New(&function.Spec{
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		list := args[0]
-		if list.LengthInt() == 0 {
+		// A set's length can be unknown even when the set itself is known,
+		// because unknown elements might collapse with known ones. Matching
+		// OpenTofu, defer to an unknown result rather than counting elements
+		// at face value (which would wrongly report "more than one element").
+		lenVal := list.Length()
+		if !lenVal.IsKnown() {
+			return cty.UnknownVal(retType), nil
+		}
+		l := list.LengthInt()
+		if l == 0 {
 			return cty.NullVal(retType), nil
 		}
-		if list.LengthInt() > 1 {
+		if l > 1 {
 			return cty.NilVal, fmt.Errorf("list has more than one element")
 		}
 		for it := list.ElementIterator(); it.Next(); {

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -730,6 +730,33 @@ func TestSumEmptyList(t *testing.T) {
 	assert.EqualError(t, err, "cannot sum an empty list")
 }
 
+// TestOneUnknownLengthSet pins that `one` returns an unknown value, rather than
+// erroring, when given a set whose length is not yet known. The set is known but
+// contains an unknown element, so it could hold either one or two members once
+// resolved. OpenTofu defers to an unknown result here; counting the elements at
+// face value would wrongly report "more than one element".
+func TestOneUnknownLengthSet(t *testing.T) {
+	t.Parallel()
+	set := cty.SetVal([]cty.Value{cty.UnknownVal(cty.String), cty.StringVal("fixed")})
+	got, err := oneFunc.Call([]cty.Value{set})
+	require.NoError(t, err)
+	assert.Equal(t, cty.UnknownVal(cty.String), got)
+}
+
+// TestOneSingleElement pins that `one` returns the sole element of a one-element
+// collection, and TestOneTooMany that it errors on more than one known element.
+func TestOneSingleElement(t *testing.T) {
+	t.Parallel()
+	got, err := oneFunc.Call([]cty.Value{cty.SetVal([]cty.Value{cty.StringVal("solo")})})
+	require.NoError(t, err)
+	assert.Equal(t, cty.StringVal("solo"), got)
+
+	_, err = oneFunc.Call([]cty.Value{cty.SetVal([]cty.Value{
+		cty.StringVal("a"), cty.StringVal("b"),
+	})})
+	assert.EqualError(t, err, "list has more than one element")
+}
+
 // TestCidrHostOutOfRange pins that `cidrhost` errors when the host number does
 // not fit within the prefix's host bits, as OpenTofu does, rather than silently
 // overflowing into the network portion of the address.

--- a/tests/tfcompat/l2_one_unknown_length_set_test.go
+++ b/tests/tfcompat/l2_one_unknown_length_set_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// `one` applied to a set whose length is not yet known must defer to an
+// unknown value under `pulumi preview`, just as it does under `tofu plan`.
+// Here the set is built from a not-yet-created resource's computed `result`
+// plus a literal, so its length could be one (if they collapse) or two.
+// OpenTofu's `one` checks whether the length is known and returns an unknown
+// value when it isn't, so the plan succeeds. Before the fix, pulumi-hcl's
+// `one` took the element count at face value, decided the set had "more than
+// one element", and failed the preview.
+func TestL2OneUnknownLengthSet(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_one_unknown_length_set", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			Mode: tfcompat.StagePreview,
+			Files: map[string]string{"main.tf": `
+resource "simple_resource" "upstream" {
+  input_one = "a"
+  input_two = true
+}
+
+output "the_one" {
+  value = one(toset([simple_resource.upstream.result, "fixed"]))
+}
+`},
+		}},
+	})
+}


### PR DESCRIPTION
## Divergence

`one` applied to a **set whose length is not yet known** diverges between the two runtimes.

A set can be a *known value* while its *length* is unknown: an unknown element might collapse with a known one once it resolves. Consider a set built from a not-yet-created resource's computed attribute plus a literal:

```hcl
resource "simple_resource" "upstream" {
  input_one = "a"
  input_two = true
}

output "the_one" {
  value = one(toset([simple_resource.upstream.result, "fixed"]))
}
```

At preview/plan time `simple_resource.upstream.result` is unknown, so the set holds either one element (if it equals `"fixed"`) or two.

- **OpenTofu** (`tofu plan`): `one` checks `Length().IsKnown()`, sees the length is not yet known, and returns an **unknown value** — the plan succeeds.
- **pulumi-hcl** (before this fix): `one` called `LengthInt()`, counted two elements at face value, and failed the preview with `Call to function "one" failed: list has more than one element`.

This is a migration-direction bug: configuration that plans cleanly under OpenTofu errored under `pulumi preview`.

## Fix

`one` now checks `Length().IsKnown()` first and defers to an unknown value when the length cannot yet be determined, matching [OpenTofu's `OneFunc`](https://github.com/opentofu/opentofu/blob/main/internal/lang/funcs/collection.go). Lists and tuples always have a known length, so only the set case changes behavior.

## Tests

- `TestL2OneUnknownLengthSet` (tfcompat) — fails before, passes after: `tofu plan` succeeds while `pulumi preview` errored on the same program.
- `TestOneUnknownLengthSet` / `TestOneSingleElement` (unit) — pin the unknown-length-set, single-element, and too-many-elements behaviors.

## Sibling sweep

The root cause is taking `LengthInt()` at face value without checking whether the length is known. Lists and tuples cannot have an unknown length, so only sets are affected. The other length-gated hand-rolled functions (`matchkeys`, `sum`) are out of scope for this domain (claimed/handled separately), and `index`/`alltrue`/`anytrue` bail to unknown per element rather than via a length check, so they are unaffected.