### PR TITLE
Parse and evaluate `check` blocks

### DIFF
--- a/.changes/unreleased/runtime-Improvements-249.yaml
+++ b/.changes/unreleased/runtime-Improvements-249.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Support `check` blocks
+time: 2026-06-08T16:36:47.659708+02:00
+custom:
+    Component: runtime
+    PR: "249"

--- a/pkg/hcl/ast/check.go
+++ b/pkg/hcl/ast/check.go
@@ -1,0 +1,49 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	"github.com/hashicorp/hcl/v2"
+)
+
+// Check represents a top-level check block.
+//
+// Terraform syntax:
+//
+//	check "health" {
+//	  assert {
+//	    condition     = data.http.example.status_code == 200
+//	    error_message = "${data.http.example.url} returned an unhealthy status."
+//	  }
+//	}
+//
+// A check's assertions are non-blocking: a failed assertion reports a warning
+// and the operation continues, unlike a resource precondition or postcondition.
+type Check struct {
+	// Name is the check name (the label on the check block).
+	Name string
+
+	// Asserts contains the assertions evaluated for this check.
+	Asserts []*CheckRule
+
+	// DataResource is the check's optional scoped data source, read fresh on
+	// every operation and visible only to this check's assertions. A check may
+	// declare at most one. It is modelled as a Resource with IsDataSource set,
+	// matching data sources elsewhere in the config.
+	DataResource *Resource
+
+	// DeclRange is the source range of the check block.
+	DeclRange hcl.Range
+}

--- a/pkg/hcl/ast/config.go
+++ b/pkg/hcl/ast/config.go
@@ -57,6 +57,9 @@ type Config struct {
 	// Imports contains import blocks for importing existing resources.
 	Imports []*Import
 
+	// Checks maps check name to its top-level check block.
+	Checks map[string]*Check
+
 	// Files contains the parsed HCL files.
 	Files map[string]*hcl.File
 
@@ -75,6 +78,7 @@ func NewConfig() *Config {
 		Outputs:     make(map[string]*Output),
 		Modules:     make(map[string]*Module),
 		Calls:       make(map[string]*Call),
+		Checks:      make(map[string]*Check),
 		Files:       make(map[string]*hcl.File),
 	}
 }

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -114,6 +114,8 @@ func (p *Parser) parseBlock(config *ast.Config, block *hcl.Block) hcl.Diagnostic
 		return p.parseMovedBlock(config, block)
 	case "import":
 		return p.parseImportBlock(config, block)
+	case "check":
+		return p.parseCheckBlock(config, block)
 	case "call":
 		return p.parseCallBlock(config, block)
 	default:
@@ -598,10 +600,9 @@ func (p *Parser) parseLocalsBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	return diags
 }
 
-// parseResourceBlock parses a resource or data block.
+// parseResourceBlock parses a resource or data block and records it in the
+// config's Resources or DataSources map.
 func (p *Parser) parseResourceBlock(config *ast.Config, block *hcl.Block, isDataSource bool) hcl.Diagnostics {
-	var diags hcl.Diagnostics
-
 	resourceType := block.Labels[0]
 	name := block.Labels[1]
 	key := ast.ResourceKey(resourceType, name)
@@ -614,14 +615,27 @@ func (p *Parser) parseResourceBlock(config *ast.Config, block *hcl.Block, isData
 	}
 
 	if _, exists := targetMap[key]; exists {
-		diags = append(diags, &hcl.Diagnostic{
+		return hcl.Diagnostics{{
 			Severity: hcl.DiagError,
 			Summary:  fmt.Sprintf("Duplicate %s", blockType),
 			Detail:   fmt.Sprintf("A %s %q %q was already declared.", blockType, resourceType, name),
 			Subject:  &block.DefRange,
-		})
-		return diags
+		}}
 	}
+
+	resource, diags := p.decodeResourceBlock(block, isDataSource)
+	targetMap[key] = resource
+	return diags
+}
+
+// decodeResourceBlock decodes a resource or data block body into a Resource
+// without recording it in the config, so callers that scope the block
+// elsewhere (e.g. a check's data source) can reuse the same decoding.
+func (p *Parser) decodeResourceBlock(block *hcl.Block, isDataSource bool) (*ast.Resource, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+
+	resourceType := block.Labels[0]
+	name := block.Labels[1]
 
 	content, remain, contentDiags := block.Body.PartialContent(resourceSchema)
 	diags = append(diags, contentDiags...)
@@ -701,8 +715,7 @@ func (p *Parser) parseResourceBlock(config *ast.Config, block *hcl.Block, isData
 		}
 	}
 
