### PR TITLE
Don't carry an unused `lookup` default's sensitivity onto a present value

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-252.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-252.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: '`lookup` no longer treats a found value as sensitive because of an unused `default`'
+time: 2026-06-09T09:44:47.000000+00:00
+custom:
+    Component: runtime
+    PR: "252"

--- a/.claude/skills/find-tfcompat-bug/SKILL.md
+++ b/.claude/skills/find-tfcompat-bug/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: find-tfcompat-bug
-description: Find, prove, fix, and ship a single runtime divergence between OpenTofu and pulumi-hcl. Use when the user asks to "find another bug/mismatch", find a tfcompat mismatch, or hunt for behavior that differs from Terraform/OpenTofu.
+description: Find and prove a single runtime divergence between OpenTofu and pulumi-hcl with a failing tfcompat test. Use when the user asks to "find another bug/mismatch", find a tfcompat mismatch, or hunt for behavior that differs from Terraform/OpenTofu.
 ---
 
-# Find the next tfcompat bug
+# Find & prove the next tfcompat bug
 
-Hunt one genuine runtime divergence between OpenTofu (`tofu apply`) and pulumi-hcl,
-prove it with a failing `tfcompat` test, fix the pulumi-hcl runtime to faithfully match
-OpenTofu, verify failing-before / passing-after, and ship it as its own PR.
+Hunt one genuine runtime divergence between OpenTofu (`tofu apply`) and pulumi-hcl, and
+**prove it with a failing `tfcompat` test**. That is the whole job of this skill: find a
+real divergence and leave behind a test that fails on `master` for the right reason. You
+**stop at the proven failure** — you do not fix it. To turn a proven failure into a
+shipped fix, hand off to the [`fix-tfcompat-bug`](../fix-tfcompat-bug/SKILL.md) skill.
 
 The divergence can be anywhere the two runtimes can disagree — an expression/function
 result (the L1 seam), or resource, module, provider, or lifecycle behavior (the L2
@@ -22,8 +24,7 @@ bug to chase here: no OpenTofu config depends on it, and tightening pulumi-hcl t
 reject it removes capability without helping any migration. If the only divergence you can
 find is pulumi-hcl being more permissive than OpenTofu, discard it and keep hunting.
 
-Each invocation produces **exactly one** bug fix on its **own branch off master**
-with its own changelog entry and PR. Do not stack fixes.
+Each invocation produces **exactly one** proven failing test. Don't bundle several.
 
 ## Ground rules (from CLAUDE.md — do not violate)
 
@@ -32,11 +33,9 @@ with its own changelog entry and PR. Do not stack fixes.
   probe — never from memory. A backwards memory of token semantics has already burned
   us once.
 - Faithfully match OpenTofu. The goal is parity, not "better". No hacks.
-- `git add` specific files only, never `git add .`. Don't touch staging the user left.
-- Don't self-attribute as commit co-author. Complete punctuation in commit bodies.
-- Commit / push / open PR only when the user asks (the find+fix+verify is automatic;
-  shipping waits for the modeled flow below, which the user has standing-approved for
-  this loop — confirm if unsure).
+- The deliverable is new test files only — you ADD `tests/tfcompat/` files. Don't edit
+  runtime source under `pkg/` (that's the fixing skill's job), and don't touch staging the
+  user left.
 
 ## Source-of-truth locations
 
@@ -143,86 +142,24 @@ disk fixture can't express — an `ExpectErr` assertion, or a multi-stage
 preview/destroy/re-apply sequence. A normal output-comparison case (even one with several
 files) belongs on disk, not inline.
 
-Confirm the bug is real **on master before the fix**:
+Confirm the bug is real **on master**:
 
 ```bash
 PATH="$PWD/bin:$PATH" go test ./tests/tfcompat/ -run 'Test(L1|L2)<Name>' -count=1 -v
 ```
 
-It must FAIL, and the failure must show the genuine OpenTofu-vs-pulumi difference. If it
-passes, the bug isn't real (or isn't observable) — go back to Step 2.
+It must FAIL, and the failure must show the genuine OpenTofu-vs-pulumi difference (a real
+output diff or a matched `ExpectErr`), not a harness/provider/fixture error. If it passes,
+the bug isn't real (or isn't observable) — go back to Step 1.
 
