### PR TITLE
Expand a leading `~` in the file-reading and path functions

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-223.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-223.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Expand a leading `~` in `file`, `filebase64`, `fileexists`, `filemd5`, `filesha1`, `filesha256`, `filesha512`, `filebase64sha256`, `filebase64sha512`, `templatefile`, and `pathexpand`
+time: 2026-06-03T12:00:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "223"

--- a/.changes/unreleased/runtime-bug-fixes-226.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-226.yaml
@@ -3,4 +3,4 @@ body: Expand a leading `~` in `file`, `filebase64`, `fileexists`, `filemd5`, `fi
 time: 2026-06-03T12:00:00.000000+02:00
 custom:
     Component: runtime
-    PR: "223"
+    PR: "226"

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-mux v0.23.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opentofu/registry-address/v2 v2.0.0-20250611143131-d0a99bd8acdd
 	github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8
 	github.com/pulumi/providertest v0.7.0
@@ -216,7 +217,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mitchellh/cli v1.1.5 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -51,6 +51,7 @@ import (
 	"github.com/hashicorp/hcl/v2/ext/customdecode"
 	"github.com/hashicorp/hcl/v2/ext/tryfunc"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pulumi-labs/pulumi-hcl/vendored/ipaddr"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
@@ -1000,15 +1001,8 @@ var pathExpandFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.String),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		path := args[0].AsString()
-		if strings.HasPrefix(path, "~") {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return cty.NilVal, err
-			}
-			path = filepath.Join(home, path[1:])
-		}
-		return cty.StringVal(path), nil
+		homePath, err := homedir.Expand(args[0].AsString())
+		return cty.StringVal(homePath), err
 	},
 })
 
@@ -1022,6 +1016,21 @@ var basenameFunc = function.New(&function.Spec{
 	},
 })
 
+// resolveFilePath turns a path argument from one of the file* functions into a
+// concrete path on disk, matching OpenTofu's openFile: a leading `~` is expanded
+// to the user's home directory, a relative path is resolved against baseDir, and
+// the result is cleaned for the host OS.
+func resolveFilePath(baseDir, path string) (string, error) {
+	path, err := homedir.Expand(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to expand ~: %w", err)
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
+	}
+	return filepath.Clean(path), nil
+}
+
 func fileFunc(baseDir string) function.Function {
 	return function.New(&function.Spec{
 		Params: []function.Parameter{
@@ -1029,9 +1038,9 @@ func fileFunc(baseDir string) function.Function {
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			path := args[0].AsString()
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(baseDir, path)
+			path, err := resolveFilePath(baseDir, args[0].AsString())
+			if err != nil {
+				return cty.NilVal, err
 			}
 			content, err := os.ReadFile(path)
 			if err != nil {
@@ -1049,12 +1058,40 @@ func fileExistsFunc(baseDir string) function.Function {
 		},
 		Type: function.StaticReturnType(cty.Bool),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			path := args[0].AsString()
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(baseDir, path)
+			path, err := resolveFilePath(baseDir, args[0].AsString())
+			if err != nil {
+				return cty.NilVal, err
 			}
-			_, err := os.Stat(path)
-			return cty.BoolVal(err == nil), nil
+
+			fi, err := os.Stat(path)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return cty.False, nil
+				}
+				return cty.NilVal, fmt.Errorf("failed to stat %s", path)
+			}
+
+			if fi.Mode().IsRegular() {
+				return cty.True, nil
+			}
+
+			// Match OpenTofu: anything that exists but is not a regular file
+			// (a directory, device node, pipe, socket, ...) is an error rather
+			// than a silent false.
+			fileType := fi.Mode().Type()
+			switch {
+			case (fileType & os.ModeDir) != 0:
+				err = fmt.Errorf("%s is a directory, not a file", path)
+			case (fileType & os.ModeDevice) != 0:
+				err = fmt.Errorf("%s is a device node, not a regular file", path)
+			case (fileType & os.ModeNamedPipe) != 0:
+				err = fmt.Errorf("%s is a named pipe, not a regular file", path)
+			case (fileType & os.ModeSocket) != 0:
+				err = fmt.Errorf("%s is a unix domain socket, not a regular file", path)
+			default:
+				err = fmt.Errorf("%s is not a regular file", path)
+			}
+			return cty.False, err
 		},
 	})
 }
@@ -1116,9 +1153,9 @@ func fileBase64Func(baseDir string) function.Function {
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			path := args[0].AsString()
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(baseDir, path)
+			path, err := resolveFilePath(baseDir, args[0].AsString())
+			if err != nil {
+				return cty.NilVal, err
 			}
 			content, err := os.ReadFile(path)
 			if err != nil {
@@ -1144,9 +1181,9 @@ func templateFileFunc(baseDir string, nestedFuncs map[string]function.Function) 
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			path := args[0].AsString()
-			fullPath := path
-			if !filepath.IsAbs(fullPath) {
-				fullPath = filepath.Join(baseDir, fullPath)
+			fullPath, err := resolveFilePath(baseDir, path)
+			if err != nil {
+				return cty.NilVal, err
 			}
 			content, err := os.ReadFile(fullPath)
 			if err != nil {
@@ -1375,9 +1412,9 @@ func fileBase64Sha256Func(baseDir string) function.Function {
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			path := args[0].AsString()
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(baseDir, path)
+			path, err := resolveFilePath(baseDir, args[0].AsString())
+			if err != nil {
+				return cty.NilVal, err
 			}
 			content, err := os.ReadFile(path)
 			if err != nil {
@@ -1396,9 +1433,9 @@ func fileBase64Sha512Func(baseDir string) function.Function {
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			path := args[0].AsString()
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(baseDir, path)
+			path, err := resolveFilePath(baseDir, args[0].AsString())
+			if err != nil {
+				return cty.NilVal, err
 			}
 			content, err := os.ReadFile(path)
 			if err != nil {
@@ -1417,9 +1454,9 @@ func fileMd5Func(baseDir string) function.Function {
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			path := args[0].AsString()
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(baseDir, path)
+			path, err := resolveFilePath(baseDir, args[0].AsString())
+			if err != nil {
+				return cty.NilVal, err
 			}
 			content, err := os.ReadFile(path)
 			if err != nil {
@@ -1438,9 +1475,9 @@ func fileSha1Func(baseDir string) function.Function {
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			path := args[0].AsString()
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(baseDir, path)
+			path, err := resolveFilePath(baseDir, args[0].AsString())
+			if err != nil {
+				return cty.NilVal, err
 			}
 			content, err := os.ReadFile(path)
 			if err != nil {
@@ -1459,9 +1496,9 @@ func fileSha256Func(baseDir string) function.Function {
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			path := args[0].AsString()
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(baseDir, path)
+			path, err := resolveFilePath(baseDir, args[0].AsString())
+			if err != nil {
+				return cty.NilVal, err
 			}
 			content, err := os.ReadFile(path)
 			if err != nil {
@@ -1480,9 +1517,9 @@ func fileSha512Func(baseDir string) function.Function {
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			path := args[0].AsString()
-			if !filepath.IsAbs(path) {
-				path = filepath.Join(baseDir, path)
+			path, err := resolveFilePath(baseDir, args[0].AsString())
+			if err != nil {
+				return cty.NilVal, err
 			}
 			content, err := os.ReadFile(path)
 			if err != nil {

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -1088,6 +1088,59 @@ func TestFileFunctions(t *testing.T) {
 	})
 }
 
+// TestFileTildeExpansion pins that the file-reading functions expand a leading
+// `~` to the user's home directory, matching OpenTofu's openFile. Before the
+// fix these functions treated `~` as a literal path segment relative to baseDir
+// and so failed to find a file OpenTofu reads successfully.
+func TestFileTildeExpansion(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	// Write a uniquely named file directly in the home directory so the `~`
+	// path resolves to it; remove it afterwards.
+	name := fmt.Sprintf(".pulumi_hcl_tilde_test_%d.txt", os.Getpid())
+	abs := filepath.Join(home, name)
+	require.NoError(t, os.WriteFile(abs, []byte("hi"), 0o600))
+	t.Cleanup(func() { _ = os.Remove(abs) })
+
+	// baseDir deliberately differs from home so a missing `~` expansion would
+	// resolve the path under baseDir and fail.
+	baseDir := t.TempDir()
+	tildePath := fmt.Sprintf("~/%s", name)
+
+	t.Run("file", func(t *testing.T) {
+		got := evalExpr(t, baseDir, fmt.Sprintf("file(%q)", tildePath))
+		assert.Equal(t, cty.StringVal("hi"), got)
+	})
+
+	t.Run("filebase64", func(t *testing.T) {
+		got := evalExpr(t, baseDir, fmt.Sprintf("filebase64(%q)", tildePath))
+		assert.Equal(t, cty.StringVal(base64.StdEncoding.EncodeToString([]byte("hi"))), got)
+	})
+
+	t.Run("fileexists", func(t *testing.T) {
+		got := evalExpr(t, baseDir, fmt.Sprintf("fileexists(%q)", tildePath))
+		assert.Equal(t, cty.True, got)
+	})
+
+	t.Run("filemd5", func(t *testing.T) {
+		got := evalExpr(t, baseDir, fmt.Sprintf("filemd5(%q)", tildePath))
+		assert.Equal(t, evalExpr(t, baseDir, `md5("hi")`), got)
+	})
+}
+
+// TestFileExistsDirectory pins that fileexists errors on a path that exists but
+// is a directory rather than a regular file, matching OpenTofu. This is an
+// error path, so it calls the function directly rather than via evalExpr.
+func TestFileExistsDirectory(t *testing.T) {
+	baseDir := t.TempDir()
+	dir := filepath.Join(baseDir, "adir")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+
+	_, err := fileExistsFunc(baseDir).Call([]cty.Value{cty.StringVal("adir")})
+	require.EqualError(t, err, fmt.Sprintf("%s is a directory, not a file", dir))
+}
+
 // TestFilesetGlob exercises fileset's glob semantics against OpenTofu: the `**`
 // operator recurses, directories are excluded, and paths use forward slashes.
 func TestFilesetGlob(t *testing.T) {

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -1093,6 +1093,7 @@ func TestFileFunctions(t *testing.T) {
 // fix these functions treated `~` as a literal path segment relative to baseDir
 // and so failed to find a file OpenTofu reads successfully.
 func TestFileTildeExpansion(t *testing.T) {
+	t.Parallel()
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
@@ -1109,21 +1110,25 @@ func TestFileTildeExpansion(t *testing.T) {
 	tildePath := fmt.Sprintf("~/%s", name)
 
 	t.Run("file", func(t *testing.T) {
+		t.Parallel()
 		got := evalExpr(t, baseDir, fmt.Sprintf("file(%q)", tildePath))
 		assert.Equal(t, cty.StringVal("hi"), got)
 	})
 
 	t.Run("filebase64", func(t *testing.T) {
+		t.Parallel()
 		got := evalExpr(t, baseDir, fmt.Sprintf("filebase64(%q)", tildePath))
 		assert.Equal(t, cty.StringVal(base64.StdEncoding.EncodeToString([]byte("hi"))), got)
 	})
 
 	t.Run("fileexists", func(t *testing.T) {
+		t.Parallel()
 		got := evalExpr(t, baseDir, fmt.Sprintf("fileexists(%q)", tildePath))
 		assert.Equal(t, cty.True, got)
 	})
 
 	t.Run("filemd5", func(t *testing.T) {
+		t.Parallel()
 		got := evalExpr(t, baseDir, fmt.Sprintf("filemd5(%q)", tildePath))
 		assert.Equal(t, evalExpr(t, baseDir, `md5("hi")`), got)
 	})
@@ -1133,6 +1138,7 @@ func TestFileTildeExpansion(t *testing.T) {
 // is a directory rather than a regular file, matching OpenTofu. This is an
 // error path, so it calls the function directly rather than via evalExpr.
 func TestFileExistsDirectory(t *testing.T) {
+	t.Parallel()
 	baseDir := t.TempDir()
 	dir := filepath.Join(baseDir, "adir")
 	require.NoError(t, os.Mkdir(dir, 0o755))

--- a/tests/tfcompat/l1_file_tilde_test.go
+++ b/tests/tfcompat/l1_file_tilde_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/stretchr/testify/require"
+)
+
+// TestL1FileTilde pins that the file-reading functions expand a leading `~` to
+// the user's home directory, matching OpenTofu's openFile. The fixture reads a
+// file via `~/<name>`; OpenTofu reads it and reports it exists, so pulumi-hcl
+// must too. The test writes the referenced file into the shared $HOME both
+// runtimes see and removes it afterwards. The outputs are the file's literal
+// contents and existence booleans, neither of which embeds a machine-specific
+// path, so the comparison is stable across hosts.
+func TestL1FileTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	name := fmt.Sprintf(".pulumi_hcl_tfcompat_tilde_%d.txt", os.Getpid())
+	abs := filepath.Join(home, name)
+	require.NoError(t, os.WriteFile(abs, []byte("from-home"), 0o600))
+	t.Cleanup(func() { _ = os.Remove(abs) })
+
+	program := fmt.Sprintf(`
+output "content" { value = file("~/%[1]s") }
+output "b64"     { value = filebase64("~/%[1]s") }
+output "exists"  { value = fileexists("~/%[1]s") }
+`, name)
+
+	tfcompat.RunCase(t, "l1_file_tilde", tfcompat.Case{
+		Stages: []tfcompat.Stage{
+			{Files: map[string]string{"main.tf": program}},
+		},
+	})
+}

--- a/tests/tfcompat/l1_file_tilde_test.go
+++ b/tests/tfcompat/l1_file_tilde_test.go
@@ -32,6 +32,7 @@ import (
 // contents and existence booleans, neither of which embeds a machine-specific
 // path, so the comparison is stable across hosts.
 func TestL1FileTilde(t *testing.T) {
+	t.Parallel()
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Divergence

OpenTofu's `file`, `filebase64`, `fileexists`, the `file*` hash functions
(`filemd5`/`filesha1`/`filesha256`/`filesha512`/`filebase64sha256`/`filebase64sha512`),
and `templatefile` all expand a leading `~` in their path argument to the user's home
directory (via `homedir.Expand`, inside `openFile`). pulumi-hcl treated `~` as a literal
path segment and joined it to the module directory.

So a configuration that reads `file("~/config.json")` (or any `~`-relative path) works
under `tofu apply` but fails under `pulumi up` with:

```
Call to function "file" failed: open <module>/~/config.json: no such file or directory
```

This is the migration-direction bug: OpenTofu succeeds, pulumi-hcl errors.

## Fix

All file-reading functions now resolve their path through a single helper that mirrors
OpenTofu's `openFile`: expand `~`, resolve relative paths against the base directory, then
`filepath.Clean`.

## Sweep

Same root cause folded into one PR:

- `pathexpand` now uses `homedir.Expand`, matching OpenTofu's rejection of `~user` paths
  (the old impl silently produced a bogus path like `/home/userfoo`).
- `fileexists` now returns an error for a path that exists but is not a regular file
  (directory, device node, pipe, socket), matching OpenTofu, instead of returning `true`.

`abspath`/`dirname`/`basename` are intentionally unchanged: OpenTofu does not `~`-expand
those.

## Tests

- `TestL1FileTilde` (tfcompat): reads a `$HOME` file via `~/<name>` through both runtimes.
  Fails before the fix (`open .../~/...: no such file or directory`), passes after.
- `TestFileTildeExpansion` / `TestFileExistsDirectory` (unit): cover `~` expansion across
  the file functions and the directory-error behavior.