-	targetMap[key] = resource
-	return diags
+	return resource, diags
 }
 
 // parsePulumiResourceOptions parses a resource or data block's nested
@@ -1080,6 +1093,71 @@ func (p *Parser) parseOutputBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	}
 
 	config.Outputs[name] = output
+	return diags
+}
+
+// parseCheckBlock parses a top-level check block. Each assert block reuses the
+// condition/error_message schema shared with preconditions. A check may declare
+// at most one scoped data source, which is decoded onto the check and read, at
+// evaluation time, into a context visible only to the check's assertions.
+func (p *Parser) parseCheckBlock(config *ast.Config, block *hcl.Block) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+
+	name := block.Labels[0]
+	if _, exists := config.Checks[name]; exists {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Duplicate check",
+			Detail:   fmt.Sprintf("A check named %q was already declared.", name),
+			Subject:  &block.DefRange,
+		})
+		return diags
+	}
+
+	content, contentDiags := block.Body.Content(checkSchema)
+	diags = append(diags, contentDiags...)
+
+	check := &ast.Check{
+		Name:      name,
+		DeclRange: block.DefRange,
+	}
+
+	for _, subBlock := range content.Blocks {
+		switch subBlock.Type {
+		case "assert":
+			rule, ruleDiags := p.parseCheckRule(subBlock)
+			diags = append(diags, ruleDiags...)
+			if rule != nil {
+				check.Asserts = append(check.Asserts, rule)
+			}
+		case "data":
+			if check.DataResource != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Multiple data resource blocks",
+					Detail: fmt.Sprintf("This check block already has a data resource defined at %s.",
+						check.DataResource.DeclRange),
+					Subject: &subBlock.DefRange,
+				})
+				continue
+			}
+			ds, dsDiags := p.decodeResourceBlock(subBlock, true)
+			diags = append(diags, dsDiags...)
+			check.DataResource = ds
+		}
+	}
+
+	if len(check.Asserts) == 0 {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Missing assert block",
+			Detail:   "A check block must contain at least one assert block.",
+			Subject:  &block.DefRange,
+		})
+		return diags
+	}
+
+	config.Checks[name] = check
 	return diags
 }
 

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -613,6 +613,126 @@ resource "aws_instance" "app" {
 	}
 }
 
