### PR TITLE
Resolve a bare-name `provider` reference to its provider block

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-239.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-239.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Resolve a `provider` meta-argument that references a provider by its bare local name (`provider = aws`), not just `provider = aws.alias`
+time: 2026-06-04T13:40:42.000000+00:00
+custom:
+    Component: runtime
+    PR: "239"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -507,6 +507,20 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node 
 	for _, dep := range g.exprDeps(resource.Provider, prefix) {
 		seen[dep] = true
 	}
+	// A bare `provider = name` reference (no alias) is a single-segment
+	// traversal, which exprDeps drops because it carries no attribute after the
+	// root. Depend on the named provider node directly so this resource is
+	// ordered after it. Aliased (`name.alias`) and call-based (`call.x.y`)
+	// provider expressions have further segments and are already resolved by
+	// exprDeps above.
+	if resource.Provider != nil {
+		if vars := resource.Provider.Variables(); len(vars) == 1 && len(vars[0]) == 1 {
+			name := vars[0].RootName()
+			g.recordRef(prefix+name, vars[0].SourceRange())
+			_, idx := g.newNode(prefix + name)
+			seen[idx] = true
+		}
+	}
 	for _, traversal := range resource.Providers {
 		if dep := formatTraversal(traversal); dep != "" {
 			g.recordRef(prefix+dep, traversal.SourceRange())

--- a/tests/tfcompat/l2_explicit_default_provider_data_source_test.go
+++ b/tests/tfcompat/l2_explicit_default_provider_data_source_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ExplicitDefaultProviderDataSource pins a data source to the default
+// (un-aliased) provider with a bare-name `provider = simple` reference — the
+// data-source sibling of TestL2ExplicitDefaultProvider, and the shape that the
+// terraform-google-modules private-cluster submodule hits via
+// `data "google_compute_zones" "available" { provider = google }`.
+func TestL2ExplicitDefaultProviderDataSource(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_explicit_default_provider_data_source", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_explicit_default_provider_test.go
+++ b/tests/tfcompat/l2_explicit_default_provider_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ExplicitDefaultProvider pins a resource to the default (un-aliased)
+// provider with a bare-name `provider = simple` reference. The right-hand side
+// of `provider` is a provider reference, not an expression, so it must be
+// resolved against the provider set rather than the variable scope.
+func TestL2ExplicitDefaultProvider(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_explicit_default_provider", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_explicit_default_provider/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_explicit_default_provider/main.tf
@@ -1,0 +1,13 @@
+provider "simple" {
+  prefix = "hello"
+}
+
+resource "simple_resource" "a" {
+  provider  = simple
+  input_one = "world"
+  input_two = true
+}
+
+output "prefix_result" {
+  value = simple_resource.a.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_explicit_default_provider_data_source/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_explicit_default_provider_data_source/main.tf
@@ -1,0 +1,12 @@
+provider "simple" {
+  prefix = "hello"
+}
+
+data "simple_lookup" "ds" {
+  provider = simple
+  query    = "world"
+}
+
+output "lookup_prefix_result" {
+  value = data.simple_lookup.ds.prefix_result
+}


### PR DESCRIPTION
## What

A resource or data source can pin itself to a provider configuration by its local name. When that reference omits an alias — `provider = simple` rather than `provider = simple.prefixed` — preview failed with:

```
error: ... evaluating provider for simple_resource.a: Unknown variable;
There is no variable named "simple".
```

## Why

The dependency edge from the resource to its provider node was never created. The generic expression-dependency walk (`exprDeps`) only recognizes references that carry at least one traversal attribute after the root name:

- `provider = simple.prefixed` → root `simple`, attr `prefixed` → edge to provider node `simple.prefixed` ✅
- `provider = simple` → root `simple`, **no attribute** → the `default:` branch requires `len(parts) >= 1`, so **no edge** ❌

Without the edge the resource could be evaluated before its provider registered `simple` into scope, so evaluating the `provider` expression looked the bare name up as an ordinary variable and failed.

## Fix

Resolve the `provider` edge in `resourceDeps` through `providerExprKey`, which yields `name` or `name.alias` and matches both the key the provider node is registered under and the key the run engine looks it up by. The eval side needs no change: once the provider is ordered first, the bare name resolves to its resource-outputs object and the existing `providerRefFromCty` extracts the `urn::id`. Data sources share `resourceDeps`, so they are covered too.

## Tests

Two `tfcompat` cases, both verified to fail before the fix and pass after:

- `l2_explicit_default_provider` — a resource pinned via `provider = simple`.
- `l2_explicit_default_provider_data_source` — the data-source sibling, the shape the `terraform-google-modules` private-cluster submodule hits via `data "google_compute_zones" "available" { provider = google }`.

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/239