### PR TITLE
Refuse to render a sensitive `error_message` in custom conditions

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-254.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-254.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Refuse to render a sensitive `error_message` in custom conditions
+time: 2026-06-09T11:05:30.000000+00:00
+custom:
+    Component: runtime
+    PR: "254"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -713,13 +713,12 @@ func (e *Engine) processVariable(_ context.Context, node *graph.Node) error {
 		}
 
 		if !condOK {
-			// Get error message
 			errMsgVal, diags := e.evaluator.EvaluateExpression(validation.ErrorMessage)
-			var errMsg string
-			if diags.HasErrors() || errMsgVal.Type() != cty.String {
-				errMsg = "validation failed"
-			} else {
-				errMsg = errMsgVal.AsString()
+			errMsg := "validation failed"
+			if !diags.HasErrors() {
+				if s := renderErrorMessage(errMsgVal); s != "" {
+					errMsg = s
+				}
 			}
 			return fmt.Errorf("validation failed for variable %q: %s", varName, errMsg)
 		}
@@ -3281,7 +3280,7 @@ func evaluatePostcondition(
 			index, resourceName, msgDiags.Error())
 	}
 	msg := "postcondition check failed"
-	if s := ctyAsString(msgVal); s != "" {
+	if s := renderErrorMessage(msgVal); s != "" {
 		msg = s
 	}
 	return fmt.Errorf("postcondition for %s: %s", resourceName, msg)
@@ -3327,7 +3326,7 @@ func evaluatePrecondition(rule *ast.CheckRule, hclCtx *hcl.EvalContext, index in
 			index, resourceName, msgDiags.Error())
 	}
 	msg := "precondition check failed"
-	if s := ctyAsString(msgVal); s != "" {
+	if s := renderErrorMessage(msgVal); s != "" {
 		msg = s
 	}
 	return fmt.Errorf("precondition for %s: %s", resourceName, msg)
@@ -3411,7 +3410,7 @@ func evaluateCheckAssert(evaluator *eval.Evaluator, rule *ast.CheckRule) string 
 	if msgDiags.HasErrors() {
 		return "assertion failed (could not evaluate error message)"
 	}
-	if msg := ctyAsString(msgVal); msg != "" {
+	if msg := renderErrorMessage(msgVal); msg != "" {
 		return msg
 	}
 	return "assertion failed"
@@ -3458,4 +3457,23 @@ func ctyAsString(v cty.Value) string {
 		return ""
 	}
 	return v.AsString()
+}
+
+// sensitiveErrorMessageRef is the text substituted for a custom-condition
+// error_message that interpolates a sensitive value. Rendering the real message
+// would leak the secret, so the reference is reported instead.
+const sensitiveErrorMessageRef = "Error message refers to sensitive values"
+
+// renderErrorMessage reads a custom-condition error_message (variable
+// validation, precondition, postcondition, or check assertion). It refuses to
+// render a message that carries the sensitive mark — returning
+// sensitiveErrorMessageRef rather than the interpolated secret — while still
+// tolerating the non-sensitive marks (e.g. DepMarks) that resource outputs
+// carry. A null / unknown / non-string value yields "" so the caller can fall
+// back to its own default message.
+func renderErrorMessage(v cty.Value) string {
+	if v.HasMark(eval.SensitiveMark) {
+		return sensitiveErrorMessageRef
+	}
+	return ctyAsString(v)
 }

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -1187,6 +1187,50 @@ variable "instance_type" {
 	}
 }
 
+func TestEngine_VariableValidationFail_SensitiveErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+variable "password" {
+  type      = string
+  sensitive = true
+  default   = "abc"
+
+  validation {
+    condition     = length(var.password) >= 8
+    error_message = "Password is too short: '${var.password}'"
+  }
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	if diags.HasErrors() {
+		t.Fatalf("parse error: %s", diags.Error())
+	}
+
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: &testutil.MockResourceMonitor{},
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader:    schemaloader.New(t, schema.PackageSpec{Name: "aws"}),
+	})
+
+	err := engine.Run(t.Context())
+
+	if err == nil {
+		t.Fatal("expected error for validation failure")
+	}
+	if !strings.Contains(err.Error(), "Error message refers to sensitive values") {
+		t.Errorf("expected sensitive-reference error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "abc") {
+		t.Errorf("sensitive value leaked into error: %v", err)
+	}
+}
+
 func TestEngine_Precondition(t *testing.T) {
 	t.Parallel()
 
@@ -1245,6 +1289,49 @@ resource "test_resource" "res" {
 		require.False(t, hasRegisteredResource(mock, "test:index:Resource"),
 			"resource must not be registered when precondition fails")
 	})
