### PR TITLE
Split git revision off subdir in module sources

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-247.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-247.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Split the `?ref=` git revision off `//subdir` when resolving git module sources
+time: 2026-06-08T11:12:17.000000+00:00
+custom:
+    Component: runtime
+    PR: "247"

--- a/pkg/hcl/modules/loader.go
+++ b/pkg/hcl/modules/loader.go
@@ -131,7 +131,7 @@ func (l *Loader) LoadModule(source, versionConstraint, callerDir string) (*Loade
 // resolveSource resolves a module source to an absolute path on disk.
 // versionConstraint applies only to registry sources.
 func (l *Loader) resolveSource(source, versionConstraint, callerDir string) (string, error) {
-	source, subdir := splitSourceSubdir(source)
+	source, subdir := getmodules.SplitPackageSubdir(source)
 
 	var resolvedPath string
 	var err error
@@ -159,23 +159,6 @@ func (l *Loader) resolveSource(source, versionConstraint, callerDir string) (str
 		}
 	}
 	return resolvedPath, nil
-}
-
-// splitSourceSubdir splits a source into the base source and optional subdir.
-// e.g., "git::https://example.com/repo.git//modules/foo" -> ("git::https://example.com/repo.git", "modules/foo")
-func splitSourceSubdir(source string) (string, string) {
-	idx := strings.Index(source, "//")
-	if idx == -1 {
-		return source, ""
-	}
-	if idx > 0 && source[idx-1] == ':' {
-		nextIdx := strings.Index(source[idx+2:], "//")
-		if nextIdx == -1 {
-			return source, ""
-		}
-		idx = idx + 2 + nextIdx
-	}
-	return source[:idx], source[idx+2:]
 }
 
 func (l *Loader) resolveLocalSource(source string, callerDir string) (string, error) {

--- a/pkg/hcl/modules/loader_test.go
+++ b/pkg/hcl/modules/loader_test.go
@@ -339,6 +339,53 @@ func TestLoadModule_HostQualifiedRegistrySource(t *testing.T) {
 	require.Contains(t, loaded.Config.Outputs, "ok")
 }
 
+func TestLoadModule_GitSubdirWithRef(t *testing.T) {
+	t.Parallel()
+
+	repo := initGitRepo(t, "modules/iam-policy/main.tf", `output "ok" { value = "v1" }`)
+	git(t, repo, "tag", "v1")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, "modules/iam-policy/main.tf"),
+		[]byte(`output "ok2" { value = "head" }`), 0o600))
+	git(t, repo, "commit", "-am", "rename output")
+
+	l := newTestLoader(t, "http://invalid.example")
+	source := "git::file://" + repo + "//modules/iam-policy?ref=v1"
+
+	loaded, err := l.LoadModule(source, "", t.TempDir())
+	require.NoError(t, err)
+	require.NotNil(t, loaded.Config)
+	require.Contains(t, loaded.Config.Outputs, "ok",
+		"ref=v1 should pin the checkout to the tagged commit")
+	require.NotContains(t, loaded.Config.Outputs, "ok2",
+		"HEAD's output must not appear when ref=v1 is requested")
+}
+
+// initGitRepo creates a git repository in a temp dir containing a single file
+// (relativePath → content), committed on the default branch.
+func initGitRepo(t *testing.T, relativePath, content string) string {
+	t.Helper()
+	repo := t.TempDir()
+	full := filepath.Join(repo, relativePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+
+	git(t, repo, "init")
+	git(t, repo, "config", "user.email", "test@example.com")
+	git(t, repo, "config", "user.name", "test")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	return repo
+}
+
+func git(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %s: %s", strings.Join(args, " "), out)
+}
+
 // buildModuleTarGz packs `files` (name → content) into a gzipped tar archive
 // using the system `tar`. The returned bytes are the raw .tar.gz body that
 // PackageFetcher / go-getter can consume.


### PR DESCRIPTION
## What

A git module `source` that combines a subdirectory (`//modules/foo`) with a
`?ref=` query was mis-parsed: the hand-rolled `splitSourceSubdir` folded the
entire `?ref=...` query into the subdirectory path, so resolution then looked
for a literal subdir named `modules/foo?ref=v1` and failed before any provider
or credentials were involved.

## Fix

Replace `splitSourceSubdir` with the already-vendored
`getmodules.SplitPackageSubdir`, which delegates to go-getter's
`SourceDirSubdir` — the same code path OpenTofu uses. It moves the query off
the subdir and back onto the package address, so the package is fetched at the
requested ref and the subdir resolves correctly.

This also fixes registry sources that combine `//subdir` with `?version=`,
which the old splitter mishandled the same way.

## Test

`TestLoadModule_GitSubdirWithRef` is an end-to-end regression test against a
local `git::file://` repo: tag `v1` exposes output `ok`, HEAD renames it to
`ok2`. Loading `…//modules/iam-policy?ref=v1` must surface `ok` and not `ok2`,
proving both that the subdir resolved and that the ref pinned the checkout to
the tag. Confirmed it fails with the old splitter (reproducing the issue's exact
`subdir "modules/iam-policy?ref=v1" does not exist` error) and passes with the
fix.

Fixes #233