### PR TITLE
Pre-install `terraform-provider` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       # terraform_remote_state lowers to the pulumi-terraform getLocalReference
       # invoke; the tfcompat harness disables plugin acquisition, so pre-install it.
       - run: pulumi plugin install resource terraform 6.0.2
+      - run: pulumi plugin install resource terraform-provider 1.1.3
       - run: make test_cover
         env:
           # Enable the live terraform_remote_state `remote` backend test.


### PR DESCRIPTION
This is used in smoke tests, we should include it by default to preempt avoid test flakes.