+}
+
+func TestEngine_Precondition_SensitiveErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+variable "secret" {
+  type      = string
+  sensitive = true
+  default   = "abc"
+}
+
+resource "test_resource" "res" {
+  field = "x"
+
+  lifecycle {
+    precondition {
+      condition     = length(var.secret) >= 8
+      error_message = "Secret too short: '${var.secret}'"
+    }
+  }
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader:    schemaloader.New(t, testSchema()),
+	})
+
+	err := engine.Run(t.Context())
+	require.ErrorContains(t, err, "Error message refers to sensitive values")
+	require.NotContains(t, err.Error(), "abc", "sensitive value leaked into precondition error")
+	require.False(t, hasRegisteredResource(mock, "test:index:Resource"),
+		"resource must not be registered when precondition fails")
 }
 
 func TestEngine_Precondition_ReferencesOtherResource(t *testing.T) {

--- a/tests/tfcompat/l1_sensitive_error_message_test.go
+++ b/tests/tfcompat/l1_sensitive_error_message_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1Validation_SensitiveErrorMessage asserts that a failing variable
+// validation whose error_message interpolates a sensitive value is rejected
+// the same way on both runtimes. OpenTofu refuses to render the message and
+// fails with "Error message refers to sensitive values"; pulumi-hcl must
+// produce an equivalent failure rather than leaking the sensitive value.
+func TestL1Validation_SensitiveErrorMessage(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_validation_sensitive_error", tfcompat.Case{
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{"main.tf": `
+variable "password" {
+  type      = string
+  sensitive = true
+  default   = "abc"
+
+  validation {
+    condition     = length(var.password) >= 8
+    error_message = "Password is too short: '${var.password}'"
+  }
+}
+
+output "ok" {
+  value = "ok"
+}
+`},
+			ExpectErr: "Error message refers to sensitive values",
+		}},
+	})
+}


### PR DESCRIPTION
A custom-condition `error_message` (variable `validation`, `precondition`, `postcondition`, or `check` assertion) is evaluated when its condition fails. When that message interpolates a **sensitive** value, the runtime mishandled the resulting sensitive-marked string — in two different ways depending on the path.

## The divergence

```hcl
variable "password" {
  type = string; sensitive = true; default = "abc"
  validation {
    condition     = length(var.password) >= 8
    error_message = "Password is too short: '${var.password}'"
  }
}
```

- **OpenTofu** refuses to render the message and fails with `Error message refers to sensitive values`, never emitting the secret.
- **pulumi-hcl, variable `validation`:** called `cty.Value.AsString()` on the sensitive-marked string and **panicked** the DAG walk (`value is marked, so must be unmarked first`, `pkg/hcl/run/run.go`).
- **pulumi-hcl, `precondition`/`postcondition`/`check`:** these went through `ctyAsString`, which unmarks and renders — so they **leaked** the secret into the failure text (e.g. `precondition for X: Secret too short: 'abc'`).

A real config that yields a tidy, secret-safe validation error in OpenTofu therefore either crashed the language host or printed the secret.

## Fix

Add a `renderErrorMessage` helper that returns a fixed `Error message refers to sensitive values` reference when the message carries the sensitive mark — never the interpolated secret — while still tolerating the non-sensitive marks (DepMarks) that resource outputs carry. All four condition sites (variable validation, precondition, postcondition, check) route through it.

## Sweep

The panic was only the variable-validation path; the sweep found the `precondition`/`postcondition`/`check` paths shared the same root cause via `ctyAsString` and leaked rather than panicked. All four are fixed together here.

## Tests

- `TestL1Validation_SensitiveErrorMessage` (tfcompat) — proves both runtimes now fail with `Error message refers to sensitive values`. Panicked on `master`.
- `TestEngine_VariableValidationFail_SensitiveErrorMessage` (unit) — no panic; error contains the reference and not the secret.
- `TestEngine_Precondition_SensitiveErrorMessage` (unit) — the resource-precondition sibling: error contains the reference, does not contain the secret, and the resource is not registered. Leaked `'abc'` on `master`.

Note: output-block preconditions follow a separate, not-yet-enforced code path in pulumi-hcl and are out of scope here.