### PR TITLE
Inherit default provider configurations into child modules

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-236.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-236.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Inherit default provider configurations into child modules
+time: 2026-06-08T10:32:11.000000Z
+custom:
+    Component: runtime
+    PR: "236"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -368,8 +368,9 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 	}
 
 	// Inline module contents into the graph for fine-grained dependency tracking.
+	rootScope := &moduleScope{config: config}
 	for name, module := range config.Modules {
-		if err := g.inlineModule(name, module, modulepath.Root(), moduleLoader, workDir); err != nil {
+		if err := g.inlineModule(name, module, modulepath.Root(), moduleLoader, workDir, rootScope); err != nil {
 			return nil, fmt.Errorf("inlining module %s: %w", name, err)
 		}
 	}
@@ -412,6 +413,36 @@ func (g *Graph) defaultProviderDeps(resource *ast.Resource, config *ast.Config, 
 	}
 	_, idx := g.newNode(prefix + pkgName)
 	return []pdag.Node{idx}
+}
+
+// moduleScope is an ancestor module's node-key prefix and config, linked toward
+// the root via parent. Scopes are immutable once built and shared by reference.
+type moduleScope struct {
+	prefix string
+	config *ast.Config
+	parent *moduleScope
+}
+
+// inheritedProviderDeps returns an edge to the nearest ancestor module's
+// un-aliased `provider "<pkg>" {}` block, for an in-module resource/data source
+// with no `provider`, no own-module block, and no pass-through. parent is the
+// enclosing module's scope; the walk runs from there toward the root. The edge
+// forces that block to register and orders it before the resource.
+func (g *Graph) inheritedProviderDeps(resource *ast.Resource, parent *moduleScope) []pdag.Node {
+	if resource.Provider != nil {
+		return nil
+	}
+	pkgName := packageNameFromResourceType(resource.Type)
+	if pkgName == "" {
+		return nil
+	}
+	for s := parent; s != nil; s = s.parent {
+		if _, ok := s.config.Providers[pkgName]; ok {
+			_, idx := g.newNode(s.prefix + pkgName)
+			return []pdag.Node{idx}
+		}
+	}
+	return nil
 }
 
 // passThroughProviderDeps returns an edge from an in-module resource to the
