### PR TITLE
Preserve element types of a heterogeneous tuple or object passed through `terraform_data`

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-256.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-256.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Preserve element types of a heterogeneous tuple or object passed through `terraform_data`
+time: 2026-06-09T12:14:29.000000+00:00
+custom:
+    Component: runtime
+    PR: "256"

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1261,7 +1261,7 @@ func unifyOrObject(m map[string]cty.Value) cty.Value {
 		types = append(types, v.Type())
 	}
 	unified, conversions := convert.UnifyUnsafe(types)
-	if unified == cty.NilType {
+	if unified == cty.NilType || isLossyPrimitiveUnification(unified, types) {
 		return cty.ObjectVal(m)
 	}
 	out := make(map[string]cty.Value, len(m))
@@ -1288,6 +1288,24 @@ func unifyOrObject(m map[string]cty.Value) cty.Value {
 	return cty.MapVal(out)
 }
 
+// isLossyPrimitiveUnification reports whether unifying to unified would coerce
+// elements between primitive types — e.g. collapsing [number, string, bool] to
+// string. Such a unification erases each element's own type, so a heterogeneous
+// value must stay a tuple/object rather than be flattened to a list/map. A
+// structural unification (e.g. object -> map) keeps a non-primitive target and
+// is left to proceed.
+func isLossyPrimitiveUnification(unified cty.Type, types []cty.Type) bool {
+	if !unified.IsPrimitiveType() {
+		return false
+	}
+	for _, t := range types {
+		if !t.Equals(unified) {
+			return true
+		}
+	}
+	return false
+}
+
 // blockListValue assembles the elements of a repeated TF block (each an object)
 // into a cty list when they share a type, or a tuple when an optional attribute
 // is set in some blocks and omitted in others so their object types differ.
@@ -1312,7 +1330,7 @@ func unifyOrTuple(arr []cty.Value) cty.Value {
 		types[i] = v.Type()
 	}
 	unified, conversions := convert.UnifyUnsafe(types)
-	if unified == cty.NilType {
+	if unified == cty.NilType || isLossyPrimitiveUnification(unified, types) {
 		return cty.TupleVal(arr)
 	}
 	out := make([]cty.Value, len(arr))

--- a/tests/tfcompat/testdata/cases/l2_terraform_data/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_data/main.tf
@@ -12,6 +12,31 @@ resource "terraform_data" "no_input" {
   triggers_replace = ["v1"]
 }
 
+# input/output are dynamically typed, so a heterogeneous tuple must round-trip
+# with each element's type intact rather than being coerced to a single element
+# type. An object with mixed-typed fields keeps its per-attribute types too.
+resource "terraform_data" "tuple" {
+  input = [1, "two", true]
+}
+
+resource "terraform_data" "obj" {
+  input = {
+    name = "alice"
+    age  = 30
+    tags = ["a", "b"]
+  }
+}
+
+# An object whose attributes are all scalars of differing types must keep each
+# attribute's type rather than collapsing to a single-typed map.
+resource "terraform_data" "scalar_obj" {
+  input = {
+    a = 1
+    b = "two"
+    c = true
+  }
+}
+
 output "value" {
   value = terraform_data.example.output
 }
@@ -30,4 +55,16 @@ output "no_input_input_null" {
 
 output "no_input_triggers" {
   value = terraform_data.no_input.triggers_replace
+}
+
+output "tuple_output" {
+  value = terraform_data.tuple.output
+}
+
+output "obj_output" {
+  value = terraform_data.obj.output
+}
+
+output "scalar_obj_output" {
+  value = terraform_data.scalar_obj.output
 }


### PR DESCRIPTION
Reconstructing a dynamically-typed (`AnyType`) property value back into a cty value unified its elements with `convert.UnifyUnsafe`. cty treats number→string and bool→string as *safe* conversions, so a heterogeneous collection collapsed onto a single primitive type, losing each element's type:

```hcl
resource "terraform_data" "tuple"      { input = [1, "two", true] }
resource "terraform_data" "scalar_obj" { input = { a = 1, b = "two", c = true } }
output "tuple_output"      { value = terraform_data.tuple.output }
output "scalar_obj_output" { value = terraform_data.scalar_obj.output }
```

| | OpenTofu | pulumi-hcl (before) |
|---|---|---|
| `tuple_output` | `[1, "two", true]` | `["1", "two", "true"]` |
| `scalar_obj_output` | `{a=1, b="two", c=true}` | `{a="1", b="two", c="true"}` |

`terraform_data.input`/`output` are dynamically typed, so OpenTofu preserves each element's type — this is the OpenTofu-succeeds / pulumi-differs direction.

## Fix

Guard `unifyOrTuple` and `unifyOrObject` against a unification whose target is a **primitive** type that not every element already has — that is a lossy scalar coercion, so the value stays a `cty.TupleVal`/`cty.ObjectVal` that preserves per-element types. **Structural** unification (e.g. object→map, used to collapse union-typed members) keeps a non-primitive target and still proceeds, so that behavior is unchanged.

## Sweep

The proven failure was the tuple; the sweep found `unifyOrObject` shared the exact root cause and stringified an all-scalar heterogeneous object the same way (masked in the original repro because that object had a list member, which blocked unification and hid the bug). Both are fixed and covered.

## Tests

- Folded into the existing `TestL2TerraformData` (`testdata/cases/l2_terraform_data/main.tf`): a heterogeneous tuple and an all-scalar object that must round-trip with types intact. Both diverged on `master`, pass here.
- The `unifyOr*` change is constrained by the existing `TestResourceOutputToCtyUnionTypeCollapseNested` unit tests (object↔map union collapse), which still pass — the guard only blocks primitive coercion, not structural collapse.
- Full `pkg/hcl/...` and the entire tfcompat suite are green.