### PR TITLE
Decode underscore-containing YAML scalars as strings in `yamldecode`

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-255.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-255.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Decode underscore-containing YAML scalars as strings in `yamldecode`
+time: 2026-06-09T11:35:07.000000+00:00
+custom:
+    Component: runtime
+    PR: "255"

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/xanzy/ssh-agent v0.3.3
 	github.com/zclconf/go-cty v1.18.1
-	github.com/zclconf/go-cty-yaml v1.0.3
+	github.com/zclconf/go-cty-yaml v1.1.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.51.0

--- a/go.sum
+++ b/go.sum
@@ -4176,8 +4176,8 @@ github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRK
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
-github.com/zclconf/go-cty-yaml v1.0.3 h1:og/eOQ7lvA/WWhHGFETVWNduJM7Rjsv2RRpx1sdFMLc=
-github.com/zclconf/go-cty-yaml v1.0.3/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
+github.com/zclconf/go-cty-yaml v1.1.0 h1:nP+jp0qPHv2IhUVqmQSzjvqAWcObN0KBkUl2rWBdig0=
+github.com/zclconf/go-cty-yaml v1.1.0/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=

--- a/tests/tfcompat/testdata/cases/l1_yaml/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_yaml/main.tf
@@ -23,6 +23,19 @@ output "decode_timestamp" {
   value = yamldecode("d: 2020-01-01")
 }
 
+# YAML integer-tag resolution: a scalar containing underscores is not an integer
+# and stays a string, while plain decimal, octal (0o) and hex (0x) scalars
+# resolve to numbers.
+output "decode_int_tags" {
+  value = {
+    underscore_dec = yamldecode("v: 1_000").v
+    underscore_oct = yamldecode("v: 0o1_0").v
+    underscore_hex = yamldecode("v: 0x1_f").v
+    plain_hex      = yamldecode("v: 0x1f").v
+    plain_oct      = yamldecode("v: 0o17").v
+  }
+}
+
 output "roundtrip" {
   value = yamldecode(yamlencode({ a = 1, b = "two", nested = { c = true } }))
 }


### PR DESCRIPTION
OpenTofu and pulumi-hcl bind `yamldecode`/`yamlencode` to `go-cty-yaml`, but pin different versions — pulumi-hcl `v1.0.3`, OpenTofu `v1.1.0` — and the two resolve YAML integer tags differently:

```hcl
output "x" { value = yamldecode("v: 1_000").v }
# OpenTofu: "1_000" (string)   pulumi-hcl (before): 1000 (number)
```

Per the YAML spec an underscore is not part of the integer grammar, so a scalar like `1_000`, `0o1_0`, or `0x1_f` is a plain string, not a number. `go-cty-yaml` v1.1.0 tightened integer-tag resolution to drop underscores from all three numeric bases (decimal, octal `0o`, hex `0x`); the pinned v1.0.3 still resolved them as integers, so a config that round-trips such a value through `yamldecode` got a number where OpenTofu gets a string.

## Fix

Bump `go-cty-yaml` from v1.0.3 to v1.1.0 (the version OpenTofu uses). `yamldecode` and `yamlencode` are the only consumers.

## Sweep

The same version gap affects every underscore-containing numeric base, not just decimal. The folded test covers decimal, octal, and hex underscore scalars (all now strings) alongside the plain `0x1f`/`0o17` forms that still resolve to numbers. `yamlencode` (the inverse) is exercised by the existing `l1_yaml` encode outputs and is unaffected by the bump.

## Tests

Extended `TestL1Yaml` (`testdata/cases/l1_yaml/main.tf`) with a `decode_int_tags` output. On v1.0.3 the underscore scalars decoded to `1000`/`31`/`8`; on v1.1.0 they decode to `"1_000"`/`"0o1_0"`/`"0x1_f"`, matching OpenTofu. Failed on `master`, passes here; full `pkg/hcl/...` suite green.