@@ -811,7 +842,7 @@ func rangeLess(a, b hcl.Range) bool {
 // rooted at parentPath.
 func (g *Graph) inlineModule(
 	name string, mod *ast.Module, parentPath modulepath.Path,
-	moduleLoader ModuleLoader, workDir string,
+	moduleLoader ModuleLoader, workDir string, parent *moduleScope,
 ) error {
 	loaded, err := moduleLoader.LoadModule(mod.Source, mod.Version, workDir)
 	if err != nil {
@@ -926,8 +957,13 @@ func (g *Graph) inlineModule(
 	for key, resource := range loaded.Config.Resources {
 		deps := g.resourceDeps(resource, prefix)
 		deps = append(deps, initIdx)
-		deps = append(deps, g.defaultProviderDeps(resource, loaded.Config, prefix)...)
-		deps = append(deps, g.passThroughProviderDeps(resource, mod, parentPrefix)...)
+		ownDeps := g.defaultProviderDeps(resource, loaded.Config, prefix)
+		passDeps := g.passThroughProviderDeps(resource, mod, parentPrefix)
+		deps = append(deps, ownDeps...)
+		deps = append(deps, passDeps...)
+		if len(ownDeps) == 0 && len(passDeps) == 0 {
+			deps = append(deps, g.inheritedProviderDeps(resource, parent)...)
+		}
 		if err := g.AddNode(&Node{
 			Key:        prefix + key,
 			Type:       NodeTypeResource,
@@ -942,8 +978,13 @@ func (g *Graph) inlineModule(
 	for key, ds := range loaded.Config.DataSources {
 		deps := g.resourceDeps(ds, prefix)
 		deps = append(deps, initIdx)
-		deps = append(deps, g.defaultProviderDeps(ds, loaded.Config, prefix)...)
-		deps = append(deps, g.passThroughProviderDeps(ds, mod, parentPrefix)...)
+		ownDeps := g.defaultProviderDeps(ds, loaded.Config, prefix)
+		passDeps := g.passThroughProviderDeps(ds, mod, parentPrefix)
+		deps = append(deps, ownDeps...)
+		deps = append(deps, passDeps...)
+		if len(ownDeps) == 0 && len(passDeps) == 0 {
+			deps = append(deps, g.inheritedProviderDeps(ds, parent)...)
+		}
 		if err := g.AddNode(&Node{
 			Key:        prefix + "data." + key,
 			Type:       NodeTypeDataSource,
@@ -991,8 +1032,9 @@ func (g *Graph) inlineModule(
 	}
 
 	// Nested modules
+	scope := &moduleScope{prefix: prefix, config: loaded.Config, parent: parent}
 	for nestedName, nestedMod := range loaded.Config.Modules {
-		if err := g.inlineModule(nestedName, nestedMod, path, moduleLoader, loaded.SourcePath); err != nil {
+		if err := g.inlineModule(nestedName, nestedMod, path, moduleLoader, loaded.SourcePath, scope); err != nil {
 			return fmt.Errorf("inlining nested module %s: %w", nestedName, err)
 		}
 	}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -857,6 +857,25 @@ func (e *Engine) resolvePassThroughProvider(modInfo *graph.ModuleInfo, localKey 
 	return ref
 }
 
+// inheritedDefaultProvider walks up the module tree from modInfo, returning the
+// nearest ancestor's registered un-aliased default provider config for pkg
+// (URN::ID), or "" if none. The graph adds a matching edge so that block is
+// registered before this resolves.
+func (e *Engine) inheritedDefaultProvider(modInfo *graph.ModuleInfo, pkg string) string {
+	for path := modInfo.Path; ; {
+		parent, _, ok := path.Parent()
+		if !ok {
+			return ""
+		}
+		if outputs, ok := e.resourceOutputs.Get(parent.PrefixString() + pkg); ok {
+			if ref, err := providerRefFromCty(outputs); err == nil {
+				return ref
+			}
+		}
+		path = parent
+	}
+}
+
 // parentEvalContext returns the eval.Context of the enclosing module
 // instance (or the root context when modInfo's parent is root).
 func (e *Engine) parentEvalContext(modInfo *graph.ModuleInfo) *eval.Context {
@@ -1426,8 +1445,9 @@ func (e *Engine) buildResourceOptionsInContext(
 	} else if modInfo != nil {
 		// Implicit default in a module: try a pass-through entry, then
 		// the in-module `provider "<pkg>" {}` block (registered earlier
-		// at key resPrefix+pkg in resourceOutputs). If neither exists,
-		// fall through to Pulumi's engine default.
+		// at key resPrefix+pkg in resourceOutputs), then an inherited
+		// ancestor default. If none exist, fall through to Pulumi's
+		// engine default.
 		pkg := packageNameFromResourceType(res.Type)
 		if ref := e.resolvePassThroughProvider(modInfo, pkg); ref != "" {
 			opts.Provider = ref
@@ -1435,6 +1455,8 @@ func (e *Engine) buildResourceOptionsInContext(
 			if ref, err := providerRefFromCty(outputs); err == nil {
 				opts.Provider = ref
 			}
+		} else if ref := e.inheritedDefaultProvider(modInfo, pkg); ref != "" {
+			opts.Provider = ref
 		}
 	} else {
 		if ref, ok := e.defaultProviders.Get(packageNameFromResourceType(res.Type)); ok {
@@ -2260,6 +2282,8 @@ func (e *Engine) invokeDataSourceOnce(
 			if ref, err := providerRefFromCty(outputs); err == nil {
 				invokeReq.Provider = ref
 			}
+		} else if ref := e.inheritedDefaultProvider(node.ModuleInfo, pkg); ref != "" {
+			invokeReq.Provider = ref
 		}
 	} else {
 		if ref, ok := e.defaultProviders.Get(packageNameFromResourceType(ds.Type)); ok {

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -2845,3 +2845,191 @@ module "child" {
 		second.PropertyDependencies)
 	assert.Equal(t, []string{urnOf(first)}, second.Dependencies)
 }
+
+// When both the root and a child module declare a default `provider "simple"`
+// config, a resource in the child binds to the child's own block, not the
+// inherited root default.
+func TestEngine_ProviderResolution_ChildModuleBlockWins(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	childDir := tmpDir + "/modules/child"
+	require.NoError(t, os.MkdirAll(childDir, 0o755))
+
+	require.NoError(t, os.WriteFile(childDir+"/main.tf", []byte(`
+provider "simple" {
+  prefix = "child-prefix"
+}
+
+resource "simple_resource" "r" {
+  input = "p7"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(`
+provider "simple" {
+  prefix = "root-prefix"
+}
+
+module "child" {
+  source = "./modules/child"
+}
+`), 0o644))
+
+	p := parser.NewParser()
+	config, diags := p.ParseDirectory(tmpDir)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         tmpDir,
+		RootDir:         tmpDir,
+
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "simple",
+			Provider: schema.ResourceSpec{
+				InputProperties: map[string]schema.PropertySpec{
+					"prefix": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+			Resources: map[string]schema.ResourceSpec{
+				"simple:index:Resource": {
+					InputProperties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	// Locate a registered provider block by its `prefix` config value.
+	findProvider := func(prefix string) (run.RegisterResourceRequest, bool) {
+		for _, r := range mock.RegisteredResources {
+			if r.Type != "pulumi:providers:simple" {
+				continue
+			}
+			if v, ok := r.Inputs.GetOk("prefix"); ok && v.IsString() && v.AsString() == prefix {
+				return r, true
+			}
+		}
+		return run.RegisterResourceRequest{}, false
+	}
+
+	// The child resource depends on the child's own block, so that block
+	// registers on its own (no AlwaysRegisterProviders).
+	childProvider, ok := findProvider("child-prefix")
+	require.True(t, ok, "child module's provider block should register")
+
+	// MockResourceMonitor mints URN urn:pulumi:test::project::<type>::<name>
+	// and ID <name>-id; a provider ref is "<urn>::<id>".
+	providerRef := func(r run.RegisterResourceRequest) string {
+		urn := "urn:pulumi:test::project::" + r.Type + "::" + r.Name
+		return urn + "::" + r.Name + "-id"
+	}
+
+	var childResource *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Type == "simple:index:Resource" {
+			childResource = &mock.RegisteredResources[i]
+			break
+		}
+	}
+	require.NotNil(t, childResource, "child resource should register")
+
+	assert.Equal(t, providerRef(childProvider), childResource.Provider,
+		"a resource in a child module with its own provider block must bind to that block")
+
+	// The root block is unused (the child binds to its own block), so it is not
+	// configured — TF only configures providers something actually uses.
+	_, rootRegistered := findProvider("root-prefix")
+	assert.False(t, rootRegistered, "the unused root provider block must not register")
+}
+
+// A resource in a child module with no provider block and no `providers = {}`
+// mapping inherits the root module's default provider config. The graph edge
+// also registers the otherwise-unused root block (no AlwaysRegisterProviders).
+func TestEngine_ProviderResolution_ChildInheritsRootDefault(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	childDir := tmpDir + "/modules/child"
+	require.NoError(t, os.MkdirAll(childDir, 0o755))
+
+	require.NoError(t, os.WriteFile(childDir+"/main.tf", []byte(`
+resource "simple_resource" "r" {
+  input = "p2"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(`
+provider "simple" {
+  prefix = "root-prefix"
+}
+
+module "child" {
+  source = "./modules/child"
+}
+`), 0o644))
+
+	p := parser.NewParser()
+	config, diags := p.ParseDirectory(tmpDir)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         tmpDir,
+		RootDir:         tmpDir,
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "simple",
+			Provider: schema.ResourceSpec{
+				InputProperties: map[string]schema.PropertySpec{
+					"prefix": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+			Resources: map[string]schema.ResourceSpec{
+				"simple:index:Resource": {
+					InputProperties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var rootProvider, childResource *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		switch mock.RegisteredResources[i].Type {
+		case "pulumi:providers:simple":
+			rootProvider = &mock.RegisteredResources[i]
+		case "simple:index:Resource":
+			childResource = &mock.RegisteredResources[i]
+		}
+	}
+	require.NotNil(t, rootProvider, "the root provider block should register via the inherited edge")
+	require.NotNil(t, childResource, "child resource should register")
+
+	rootRef := "urn:pulumi:test::project::" + rootProvider.Type + "::" + rootProvider.Name +
+		"::" + rootProvider.Name + "-id"
+	assert.Equal(t, rootRef, childResource.Provider,
+		"a child resource with no provider block must inherit the root default provider")
+}

--- a/tests/tfcompat/l2_module_provider_inherited_by_called_module_test.go
+++ b/tests/tfcompat/l2_module_provider_inherited_by_called_module_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ModuleProviderInheritedByCalledModule pins TF's behaviour for a default
+// `provider` block declared in a non-root module: the `mid` module configures
+// `simple` with prefix = "mid-prefix" and calls a grandchild module (with no
+// provider block of its own), which inherits that config, so the grandchild's
+// resource produces "mid-prefix-p5".
+//
+// pulumi-hcl synthesizes a fresh, unconfigured default provider for the called
+// module instead of inheriting `mid`'s, dropping the prefix.
+func TestL2ModuleProviderInheritedByCalledModule(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_provider_inherited_by_called_module", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_provider_inheritance_test.go
+++ b/tests/tfcompat/l2_provider_inheritance_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ProviderInheritance pins TF's default-provider inheritance for child
+// modules. The root configures `simple` with prefix = "root-prefix"; each child
+// exercises one inheritance property:
+//
+//   - p2_plain: a child with no provider block inherits the root config.
+//   - p3_required_providers: a `required_providers` block (no config block)
+//     does not stop inheritance.
+//   - p4_grandchild: inheritance is recursive through a nested module.
+//   - p6_data_source: a data source inherits the root config.
+//
+// All four reproduce https://github.com/pulumi-labs/pulumi-hcl/issues/236:
+// pulumi-hcl synthesizes a fresh, unconfigured default provider per module
+// instead of inheriting the root's, dropping the prefix.
+func TestL2ProviderInheritance(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_provider_inheritance", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_module_provider_inherited_by_called_module/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_provider_inherited_by_called_module/main.tf
@@ -1,0 +1,3 @@
+module "mid" {
+  source = "./modules/mid"
+}

--- a/tests/tfcompat/testdata/cases/l2_module_provider_inherited_by_called_module/modules/mid/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_provider_inherited_by_called_module/modules/mid/main.tf
@@ -1,0 +1,7 @@
+provider "simple" {
+  prefix = "mid-prefix"
+}
+
+module "grandchild" {
+  source = "./modules/grandchild"
+}

--- a/tests/tfcompat/testdata/cases/l2_module_provider_inherited_by_called_module/modules/mid/modules/grandchild/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_provider_inherited_by_called_module/modules/mid/modules/grandchild/main.tf
@@ -1,0 +1,4 @@
+resource "simple_resource" "r" {
+  input_one = "p5"
+  input_two = true
+}

--- a/tests/tfcompat/testdata/cases/l2_provider_inheritance/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_inheritance/main.tf
@@ -1,0 +1,27 @@
+provider "simple" {
+  prefix = "root-prefix"
+}
+
+# P2: child with no provider block inherits the root default config.
+module "p2_plain" {
+  source = "./modules/p2_plain"
+}
+
+# P3: child with a `required_providers` block (but no config block) still
+# inherits the root default config.
+module "p3_required_providers" {
+  source = "./modules/p3_required_providers"
+}
+
+# P4: inheritance is recursive — a grandchild two levels deep inherits the
+# root default config.
+module "p4_grandchild" {
+  source = "./modules/p4_grandchild"
+}
+
+# P6: a data source (not a resource) in a child inherits the root default
+# config.
+module "p6_data_source" {
+  source = "./modules/p6_data_source"
+}
+

--- a/tests/tfcompat/testdata/cases/l2_provider_inheritance/modules/p2_plain/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_inheritance/modules/p2_plain/main.tf
@@ -1,0 +1,4 @@
+resource "simple_resource" "r" {
+  input_one = "p2"
+  input_two = true
+}

--- a/tests/tfcompat/testdata/cases/l2_provider_inheritance/modules/p3_required_providers/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_inheritance/modules/p3_required_providers/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+resource "simple_resource" "r" {
+  input_one = "p3"
+  input_two = true
+}

--- a/tests/tfcompat/testdata/cases/l2_provider_inheritance/modules/p4_grandchild/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_inheritance/modules/p4_grandchild/main.tf
@@ -1,0 +1,3 @@
+module "grandchild" {
+  source = "./modules/grandchild"
+}

--- a/tests/tfcompat/testdata/cases/l2_provider_inheritance/modules/p4_grandchild/modules/grandchild/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_inheritance/modules/p4_grandchild/modules/grandchild/main.tf
@@ -1,0 +1,4 @@
+resource "simple_resource" "r" {
+  input_one = "p4"
+  input_two = true
+}

--- a/tests/tfcompat/testdata/cases/l2_provider_inheritance/modules/p6_data_source/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_inheritance/modules/p6_data_source/main.tf
@@ -1,0 +1,3 @@
+data "simple_lookup" "ds" {
+  query = "p6"
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/236.

## Problem

A resource or data source in a child module with no `provider` block of its own
and no `providers = {}` mapping was bound to a fresh, **unconfigured** default
provider synthesized per module, instead of inheriting the root module's default
provider configuration. For e.g. `azurerm` this drops the required `features {}`
block and `pulumi preview` fails.

In Terraform/OpenTofu a child module inherits its parent's default (un-aliased)
provider configuration, recursively up to the root.

## Fix

- **Graph** (`pkg/hcl/graph/graph.go`): when an in-module resource/data source has
  no own-module provider block and no pass-through, add an implicit dependency edge
  to the nearest ancestor module's un-aliased default provider block. This both
  registers that otherwise-unused block and orders it before the resource. Ancestor
  scopes are threaded as an immutable back-pointer chain.
- **Runtime** (`pkg/hcl/run/run.go`): `inheritedDefaultProvider` walks the module
  tree from the resource toward the root and resolves to the nearest registered
  ancestor default provider. Wired into both the resource and the data-source invoke
  paths.

Resolution order matches Terraform: explicit `provider =` > `providers = {}`
pass-through > own-module default block > nearest-ancestor inherited default.

## Tests

- `tests/tfcompat/l2_provider_inheritance` — a child with no block, a child with a
  `required_providers` block, a nested grandchild, and a data source all inherit the
  root default.
- `tests/tfcompat/l2_module_provider_inherited_by_called_module` — a non-root
  module's default block is inherited by a grandchild it calls.
- `pkg/hcl/run` unit tests assert the resolved provider reference directly: a child
  with no block inherits root; a child with its own block binds to that block (not
  root), and the unused root block is not registered.

The "both root and child declare the default provider" precedence case is covered by
the unit test rather than tfcompat: the tfcompat harness serves one provider instance
per name over reattach, so two configurations of the same provider clobber each
other's state and cannot be compared there.