+func TestParseCheckBlock(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+check "health" {
+  assert {
+    condition     = 1 == 1
+    error_message = "first"
+  }
+
+  assert {
+    condition     = 2 == 2
+    error_message = "second"
+  }
+}
+`)
+	p := NewParser()
+	config, diags := p.ParseSource("test.tf", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	check, ok := config.Checks["health"]
+	require.True(t, ok, "expected check %q", "health")
+	assert.Equal(t, "health", check.Name)
+	require.Len(t, check.Asserts, 2)
+	for _, a := range check.Asserts {
+		assert.NotNil(t, a.Condition)
+		assert.NotNil(t, a.ErrorMessage)
+	}
+}
+
+func TestParseCheckBlockMissingAssert(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+check "empty" {
+}
+`)
+	p := NewParser()
+	config, diags := p.ParseSource("test.tf", src)
+	require.True(t, diags.HasErrors())
+	assert.Equal(t, "Missing assert block", diags[0].Summary)
+	_, ok := config.Checks["empty"]
+	assert.False(t, ok, "a check with no assert block must not be recorded")
+}
+
+func TestParseCheckBlockDuplicate(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+check "dup" {
+  assert {
+    condition     = true
+    error_message = "a"
+  }
+}
+
+check "dup" {
+  assert {
+    condition     = true
+    error_message = "b"
+  }
+}
+`)
+	p := NewParser()
+	_, diags := p.ParseSource("test.tf", src)
+	require.True(t, diags.HasErrors())
+	assert.Equal(t, "Duplicate check", diags[0].Summary)
+}
+
+func TestParseCheckBlockScopedDataSource(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+check "with_data" {
+  data "http" "example" {
+    url = "https://example.com"
+  }
+
+  assert {
+    condition     = data.http.example.status_code == 200
+    error_message = "a"
+  }
+}
+`)
+	p := NewParser()
+	config, diags := p.ParseSource("test.tf", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	check, ok := config.Checks["with_data"]
+	require.True(t, ok, "expected check %q", "with_data")
+	require.NotNil(t, check.DataResource)
+	assert.Equal(t, "http", check.DataResource.Type)
+	assert.Equal(t, "example", check.DataResource.Name)
+	assert.True(t, check.DataResource.IsDataSource)
+
+	// A check's scoped data source must not leak into the global data sources.
+	_, leaked := config.DataSources["http.example"]
+	assert.False(t, leaked, "scoped data source must not be registered globally")
+}
+
+func TestParseCheckBlockMultipleDataSources(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+check "two_data" {
+  data "http" "a" {
+    url = "https://example.com"
+  }
+
+  data "http" "b" {
+    url = "https://example.org"
+  }
+
+  assert {
+    condition     = data.http.a.status_code == 200
+    error_message = "a"
+  }
+}
+`)
+	p := NewParser()
+	_, diags := p.ParseSource("test.tf", src)
+	require.True(t, diags.HasErrors())
+	assert.Equal(t, "Multiple data resource blocks", diags[0].Summary)
+}
+
 func TestParseProviderCallReserved(t *testing.T) {
 	t.Parallel()
 	src := []byte(`

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -32,7 +32,16 @@ var rootSchema = &hcl.BodySchema{
 		{Type: "module", LabelNames: []string{"name"}},
 		{Type: "moved"},
 		{Type: "import"},
+		{Type: "check", LabelNames: []string{"name"}},
 		{Type: "call", LabelNames: []string{"resource", "method"}},
+	},
+}
+
+// checkSchema defines the structure of a top-level check block.
+var checkSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "assert"},
+		{Type: "data", LabelNames: []string{"type", "name"}},
 	},
 }
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -82,6 +82,9 @@ type ResourceMonitor interface {
 	// RegisterResourceHook registers a named callback. Must be called before any
 	// resource registration that binds the hook by name via Hooks.
 	RegisterResourceHook(ctx context.Context, name string, callback ResourceHookFunction, opts ResourceHookOptions) error
+
+	// LogWarning emits a non-fatal warning diagnostic to the engine.
+	LogWarning(ctx context.Context, message string) error
 }
 
 // ResourceHookFunction is the engine-invoked hook callback. A non-nil return
