### PR TITLE
Omit null-valued root outputs from stack outputs

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-232.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-232.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Omit `null`-valued root outputs from stack outputs
+time: 2026-06-09T09:07:04Z
+custom:
+    Component: runtime
+    PR: "232"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3068,6 +3068,12 @@ func (e *Engine) processOutput(_ context.Context, name string, output *ast.Outpu
 		return fmt.Errorf("evaluating output value: %s", diags.Error())
 	}
 
+	// Root outputs that evaluate to null are removed entirely; nothing can
+	// reference a root output, so omitting it is always safe.
+	if val.IsNull() {
+		return nil
+	}
+
 	// Convert to PropertyValue
 	pv, err := transform.CtyToPropertyValue(val)
 	if err != nil {

--- a/tests/tfcompat/l1_null_output_test.go
+++ b/tests/tfcompat/l1_null_output_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1NullOutput exercises a root output that evaluates to null. OpenTofu
+// removes null root outputs from state entirely, so they never appear in the
+// structured outputs. pulumi-hcl previously emitted the output with a null
+// value, diverging from OpenTofu.
+func TestL1NullOutput(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_null_output", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_null_output/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_null_output/main.tf
@@ -1,0 +1,13 @@
+output "present" {
+  value = "hello"
+}
+
+output "absent_when_null" {
+  value = null
+}
+
+# Only wholly-null outputs are dropped: an output whose value merely contains a
+# null must still be emitted, with the inner null preserved.
+output "object_with_inner_null" {
+  value = { a = "x", b = null }
+}


### PR DESCRIPTION
## Problem

A Terraform `output` whose value evaluates to `null` was emitted in the stack outputs with a `null` value, whereas OpenTofu removes null-valued root outputs from state entirely. A config with one string output and one `null` output is enough to show it:

```hcl
output "present"          { value = "hello" }
output "absent_when_null" { value = null }
```

OpenTofu's `tofu output -json` omits `absent_when_null`; pulumi-hcl included it as `null`.

## Fix

`processOutput` now drops root outputs that evaluate to null before they reach the stack outputs map. This matches OpenTofu's `node_output.go` `setValue`, which removes a root output when `n.Addr.Module.IsRoot() && val.IsNull()` — safe because nothing can reference a root output. Child-module outputs keep their null values (they remain referenceable) and are unaffected, since this path handles root outputs only.

Only *wholly*-null outputs are dropped, matching OpenTofu's top-level `val.IsNull()` check: an output whose value merely contains a null (e.g. `{ a = "x", b = null }`) is still emitted with the inner null preserved.

## Test

A tfcompat case (`l1_null_output`) locks in both behaviors against OpenTofu: the null output is omitted while the string is kept, and an object containing a null is emitted with the inner null intact. Verified it fails on `master` (`stack outputs differ between tofu apply and pulumi up`) and passes with the fix.

Closes https://github.com/pulumi-labs/pulumi-hcl/issues/232