### PR TITLE
Propagate marks through `length` for tuples and objects

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-231.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-231.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`length` propagates its argument''s marks onto the result for tuples and objects'
+time: 2026-06-03T16:00:00.000000+02:00
+custom:
+    Component: runtime
+    PR: "231"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -415,15 +415,16 @@ var lengthFunc = function.New(&function.Spec{
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		v := args[0]
 		ty := v.Type()
+		marks := v.Marks()
 		switch {
 		case ty == cty.DynamicPseudoType:
-			return cty.UnknownVal(cty.Number), nil
+			return cty.UnknownVal(cty.Number).WithMarks(marks), nil
 		case ty == cty.String:
 			return stdlib.Strlen(v)
 		case ty.IsTupleType():
-			return cty.NumberIntVal(int64(len(ty.TupleElementTypes()))), nil
+			return cty.NumberIntVal(int64(len(ty.TupleElementTypes()))).WithMarks(marks), nil
 		case ty.IsObjectType():
-			return cty.NumberIntVal(int64(len(ty.AttributeTypes()))), nil
+			return cty.NumberIntVal(int64(len(ty.AttributeTypes()))).WithMarks(marks), nil
 		case ty.IsListType(), ty.IsMapType(), ty.IsSetType():
 			return v.Length(), nil
 		default:

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -1414,6 +1414,58 @@ func TestUnknownPropagation(t *testing.T) {
 	}
 }
 
+// TestLengthMarkPropagation mirrors OpenTofu's LengthFunc, which carries the
+// argument's marks onto the returned count for every supported type. The tuple
+// and object branches build the count themselves, so they must reapply the
+// marks; the string/list/map branches delegate to helpers that already
+// preserve them.
+func TestLengthMarkPropagation(t *testing.T) {
+	t.Parallel()
+	funcs := Functions("/tmp")
+	length := funcs["length"]
+
+	tests := []struct {
+		name string
+		arg  cty.Value
+		want cty.Value
+	}{
+		{
+			name: "tuple",
+			arg:  cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c")}).Mark(SensitiveMark),
+			want: cty.NumberIntVal(3).Mark(SensitiveMark),
+		},
+		{
+			name: "object",
+			arg:  cty.ObjectVal(map[string]cty.Value{"a": cty.NumberIntVal(1), "b": cty.NumberIntVal(2)}).Mark(SensitiveMark),
+			want: cty.NumberIntVal(2).Mark(SensitiveMark),
+		},
+		{
+			name: "string",
+			arg:  cty.StringVal("hello").Mark(SensitiveMark),
+			want: cty.NumberIntVal(5).Mark(SensitiveMark),
+		},
+		{
+			name: "list",
+			arg:  cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}).Mark(SensitiveMark),
+			want: cty.NumberIntVal(2).Mark(SensitiveMark),
+		},
+		{
+			name: "map",
+			arg:  cty.MapVal(map[string]cty.Value{"a": cty.StringVal("1")}).Mark(SensitiveMark),
+			want: cty.NumberIntVal(1).Mark(SensitiveMark),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := length.Call([]cty.Value{tt.arg})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestAbspathAndBasename(t *testing.T) {
 	t.Parallel()
 	t.Run("basename", func(t *testing.T) {

--- a/tests/tfcompat/l1_length_sensitive_test.go
+++ b/tests/tfcompat/l1_length_sensitive_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1LengthSensitive exercises `length`'s mark propagation. OpenTofu carries
+// the sensitivity of its argument onto the returned count for every supported
+// type, including tuples and objects; pulumi-hcl must do the same rather than
+// dropping the mark.
+func TestL1LengthSensitive(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_length_sensitive", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_length_sensitive/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_length_sensitive/main.tf
@@ -1,0 +1,25 @@
+# OpenTofu's `length` propagates the sensitivity (and any other marks) of its
+# argument onto the returned count. A sensitive tuple or object therefore yields
+# a sensitive length. `issensitive` exposes that mark as a plain bool so the
+# behavior is observable in outputs without leaking the sensitive value itself.
+output "len_tuple_sensitive" {
+  value = issensitive(length(sensitive(["a", "b", "c"])))
+}
+
+output "len_object_sensitive" {
+  value = issensitive(length(sensitive({ a = 1, b = 2 })))
+}
+
+# A sensitive string, list, and map must stay sensitive too — these already
+# propagate the mark and guard against a regression in the other branches.
+output "len_string_sensitive" {
+  value = issensitive(length(sensitive("hello")))
+}
+
+output "len_list_sensitive" {
+  value = issensitive(length(sensitive(tolist(["a", "b"]))))
+}
+
+output "len_map_sensitive" {
+  value = issensitive(length(sensitive(tomap({ a = "1" }))))
+}


### PR DESCRIPTION
OpenTofu’s `LengthFunc` carries its argument’s marks (notably sensitivity) onto the returned count for **every** supported type. pulumi-hcl’s hand-rolled `length` only preserved marks on the string, list, map, and set branches — which delegate to `stdlib.Strlen` / `cty.Value.Length`, both of which propagate marks themselves — and **dropped** them on the tuple, object, and dynamic branches, which build a fresh `cty.NumberIntVal` from the type alone.

## Divergence

```hcl
output "x" {
  value = issensitive(length(sensitive(["a", "b", "c"])))
}
```

- **OpenTofu:** `true` — the length is sensitive (a bare `output` of it errors with "Output refers to sensitive values" unless marked `sensitive = true`).
- **pulumi-hcl (before):** `false` — the sensitivity mark is silently stripped, leaking the count as a plain value.

A list literal `["a","b","c"]` is a *tuple* in HCL and an object literal is an *object*, so this is the common case, not an edge one.

## Fix

Capture `v.Marks()` and reapply them via `.WithMarks(marks)` on the tuple, object, and dynamic branches — exactly as OpenTofu does. The string/list/map/set branches already propagate marks through their delegated helpers and are left unchanged (and now covered by regression tests).

## Sibling sweep

The neighboring hand-rolled collection functions don’t share this defect: `index` and `one` don’t set `AllowMarked`, so a marked argument is rejected before their `Impl` runs (matching OpenTofu); `keys`/`values` are bound to the cty stdlib. `length` was the only function building a result from a structural *type* while accepting marks.

## Verification

- `TestL1LengthSensitive` (tfcompat) — fails before, passes after; the `len_tuple_sensitive`/`len_object_sensitive` outputs flip from `false` to `true` to match OpenTofu.
- `TestLengthMarkPropagation` (unit) — asserts the sensitive mark survives for tuple, object, string, list, and map.