-## Step 3 — Fix the divergence
+## Done — hand off
 
-Edit the pulumi-hcl runtime to match OpenTofu. For a function, fix the `Impl` in
-`pkg/hcl/eval/functions.go` — and prefer delegating to the cty `stdlib.*Func` when
-OpenTofu itself binds that stdlib function (check the binding map); several bugs were
-hand-rolled reimplementations that should have been `stdlib.IndentFunc` /
-`stdlib.FormatDateFunc`. For an L2 bug the fix lives elsewhere under `pkg/hcl/`. Fix
-minimally and faithfully; run `go mod tidy` if you add a dependency.
+You now have a proven failing tfcompat test, left **uncommitted** in the working tree.
+Report:
 
-Add unit coverage next to the code you changed. For functions, add cases to
-`pkg/hcl/eval/functions_test.go`; note `evalExpr` calls `t.Fatalf` on diagnostics, so
-**error-path** cases must call `<fn>.Call(...)` directly rather than via `evalExpr`.
+1. **The divergence** — one line: what OpenTofu does vs. what pulumi-hcl does.
+2. **The test** — name + the file paths you created.
+3. **The failure output** — the captured diff/error proving it fails for the right reason.
 
-## Step 4 — Verify failing-before / passing-after
-
-```bash
-make build
-PATH="$PWD/bin:$PATH" go test ./pkg/hcl/... -run '<UnitTest>' -count=1 -v
-PATH="$PWD/bin:$PATH" go test ./tests/tfcompat/ -run 'Test(L1|L2)<Name>' -count=1 -v
-```
-
-Both must now PASS (with `-count=1` — the rebuilt binary won't be picked up otherwise).
-
-## Step 5 — Sweep for related divergences before shipping
-
-**Before you open the PR, check whether the same root cause produces a sibling
-bug, and fix it in the same PR.** A divergence almost never lives alone: the same
-helper, library choice, or code path usually backs a *sibling* operation, and
-shipping only one half leaves the matching bug behind for the next migration to
-hit.
-
-Look in particular for:
-
-- **The inverse operation.** encode ↔ decode, parse ↔ format, marshal ↔
-  unmarshal, get ↔ set. Fixing `yamlencode` (hand-rolled on `yaml.v3` instead of
-  go-cty-yaml) left an *identical* `yamldecode` bug — same wrong library, mirror
-  symptom — that had to ship as a separate follow-up. Don't make that mistake:
-  when you fix one direction, probe the other in the same session.
-- **Sibling functions sharing the impl.** Functions bound to the same hand-rolled
-  helper or the same family (`base64*`, `file*`, `cidr*`, the `to*` converters).
-  Grep for other call sites of any helper you touched.
-
-For each candidate, run a quick `tofu` probe against the equivalent pulumi-hcl
-result. If it also diverges in the migration-affecting direction, fold the fix
-into this PR and extend the one tfcompat case to cover both (one combined
-`l1_<family>` case is fine — e.g. `l1_yaml` exercising both `yamlencode` and
-`yamldecode`). If a sibling is genuinely out of scope, say so explicitly in the
-PR body rather than leaving it silently unfixed.
-
-## Step 6 — Changelog + branch + PR
-
-Consult the submit-pr skill for opening a PR.
-
-When writing your PR & changelog:
-
-- Keep the changelog `body` **terse** — a short phrase naming the change from the
-  user's point of view (e.g. ``Coerce a `variable` `default` to its declared `type` ``
-  or ``Add `base64gunzip`, `urldecode` and `cidrcontains` ``), not a sentence explaining
-  it, and with **no trailing punctuation**. Keep the `<thing>` (function/feature name)
-  in backticks.
-- The changelog body must **not mention OpenTofu** (no "match OpenTofu", "like
-  OpenTofu", "instead of erroring", or other comparison framing). Parity with OpenTofu
-  is the whole project's premise, so stating it in the changelog is noise — just
-  describe what changed. The OpenTofu-vs-pulumi divergence narrative belongs in the **PR
-  description**, where you do say "OpenTofu" (never "Terraform").
-- **Code comments must not mention OpenTofu either.** Do not add comments saying the
-  code "matches OpenTofu" / "mirrors OpenTofu's X" — that applies to the entire codebase
-  and restates the premise. A comment should explain something the code itself doesn't
-  (e.g. *why* a helper is reimplemented rather than imported); if the only thing a
-  comment would say is "this matches OpenTofu," delete it.
-
-Then, on its **own branch off master** (not stacked on a prior fix):
-
-Report the divergence, the fix, the verification results, and the PR URL.
+To fix the divergence and ship it, continue with the
+[`fix-tfcompat-bug`](../fix-tfcompat-bug/SKILL.md) skill. **Do not fix it here.**

--- a/.claude/skills/fix-tfcompat-bug/SKILL.md
+++ b/.claude/skills/fix-tfcompat-bug/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: fix-tfcompat-bug
+description: Fix a proven OpenTofu-vs-pulumi-hcl divergence and ship it as its own PR. Use after find-tfcompat-bug has produced a failing tfcompat test — fix the runtime to match OpenTofu, sweep for the sibling bug, add unit coverage, and open a PR. Use when asked to fix/ship a known tfcompat mismatch.
+---
+
+# Fix & ship a proven tfcompat bug
+
+This skill starts from a **proven failing tfcompat test** — a divergence already found and
+captured by the [`find-tfcompat-bug`](../find-tfcompat-bug/SKILL.md) skill, with a
+`tests/tfcompat/<l1|l2>_<name>_test.go` + `testdata/cases/<name>/` fixture that **fails on
+`master` for the right reason** (a genuine OpenTofu-vs-pulumi diff or matched `ExpectErr`,
+not a harness error). Edit the pulumi-hcl runtime to faithfully match OpenTofu, verify
+failing-before / passing-after, sweep for the sibling bug, and ship it as its own PR.
+
+If you do **not** yet have such a failing test, stop and run `find-tfcompat-bug` first —
+do not invent a fix without a proven failure.
+
+This skill ships **exactly one** bug fix on its **own branch off master** with its own
+changelog entry and PR. Do not stack fixes.
+
+## Ground rules (from CLAUDE.md — do not violate)
+
+- **Confirm assumptions with research. Don't guess.** Verify every behavioral claim
+  against OpenTofu source, the cty stdlib source, the docs, or an empirical `tofu` probe.
+- Faithfully match OpenTofu. The goal is parity, not "better". No hacks.
+- `git add` specific files only, never `git add .`. Don't touch staging the user left.
+- Don't self-attribute as commit co-author. Complete punctuation in commit bodies.
+- Commit / push / open PR only when the user asks (the find+fix+verify is automatic;
+  shipping waits for the modeled flow below, which the user has standing-approved for
+  this loop — confirm if unsure).
+
+## Source-of-truth locations
+
+The Go module cache root is !`go env GOPATH`/pkg/mod.
+
+- OpenTofu funcs: !`go env GOPATH`/pkg/mod/github.com/pulumi/opentofu@*/lang/funcs/*.go
+- OpenTofu binding map: .../opentofu@*/lang/functions.go
+- cty stdlib: !`go env GOPATH`/pkg/mod/github.com/zclconf/go-cty@*/cty/function/stdlib/
+- pulumi-hcl runtime: `pkg/hcl/` (expression eval, resource / module / provider handling)
+- pulumi-hcl function registry: `pkg/hcl/eval/functions.go`
+- Function unit tests: `pkg/hcl/eval/functions_test.go`
+
+## Step 1 — Fix the divergence
+
+Edit the pulumi-hcl runtime to match OpenTofu. For a function, fix the `Impl` in
+`pkg/hcl/eval/functions.go` — and prefer delegating to the cty `stdlib.*Func` when
+OpenTofu itself binds that stdlib function (check the binding map); several bugs were
+hand-rolled reimplementations that should have been `stdlib.IndentFunc` /
+`stdlib.FormatDateFunc`. For an L2 bug the fix lives elsewhere under `pkg/hcl/`. Fix
+minimally and faithfully; run `go mod tidy` if you add a dependency.
+
+Add unit coverage next to the code you changed. For functions, add cases to
+`pkg/hcl/eval/functions_test.go`; note `evalExpr` calls `t.Fatalf` on diagnostics, so
+**error-path** cases must call `<fn>.Call(...)` directly rather than via `evalExpr`.
+
+## Step 2 — Verify failing-before / passing-after
+
+```bash
+make build
+PATH="$PWD/bin:$PATH" go test ./pkg/hcl/... -run '<UnitTest>' -count=1 -v
+PATH="$PWD/bin:$PATH" go test ./tests/tfcompat/ -run 'Test(L1|L2)<Name>' -count=1 -v
+```
+
+Both must now PASS (with `-count=1` — the rebuilt binary won't be picked up otherwise).
+The tfcompat case that failed on `master` must now pass against your fix.
+
+## Step 3 — Sweep for related divergences before shipping
+
+**Before you open the PR, check whether the same root cause produces a sibling
+bug, and fix it in the same PR.** A divergence almost never lives alone: the same
+helper, library choice, or code path usually backs a *sibling* operation, and
+shipping only one half leaves the matching bug behind for the next migration to
+hit.
+
+Look in particular for:
+
+- **The inverse operation.** encode ↔ decode, parse ↔ format, marshal ↔
+  unmarshal, get ↔ set. Fixing `yamlencode` (hand-rolled on `yaml.v3` instead of
+  go-cty-yaml) left an *identical* `yamldecode` bug — same wrong library, mirror
+  symptom — that had to ship as a separate follow-up. Don't make that mistake:
+  when you fix one direction, probe the other in the same session.
+- **Sibling functions sharing the impl.** Functions bound to the same hand-rolled
+  helper or the same family (`base64*`, `file*`, `cidr*`, the `to*` converters).
+  Grep for other call sites of any helper you touched.
+
+For each candidate, run a quick `tofu` probe against the equivalent pulumi-hcl
+result. If it also diverges in the migration-affecting direction, fold the fix
+into this PR and extend the one tfcompat case to cover both (one combined
+`l1_<family>` case is fine — e.g. `l1_yaml` exercising both `yamlencode` and
+`yamldecode`). If a sibling is genuinely out of scope, say so explicitly in the
+PR body rather than leaving it silently unfixed.
+
+## Step 4 — Changelog + branch + PR
+
+Consult the submit-pr skill for opening a PR.
+
+When writing your PR & changelog:
+
+- Keep the changelog `body` **terse** — a short phrase naming the change from the
+  user's point of view (e.g. ``Coerce a `variable` `default` to its declared `type` ``
+  or ``Add `base64gunzip`, `urldecode` and `cidrcontains` ``), not a sentence explaining
+  it, and with **no trailing punctuation**. Keep the `<thing>` (function/feature name)
+  in backticks.
+- The changelog body must **not mention OpenTofu** (no "match OpenTofu", "like
+  OpenTofu", "instead of erroring", or other comparison framing). Parity with OpenTofu
+  is the whole project's premise, so stating it in the changelog is noise — just
+  describe what changed. The OpenTofu-vs-pulumi divergence narrative belongs in the **PR
+  description**, where you do say "OpenTofu" (never "Terraform").
+- **Code comments must not mention OpenTofu either.** Do not add comments saying the
+  code "matches OpenTofu" / "mirrors OpenTofu's X" — that applies to the entire codebase
+  and restates the premise. A comment should explain something the code itself doesn't
+  (e.g. *why* a helper is reimplemented rather than imported); if the only thing a
+  comment would say is "this matches OpenTofu," delete it.
+
+Then, on its **own branch off master** (not stacked on a prior fix):
+
+Report the divergence, the fix, the verification results, and the PR URL.

--- a/.claude/skills/swarm-tfcompat-bugs/SKILL.md
+++ b/.claude/skills/swarm-tfcompat-bugs/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: swarm-tfcompat-bugs
+description: Run a swarm of parallel agents that each hunt for one OpenTofu-vs-pulumi-hcl runtime divergence and prove it with a failing tfcompat test. Use when the user asks to "spin up N agents", "run a swarm", or hunt for a tfcompat mismatch in parallel.
+---
+
+# Swarm: hunt a tfcompat divergence in parallel
+
+Dispatch N agents that each independently hunt a **different** OpenTofu-vs-pulumi-hcl
+runtime divergence and **prove it with a single failing `tfcompat` test**. The goal of a
+swarm run is to surface **one genuine failure** and report it back to the user — not to
+fix anything, not to open PRs. You (the lead) own **de-confliction** (every agent works a
+disjoint area so no two chase the same divergence) and **adjudication** (deciding which
+returned candidate is a real, in-direction failure worth reporting).
+
+Each agent runs the [`find-tfcompat-bug`](../find-tfcompat-bug/SKILL.md) skill — which is
+itself entirely find-and-prove and stops at a failing test. Agents **must not** continue
+into the [`fix-tfcompat-bug`](../fix-tfcompat-bug/SKILL.md) skill (fix, sweep, changelog,
+branch, PR). Read `find-tfcompat-bug` first for the find-and-prove technique; this one adds
+the swarm orchestration and de-confliction around it.
+
+## The deliverable
+
+A swarm run is done when **one** agent has produced a **genuine, in-direction failing
+tfcompat test** and you have confirmed it. Report back to the user:
+
+1. **The divergence** — one line: what OpenTofu does vs. what pulumi-hcl does.
+2. **The failing test** — the `tests/tfcompat/<l1|l2>_<name>_test.go` +
+   `testdata/cases/<name>/` files the agent created, left in the working tree (uncommitted).
+3. **The failure output** — the actual diff/error from running the test on `master`,
+   proving it fails for the right reason (real OpenTofu-vs-pulumi difference, not a harness
+   error).
+
+Do **not** fix the divergence, write a changelog, branch, or open a PR. Stop at a proven,
+reported failure. The user drives what happens next.
+
+## The lead's job
+
+1. **Partition the search space into disjoint domains — one per agent.** This is what
+   prevents collisions. Never spawn N agents with the same instructions. Good seams to
+   split along (mix and match to reach N):
+   - L1 function families: collection funcs; string funcs; encoding funcs; crypto/hash
+     funcs; cidr/IP funcs; date/time + numeric funcs; the `to*` type converters +
+     `can`/`try`/`type`; the sensitivity-marks seam (`sensitive`/`nonsensitive`/
+     `issensitive`); file-content/file-hash/`path.*` resolution.
+   - L2 seams: resource/module/provider plumbing; `count`/`for_each`/`dynamic`
+     meta-arguments; lifecycle (`prevent_destroy`/`ignore_changes`/`replace_triggered_by`/
+     `create_before_destroy`); pre/postcondition + variable `validation`; preview/destroy
+     lifecycle; sensitivity propagation through state.
+   - The HCL expression-eval seam: for-expressions, splat, conditionals, string templates/
+     heredocs/trim markers, index/attr access, `==`/`!=` coercion. (Note: this seam
+     delegates to upstream `hclsyntax`/`cty` and has historically been clean — assign it
+     only when you have spare agents.)
+
+2. **Build one shared exclusion list and put it in every agent's prompt.** It must name
+   (a) every bug already fixed/shipped, and (b) seams already proven clean. Without this,
+   agents re-discover already-fixed bugs and report a "failure" that is actually already
+   handled. Re-derive it each run from `git log`, the open PRs (`gh pr list`), and the
+   existing `tests/tfcompat/testdata/cases/` directory.
+
+3. **Tell each agent the other agents' domains** ("stay out of these") as a second
+   guard against overlap.
+
+4. **Spawn all N in a single message**, each with `subagent_type: general-purpose` and
+   `run_in_background: true` (so they run truly concurrently and notify you on
+   completion). Give each a unique `name` (e.g. `hunter-<domain>`). Worktree isolation is
+   **not** needed — agents only *add* new test files under `tests/tfcompat/` and don't
+   edit shared source, so they can share the working tree. (If you do hand out worktrees,
+   remember the winning test files live in that worktree, not the main tree — collect them.)
+
+5. **Collect candidates as they land and adjudicate.** For each returned candidate,
+   confirm it is a **real, in-direction** failure before declaring victory (see "Vetting"
+   below). The first candidate that passes vetting is the deliverable — report it and wind
+   the swarm down.
+
+6. **A negative is a success, not a failure.** An agent that returns an honest "no
+   in-direction divergence in my domain" has done its job — do not pressure it to invent
+   one. A fabricated or out-of-direction "failure" is worse than a clean negative.
+
+7. **Keep hunting only until you have ONE confirmed failure.** This is a single-failure
+   hunt, not a steady-state swarm. You do **not** need to maintain headcount at N, spawn
+   replacements indefinitely, or monitor any PRs. Once one candidate is vetted and
+   reported, stop spawning and let remaining agents finish or wind them down. If **all**
+   agents return negatives, you may spawn a fresh wave over still-unclaimed domains (with
+   an updated exclusion list) — but if the search space is genuinely picked over, say so
+   rather than spawning into exhausted ground.
+
+## What every agent prompt must contain
+
+- "Read and follow `.claude/skills/find-tfcompat-bug/SKILL.md` — find a candidate
+  divergence and prove it with a failing test. **Stop at the proven failure. Do NOT
+  continue into `fix-tfcompat-bug`: no fix, no changelog, no branch, no PR.**" Plus the
+  global `CLAUDE.md` rules
+  (research don't guess; faithfully verify against OpenTofu source/docs/probe; no hacks).
+- **Its assigned domain** (hunt only here) and **the other agents' domains** (stay out).
+- **The shared exclusion list.**
+- **The direction rule, restated:** a bug is OpenTofu-succeeds / pulumi-hcl-errors-or-
+  differs. pulumi-being-*more-lenient* is NOT the bug — discard it and keep hunting.
+- **Build + run:** `make build`, then run the candidate test with the freshly built
+  binaries on PATH and `-count=1`:
+  `PATH="$PWD/bin:$PATH" go test ./tests/tfcompat/ -run 'Test(L1|L2)<Name>' -count=1 -v`.
+  The test **must FAIL on master**, and the failure must show the genuine
+  OpenTofu-vs-pulumi difference (a real output diff or matching `ExpectErr`), not a
+  harness/setup error.
+- **The deliverable:** exactly ONE proven failing tfcompat case — the new
+  `_test.go` + `testdata/cases/<name>/` files left **uncommitted** in the working tree,
+  plus the captured failure output. Honest negative if the domain is genuinely clean.
+- **The required final message:** (1) one-line divergence (OpenTofu vs pulumi-hcl),
+  (2) the test name + paths of the files it created, (3) the captured failing-test output
+  proving it fails for the right reason — or an honest negative naming what it probed.
+
+## Vetting a returned candidate (the lead's adjudication)
+
+Before reporting a candidate as *the* failure, confirm:
+
+- [ ] **It reproduces.** Re-run the agent's test yourself on `master` with freshly built
+      binaries and `-count=1`. It must fail.
+- [ ] **It fails for the right reason.** The failure is a genuine OpenTofu-vs-pulumi
+      output diff or a matched `ExpectErr` — not a missing provider, a fixture typo, a
+      panic in the harness, or an unrelated build error.
+- [ ] **The direction is right.** OpenTofu succeeds (or produces value X); pulumi-hcl
+      errors or produces a different value. pulumi-hcl being *more lenient* than OpenTofu
+      is **not** the bug — reject it and keep looking.
+- [ ] **It isn't on the exclusion list.** Not an already-shipped fix or a known-clean seam
+      re-surfaced.
+
+A candidate that fails any check is sent back (or the agent stands down); keep adjudicating
+incoming candidates until one passes all four.
+
+## De-confliction checklist (the one thing that makes a swarm work)
+
+- [ ] N agents → N disjoint domains, no two overlapping.
+- [ ] Shared exclusion list names every shipped/claimed/clean area.
+- [ ] Each agent told the others' domains.
+- [ ] All spawned in one message: `general-purpose`, background, unique names.
+- [ ] Each agent stops at a **proven failing test** — no fix, no changelog, no PR.
+- [ ] Lead vets each candidate (reproduces / right reason / right direction / not excluded)
+      before reporting it as the single deliverable.

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -478,8 +478,8 @@ var listFunc = function.New(&function.Spec{
 
 var lookupFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
-		{Name: "map", Type: cty.DynamicPseudoType},
-		{Name: "key", Type: cty.String},
+		{Name: "map", Type: cty.DynamicPseudoType, AllowMarked: true},
+		{Name: "key", Type: cty.String, AllowMarked: true},
 	},
 	VarParam: &function.Parameter{
 		Name:             "default",
@@ -487,6 +487,7 @@ var lookupFunc = function.New(&function.Spec{
 		AllowNull:        true,
 		AllowUnknown:     true,
 		AllowDynamicType: true,
+		AllowMarked:      true,
 	},
 	Type: func(args []cty.Value) (cty.Type, error) {
 		ty := args[0].Type()
@@ -495,7 +496,8 @@ var lookupFunc = function.New(&function.Spec{
 			if !args[1].IsKnown() {
 				return cty.DynamicPseudoType, nil
 			}
-			key := args[1].AsString()
+			keyVal, _ := args[1].Unmark()
+			key := keyVal.AsString()
 			if ty.HasAttribute(key) {
 				return args[0].GetAttr(key).Type(), nil
 			} else if len(args) == 3 {
@@ -517,27 +519,42 @@ var lookupFunc = function.New(&function.Spec{
 		}
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		m := args[0]
-		key := args[1].AsString()
+		// The collection and key marks always propagate to the result, but the
+		// default's must not: when the key is present the default is never
+		// consulted, so a sensitive default leaves a present value unmarked.
+		// The default's marks are reapplied only when the default is returned.
+		var marks []cty.ValueMarks
+
+		mapVar, mapMarks := args[0].Unmark()
+		marks = append(marks, mapMarks)
+
+		keyVal, keyMarks := args[1].Unmark()
+		if len(keyMarks) > 0 {
+			marks = append(marks, keyMarks)
+		}
+		key := keyVal.AsString()
 
 		switch {
-		case m.Type().IsMapType():
+		case mapVar.Type().IsMapType():
 			idx := cty.StringVal(key)
-			if m.HasIndex(idx).True() {
-				return m.Index(idx), nil
+			if mapVar.HasIndex(idx).True() {
+				return mapVar.Index(idx).WithMarks(marks...), nil
 			}
-		case m.Type().IsObjectType():
-			if m.Type().HasAttribute(key) {
-				return m.GetAttr(key), nil
+		case mapVar.Type().IsObjectType():
+			if mapVar.Type().HasAttribute(key) {
+				return mapVar.GetAttr(key).WithMarks(marks...), nil
 			}
 		}
 
-		// The key is absent. Return the default converted to the return type,
-		// matching OpenTofu: for a map this is the element type, so a default
-		// of a different type is coerced (e.g. 30 into a map(string) yields the
-		// string "30").
+		// The key is absent: return the default coerced to the return type (for
+		// a map, the element type, so e.g. 30 becomes "30" in a map(string)),
+		// carrying the collection/key marks alongside the default's own.
 		if len(args) == 3 {
-			return convert.Convert(args[2], retType)
+			defaultVal, err := convert.Convert(args[2], retType)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			return defaultVal.WithMarks(marks...), nil
 		}
 
 		return cty.NilVal, fmt.Errorf("key %q not found", key)

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -207,6 +207,14 @@ func TestCollectionFunctions(t *testing.T) {
 		{"lookup map default bool to string", `lookup(tomap({a = "x"}), "missing", true)`, cty.StringVal("true")},
 		// On the object path the default keeps its own type.
 		{"lookup object default unconverted", `lookup({a = "x"}, "missing", 30)`, cty.NumberIntVal(30)},
+		// A present key never consults the default, so a sensitive default
+		// leaves the returned value unmarked.
+		{"lookup sensitive default unused", `lookup({a = "x"}, "a", sensitive("d"))`, cty.StringVal("x")},
+		// A returned default carries its own sensitivity.
+		{"lookup sensitive default used", `lookup({a = "x"}, "b", sensitive("d"))`, cty.StringVal("d").Mark(SensitiveMark)},
+		// Collection and key sensitivity always propagate to the result.
+		{"lookup sensitive element", `lookup({a = sensitive("x")}, "a", "d")`, cty.StringVal("x").Mark(SensitiveMark)},
+		{"lookup sensitive key", `lookup({a = "x"}, sensitive("a"), "d")`, cty.StringVal("x").Mark(SensitiveMark)},
 
 		// contains
 		{"contains true", `contains(["a", "b"], "a")`, cty.BoolVal(true)},

--- a/tests/tfcompat/testdata/cases/l1_lookup/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_lookup/main.tf
@@ -13,3 +13,15 @@ output "results" {
     bool_default_into_string_map   = lookup(tomap({ a = "x" }), "missing", true)
   }
 }
+
+# `lookup` carries the sensitivity of only the arguments that contribute to the
+# result. When the key is present the `default` is never consulted, so a
+# sensitive `default` leaves the result non-sensitive; when the key is absent the
+# default is returned and its sensitivity does propagate. `issensitive` exposes
+# the mark as a plain bool, observable in outputs without leaking the value.
+output "sensitivity" {
+  value = {
+    unused_default_marked = issensitive(lookup({ a = "x" }, "a", sensitive("d")))
+    used_default_marked   = issensitive(lookup({ a = "x" }, "b", sensitive("d")))
+  }
+}


### PR DESCRIPTION
When `lookup(map, key, default)` finds `key` in the collection it returns the present value and never consults `default`. OpenTofu therefore does **not** apply a sensitive `default` to a found value:

```hcl
output "x" {
  value = issensitive(lookup({ a = "x" }, "a", sensitive("d")))
}
# OpenTofu: false   pulumi-hcl (before): true
```

pulumi-hcl’s hand-rolled `lookupFunc` declared its parameters without `AllowMarked`, so cty’s generic `function.Call` unioned the marks of *every* argument — including the unused `default` — onto the result. A present value came back sensitive whenever the (unused) default was sensitive, which would force `sensitive = true` or block the value in non-sensitive contexts that OpenTofu allows.

## Fix

Mark the `map`, `key`, and `default` parameters `AllowMarked` and manage marks explicitly in the `Impl`, mirroring OpenTofu’s `LookupFunc`: the collection and key marks always propagate to the result, while the default’s own marks are reapplied only when the default is actually returned.

## Tests

- `TestL1Lookup` (`testdata/cases/l1_lookup/main.tf`) gains a `sensitivity` output covering both directions — an **unused** sensitive default leaves a present value non-sensitive (`false`), and a **used** (returned) sensitive default stays sensitive (`true`). The unused-default check failed on `master`, both pass here.
- Unit cases in `TestCollectionFunctions` covering all four mark paths: unused sensitive default (unmarked result), returned sensitive default (marked), sensitive map element (marked), sensitive key (marked).

## Sweep

The other mark paths (sensitive collection, sensitive key, sensitive returned default) already matched because cty’s generic propagation coincides with the correct behavior there — the unused-default case was the only in-direction divergence. One sibling is intentionally **out of scope**: when a key is missing and no default is given, the not-found error embeds the raw key, where OpenTofu redacts a sensitive key. That is an error-only path on input invalid in both runtimes (a working migration never hits it), so it is not the migration-affecting direction and is left for a separate change.

## Also included

The tfcompat hunting skills this fix was found with, per request: `find-tfcompat-bug` now stops at a proven failing test, the new `fix-tfcompat-bug` owns fix-and-ship, and `swarm-tfcompat-bugs` is refocused on surfacing a single proven failure rather than opening PRs.