@@ -491,6 +494,11 @@ func (e *Engine) Run(ctx context.Context) error {
 	nodeErrs := slices.Collect(e.failedNodes.Values())
 	if len(nodeErrs) > 0 {
 		return errors.Join(nodeErrs...)
+	}
+
+	// Evaluate check blocks after the program has exited.
+	if err := e.evaluateChecks(ctx); err != nil {
+		return err
 	}
 
 	// Process outputs (collect them into stackOutputs)
@@ -3317,6 +3325,90 @@ func evaluatePrecondition(rule *ast.CheckRule, hclCtx *hcl.EvalContext, index in
 		msg = s
 	}
 	return fmt.Errorf("precondition for %s: %s", resourceName, msg)
+}
+
+// evaluateChecks evaluates every check block after all resources have settled.
+// Both scoped-data-source errors and failed assertions emit warnings and
+// processing continues, matching Terraform: check blocks are the only custom
+// condition that does not block the operation.
+func (e *Engine) evaluateChecks(ctx context.Context) error {
+	contract.Assertf(e.resmon != nil, "e.resmon cannot be nil")
+	names := slices.Collect(maps.Keys(e.config.Checks))
+	slices.Sort(names)
+	var errs []error
+	for _, name := range names {
+		errs = append(errs, e.evaluateCheck(ctx, name, e.config.Checks[name]))
+	}
+	return errors.Join(errs...)
+}
+
+// evaluateCheck evaluates one check block. Its scoped data source is read into a
+// cloned context so it is visible only to this check's assertions and cannot
+// collide with a top-level data source of the same address.
+func (e *Engine) evaluateCheck(ctx context.Context, name string, check *ast.Check) error {
+	evalCtx := e.evaluator.Context()
+	var errs []error
+	if ds := check.DataResource; ds != nil {
+		evalCtx = evalCtx.Clone()
+		if err := e.readScopedDataSource(ctx, ds, evalCtx); err != nil {
+			// A scoped data source error is masked as a warning, matching TF.
+			errs = append(errs, e.warnf(ctx, "check %q data %q.%q: %s", name, ds.Type, ds.Name, err))
+		}
+	}
+	evaluator := eval.NewEvaluator(evalCtx)
+	for _, assert := range check.Asserts {
+		if msg := evaluateCheckAssert(evaluator, assert); msg != "" {
+			errs = append(errs, e.warnf(ctx, "check %q assertion failed: %s", name, msg))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// readScopedDataSource reads a check's scoped data source into evalCtx, making
+// it available as data.<type>.<name> within that context only.
+func (e *Engine) readScopedDataSource(ctx context.Context, ds *ast.Resource, evalCtx *eval.Context) error {
+	node := &graph.Node{
+		Key:      "data." + ast.ResourceKey(ds.Type, ds.Name),
+		Type:     graph.NodeTypeDataSource,
+		Resource: ds,
+	}
+	return e.processDataSourceInContext(ctx, node, ds, evalCtx)
+}
+
+// warnf emits a best-effort warning diagnostic. A transport failure emitting it
+// must not turn a non-blocking check into a failed operation.
+func (e *Engine) warnf(ctx context.Context, format string, args ...any) error {
+	return e.resmon.LogWarning(ctx, fmt.Sprintf(format, args...))
+}
+
+// evaluateCheckAssert evaluates a single check assertion. It returns the
+// assertion's error message when the condition is known and false (or its
+// condition cannot be evaluated, which Terraform masks as a warning), and ""
+// when the assertion holds or its condition is not yet known.
+func evaluateCheckAssert(evaluator *eval.Evaluator, rule *ast.CheckRule) string {
+	condVal, diags := evaluator.EvaluateExpression(rule.Condition)
+	if diags.HasErrors() {
+		return fmt.Sprintf("could not evaluate condition: %s", diags.Error())
+	}
+	condVal, _ = condVal.Unmark()
+	if !condVal.IsKnown() {
+		return ""
+	}
+	ok, err := conditionResultToBool(condVal)
+	if err != nil {
+		return err.Error()
+	}
+	if ok {
+		return ""
+	}
+	msgVal, msgDiags := evaluator.EvaluateExpression(rule.ErrorMessage)
+	if msgDiags.HasErrors() {
+		return "assertion failed (could not evaluate error message)"
+	}
+	if msg := ctyAsString(msgVal); msg != "" {
+		return msg
+	}
+	return "assertion failed"
 }
 
 // checkPulumiVersion checks if the Pulumi CLI version satisfies the required version range.

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -218,6 +218,7 @@ func (p *HCLProvider) Construct(ctx context.Context, req *pulumirpc.ConstructReq
 	// Create resource monitor adapter
 	resmon := &constructResourceMonitor{
 		client:                  monitor,
+		engine:                  p.host,
 		ctx:                     ctx,
 		parentURN:               req.Parent,
 		componentType:           req.Type,
@@ -311,6 +312,7 @@ func (p *HCLProvider) GetMapping(ctx context.Context, req *pulumirpc.GetMappingR
 // actual component resource registration expected by the Pulumi engine.
 type constructResourceMonitor struct {
 	client          pulumirpc.ResourceMonitorClient
+	engine          pulumirpc.EngineClient
 	ctx             context.Context
 	parentURN       string
 	componentType   string
@@ -573,6 +575,18 @@ func (m *constructResourceMonitor) RegisterResourceHook(
 	ctx context.Context, name string, callback run.ResourceHookFunction, opts run.ResourceHookOptions,
 ) error {
 	return fmt.Errorf("resource hooks are not supported within component constructions")
+}
+
+// LogWarning emits a non-fatal warning diagnostic to the engine.
+func (m *constructResourceMonitor) LogWarning(ctx context.Context, message string) error {
+	if m.engine == nil {
+		return nil
+	}
+	_, err := m.engine.Log(ctx, &pulumirpc.LogRequest{
+		Severity: pulumirpc.LogSeverity_WARNING,
+		Message:  message,
+	})
+	return err
 }
 
 // buildStateDependencies builds the state dependencies map from outputs.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1334,6 +1334,15 @@ func (r *resourceMonitorAdapter) CheckPulumiVersion(ctx context.Context, version
 	return err
 }
 
+// LogWarning emits a non-fatal warning diagnostic to the engine.
+func (r *resourceMonitorAdapter) LogWarning(ctx context.Context, message string) error {
+	_, err := r.engineClient.Log(ctx, &pulumirpc.LogRequest{
+		Severity: pulumirpc.LogSeverity_WARNING,
+		Message:  message,
+	})
+	return err
+}
+
 // Call invokes a method on a resource.
 func (r *resourceMonitorAdapter) Call(
 	ctx context.Context,

--- a/tests/testutil/monitor.go
+++ b/tests/testutil/monitor.go
@@ -30,6 +30,7 @@ type MockResourceMonitor struct {
 	mu                  sync.Mutex
 	RegisteredResources []run.RegisterResourceRequest
 	InvokedFunctions    []run.InvokeRequest
+	Warnings            []string
 	StackOutputs        property.Map
 	stackURN            urn.URN
 	hooks               map[string]registeredHook
@@ -152,6 +153,14 @@ func (m *MockResourceMonitor) Call(ctx context.Context, req run.CallRequest) (*r
 }
 
 func (m *MockResourceMonitor) CheckPulumiVersion(ctx context.Context, versionRange string) error {
+	return nil
+}
+
+// LogWarning records emitted warning diagnostics for assertion in tests.
+func (m *MockResourceMonitor) LogWarning(ctx context.Context, message string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Warnings = append(m.Warnings, message)
 	return nil
 }
 

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -76,6 +76,9 @@ type Provider struct {
 type Result struct {
 	Outputs   map[string]string
 	Resources []apitype.ResourceV3
+	// Output is the combined stdout/stderr of the `pulumi up`, used by tests
+	// that assert on user-visible diagnostics (e.g. check-block warnings).
+	Output string
 }
 
 // Driver wraps a long-lived pulumitest project so callers can run multiple
@@ -177,6 +180,7 @@ func (d *Driver) Apply(t *testing.T, programFiles map[string]string) Result {
 	return Result{
 		Outputs:   outputs,
 		Resources: deployment.Resources,
+		Output:    upResult.StdOut + "\n" + upResult.StdErr,
 	}
 }
 
@@ -219,6 +223,7 @@ func (d *Driver) TryApply(t *testing.T, programFiles map[string]string) (Result,
 	return Result{
 		Outputs:   outputs,
 		Resources: deployment.Resources,
+		Output:    upResult.StdOut + "\n" + upResult.StdErr + "\n" + cap.Logs(),
 	}, upErr
 }
 

--- a/tests/testutil/tfcompat/harness.go
+++ b/tests/testutil/tfcompat/harness.go
@@ -89,6 +89,11 @@ type Stage struct {
 	// ExpectErr, if non-empty, requires both runtimes to fail with an error
 	// containing this substring.
 	ExpectErr string
+	// AssertOutput, if set, runs against each runtime's combined operation
+	// output (so both are held to the same user-visible diagnostics, e.g. a
+	// check-block warning's error_message). Called once per runtime. Only
+	// invoked for a successful StageApply.
+	AssertOutput func(t *testing.T, output string)
 }
 
 // RunCase resolves testdata/cases/<caseName>/ relative to the calling test
@@ -133,6 +138,7 @@ func runCaseStages(t *testing.T, c Case) {
 		wg.Add(2)
 
 		var tfOut map[string]string
+		var tfText string
 		var tfErr error
 		var pulRes pulexec.Result
 		var pulErr error
@@ -144,7 +150,7 @@ func runCaseStages(t *testing.T, c Case) {
 			case StageDestroy:
 				tfErr = tfDriver.Destroy(t, stage.Files, c.Config)
 			default:
-				tfOut, tfErr = tfDriver.TryApply(t, stage.Files, c.Config)
+				tfOut, tfText, tfErr = tfDriver.TryApply(t, stage.Files, c.Config)
 			}
 		}()
 		go func() {
@@ -184,6 +190,10 @@ func runCaseStages(t *testing.T, c Case) {
 		require.NoErrorf(t, pulErr, "stage %d: %s failed unexpectedly", i, pulLabel)
 
 		if stage.Mode == StageApply {
+			if stage.AssertOutput != nil {
+				stage.AssertOutput(t, tfText)
+				stage.AssertOutput(t, pulRes.Output)
+			}
 			lastOK = pulRes
 			lastOKTfOutputs = tfOut
 		}

--- a/tests/testutil/tfcompat/providers/mark.go
+++ b/tests/testutil/tfcompat/providers/mark.go
@@ -1,0 +1,74 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// MarkProvider proves operation ordering with an in-memory mark. Creating
+// `mark_resource` flips the mark; the `mark_probe` data source reports the
+// mark's current value via its computed `constructed` attribute. The mark is a
+// fresh per-provider-instance closure variable, so the concurrently-running TF
+// and Pulumi paths each observe only their own operations.
+//
+// `mark_probe` requires a `token`; passing `mark_resource`'s computed token
+// makes the probe's read defer until the resource is created (the token is
+// unknown until apply), so a check reading `mark_probe.constructed` observes
+// true only when the check runs after the resource is constructed — exactly the
+// ordering a scoped data source must obey.
+func MarkProvider() *schema.Provider {
+	var constructed atomic.Bool
+	noop := func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil }
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"mark_resource": {
+				Schema: map[string]*schema.Schema{
+					// token is computed during Create, so a reference to it is
+					// unknown until apply. A scoped data source that consumes it
+					// must therefore defer its read until after this resource is
+					// created on both runtimes.
+					"token": {Type: schema.TypeString, Computed: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					constructed.Store(true)
+					d.SetId("mark")
+					return diag.FromErr(d.Set("token", "constructed"))
+				},
+				ReadContext:   noop,
+				DeleteContext: noop,
+			},
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"mark_probe": {
+				Schema: map[string]*schema.Schema{
+					"token":       {Type: schema.TypeString, Required: true},
+					"constructed": {Type: schema.TypeBool, Computed: true},
+				},
+				ReadContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("probe")
+					if err := d.Set("constructed", constructed.Load()); err != nil {
+						return diag.FromErr(err)
+					}
+					return nil
+				},
+			},
+		},
+	}
+}

--- a/tests/testutil/tfexec/driver.go
+++ b/tests/testutil/tfexec/driver.go
@@ -114,15 +114,19 @@ func (d *Driver) Dir() string { return d.cwd }
 // files (terraform.tfstate*, .terraform*) are kept across applies.
 func (d *Driver) Apply(t *testing.T, input map[string]string, config map[string]string) map[string]string {
 	t.Helper()
-	outputs, err := d.TryApply(t, input, config)
+	outputs, _, err := d.TryApply(t, input, config)
 	require.NoError(t, err)
 	return outputs
 }
 
 // TryApply is like Apply but returns the error from `tofu apply` instead of
-// failing the test. The outputs map is still parsed from terraform.tfstate when
-// the file exists, so callers can inspect post-failure state.
-func (d *Driver) TryApply(t *testing.T, input map[string]string, config map[string]string) (map[string]string, error) {
+// failing the test. It also returns the apply's combined output so callers can
+// assert on diagnostics (e.g. check-block warnings). The outputs map is still
+// parsed from terraform.tfstate when the file exists, so callers can inspect
+// post-failure state.
+func (d *Driver) TryApply(
+	t *testing.T, input map[string]string, config map[string]string,
+) (map[string]string, string, error) {
 	t.Helper()
 
 	require.NoError(t, removeProgramFiles(d.cwd))
@@ -134,17 +138,18 @@ func (d *Driver) TryApply(t *testing.T, input map[string]string, config map[stri
 	}
 
 	if _, err := d.execTf(t, "init", "-backend=false"); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	applyArgs := append(make([]string, 0, 4+2*len(config)), "apply", "-auto-approve", "-refresh=false")
 	for k, v := range config {
 		applyArgs = append(applyArgs, "-var", k+"="+v)
 	}
-	if _, err := d.execTf(t, applyArgs...); err != nil {
-		return d.tryParseOutputs(), err
+	out, err := d.execTf(t, applyArgs...)
+	if err != nil {
+		return d.tryParseOutputs(), out, err
 	}
-	return d.parseOutputs(t), nil
+	return d.parseOutputs(t), out, nil
 }
 
 // TF refuses to destroy a resource block whose destroy-time provisioner is

--- a/tests/testutil/tfexec/exec.go
+++ b/tests/testutil/tfexec/exec.go
@@ -22,7 +22,8 @@ import (
 	"testing"
 )
 
-func (d *Driver) execTf(t *testing.T, args ...string) ([]byte, error) {
+// execTf runs a tofu subcommand and returns its combined stdout+stderr.
+func (d *Driver) execTf(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	cmd := exec.Command(getTFCommand(), args...) //nolint:gosec // args are test-controlled
 	var stdout, stderr bytes.Buffer
@@ -43,5 +44,5 @@ func (d *Driver) execTf(t *testing.T, args ...string) ([]byte, error) {
 			cmd.String(), stdout.String(), stderr.String())
 		err = fmt.Errorf("%w: %s", err, stderr.String())
 	}
-	return stdout.Bytes(), err
+	return stdout.String() + stderr.String(), err
 }

--- a/tests/tfcompat/l2_check_test.go
+++ b/tests/tfcompat/l2_check_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+	"github.com/stretchr/testify/require"
+)
+
+// TestL2Check_Pass asserts a top-level check block whose assertion holds runs
+// cleanly on both runtimes, does not affect the resource or its output, and
+// surfaces no assertion warning.
+func TestL2Check_Pass(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_check_pass", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{"main.tf": `
+resource "simple_resource" "example" {
+  input_one = "hello"
+}
+
+check "result_check" {
+  assert {
+    condition     = simple_resource.example.result == "hello-false"
+    error_message = "result did not match expected value"
+  }
+}
+
+output "result" {
+  value = simple_resource.example.result
+}
+`},
+			AssertOutput: func(t *testing.T, output string) {
+				require.NotContains(t, output, "result did not match expected value")
+			},
+		}},
+	})
+}
+
+// TestL2Check_FailIsNonBlocking is the key behavior for #234: a failed check
+// assertion reports a warning but does not block the operation. Both runtimes
+// must still apply successfully, produce identical outputs, and surface the
+// assertion's error_message — unlike a precondition, which fails the update.
+func TestL2Check_FailIsNonBlocking(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_check_fail_non_blocking", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{"main.tf": `
+resource "simple_resource" "example" {
+  input_one = "hello"
+}
+
+check "result_check" {
+  assert {
+    condition     = simple_resource.example.result == "this-will-never-match"
+    error_message = "result did not match expected value"
+  }
+}
+
+output "result" {
+  value = simple_resource.example.result
+}
+`},
+			AssertOutput: func(t *testing.T, output string) {
+				require.Contains(t, output, "result did not match expected value")
+			},
+		}},
+	})
+}
+
+// TestL2Check_UnknownDeferred covers TF's "known after apply" handling: at
+// preview the assertion references the resource's computed result, which is
+// unknown, so both runtimes must defer the check without error; at apply the
+// value is known and the assertion holds.
+func TestL2Check_UnknownDeferred(t *testing.T) {
+	t.Parallel()
+	program := map[string]string{"main.tf": `
+resource "simple_resource" "example" {
+  input_one = "hello"
+}
+
+check "result_check" {
+  assert {
+    condition     = simple_resource.example.result == "hello-false"
+    error_message = "result did not match expected value"
+  }
+}
+`}
+	tfcompat.RunCase(t, "l2_check_unknown_deferred", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Files: program, Mode: tfcompat.StagePreview},
+			{Files: program},
+		},
+	})
+}
+
+// TestL2Check_ScopedDataSource proves a check's nested data source is read, is
+// visible to the check's assertion, and — crucially — runs after resources are
+// constructed. Creating mark_resource flips an in-memory mark that the scoped
+// mark_probe data source reports; the assertion requires it to be set, so it
+// holds only if the check ran after the resource was created. No warning is
+// surfaced on either runtime.
+func TestL2Check_ScopedDataSource(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_check_scoped_data_source", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "mark", Factory: providers.MarkProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{"main.tf": `
+resource "mark_resource" "example" {}
+
+check "ordering_check" {
+  data "mark_probe" "probe" {
+    token = mark_resource.example.token
+  }
+
+  assert {
+    condition     = data.mark_probe.probe.constructed
+    error_message = "scoped data source ran before mark_resource was constructed"
+  }
+}
+
+output "token" {
+  value = mark_resource.example.token
+}
+`},
+			AssertOutput: func(t *testing.T, output string) {
+				require.NotContains(t, output, "scoped data source ran before")
+				require.NotContains(t, output, "could not evaluate condition")
+			},
+		}},
+	})
+}
+
+// TestL2Check_MultipleDataSourcesRejected locks in that a check block may
+// declare at most one scoped data source: both runtimes reject a second one.
+func TestL2Check_MultipleDataSourcesRejected(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_check_multiple_data_sources", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{"main.tf": `
+check "two_data" {
+  data "simple_lookup" "a" {
+    query = "a"
+  }
+
+  data "simple_lookup" "b" {
+    query = "b"
+  }
+
+  assert {
+    condition     = data.simple_lookup.a.prefix_result == "-a"
+    error_message = "mismatch"
+  }
+}
+`},
+			ExpectErr: "Multiple data resource blocks",
+		}},
+	})
+}


### PR DESCRIPTION
This PR adds full support for OpenTofu's top level `check` blocks. We support both asserts and `data` blocks within the `check`s.

Fixes #234