### PR TITLE
Serialize an empty `set` as an empty collection rather than null

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-257.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-257.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Serialize an empty `set` as an empty collection rather than null
+time: 2026-06-09T12:50:21.000000+00:00
+custom:
+    Component: runtime
+    PR: "257"

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -958,9 +958,10 @@ func ctyListToPropertyValue(val cty.Value) (property.Value, error) {
 	return property.New(arr), nil
 }
 
-// ctySetToPropertyValue converts a cty set to a Pulumi array.
+// ctySetToPropertyValue converts a cty set to a Pulumi array. The slice is
+// allocated non-nil so an empty set becomes an empty array rather than null.
 func ctySetToPropertyValue(val cty.Value) (property.Value, error) {
-	var arr []property.Value
+	arr := make([]property.Value, 0, val.LengthInt())
 	for it := val.ElementIterator(); it.Next(); {
 		_, elemVal := it.Element()
 		pv, err := ctyToPropertyValue(elemVal)

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -696,6 +696,15 @@ func TestCtyToPropertyValue_Collections(t *testing.T) {
 			t.Errorf("expected 2 elements, got %d", len(arr))
 		}
 	})
+
+	t.Run("empty set", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := CtyToPropertyValue(cty.SetValEmpty(cty.String))
+		require.NoError(t, err)
+		require.True(t, result.IsArray(), "an empty set must be an empty array, not null")
+		require.Equal(t, 0, result.AsArray().Len())
+	})
 }
 
 func TestCtyToPropertyValue_Nested(t *testing.T) {

--- a/tests/tfcompat/l1_collection_test.go
+++ b/tests/tfcompat/l1_collection_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1Collection exercises empty set serialization. OpenTofu emits an
+// empty set as `[]`; pulumi-hcl emits `null`. The in-domain trigger is
+// `setproduct` over an empty set, but the divergence is shared by any empty
+// set value (`toset([])`, an empty `setsubtract` result).
+func TestL1Collection(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_collection", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_collection/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_collection/main.tf
@@ -1,0 +1,22 @@
+# Collection values must serialize identically whether empty or populated. An
+# empty set in particular must be an empty collection, not null; the populated
+# cases and the other collection kinds guard against a regression that special-
+# cases one kind or the empty case.
+
+# Arrays (list and tuple).
+output "empty_list"      { value = tolist([]) }
+output "nonempty_list"   { value = tolist(["a", "b"]) }
+output "empty_tuple"     { value = [] }
+output "nonempty_tuple"  { value = ["a", 1, true] }
+
+# Maps (map and object).
+output "empty_map"       { value = tomap({}) }
+output "nonempty_map"    { value = tomap({ k = "v" }) }
+output "empty_object"    { value = {} }
+output "nonempty_object" { value = { name = "n" } }
+
+# Sets, including set operations that yield an empty set.
+output "empty_set"         { value = toset([]) }
+output "nonempty_set"      { value = toset(["a", "b"]) }
+output "empty_setsubtract" { value = setsubtract(toset(["a"]), toset(["a"])) }
+output "setproduct_empty"  { value = setproduct(toset(["a"]), toset([])) }


### PR DESCRIPTION
An empty set serialized as `null` instead of an empty collection:

```hcl
output "empty_set" { value = toset([]) }
# OpenTofu: []   pulumi-hcl (before): null
```

`ctySetToPropertyValue` declared its accumulator as `var arr []property.Value`, which stays **nil** when the set is empty; `property.New(nil)` then becomes a `null`. The list, tuple, and typed-array converters all allocate their slice with `make([]property.Value, 0, …)`, so empty lists/tuples already round-tripped as `[]` — only sets were affected (empty maps/objects use a non-nil `make` map and were fine too).

## Fix

Allocate the set converter's slice with `make` like the sibling converters, so an empty set serializes as an empty array.

## Sweep

Confirmed the nil-slice pattern existed only in the set converter: the other two array builders and both map/object builders already use `make`, and the inverse (property→cty) handles empty collections explicitly (`ListValEmpty`/`MapValEmpty`/`EmptyObjectVal`). I empirically verified that only empty **sets** diverged — empty list, tuple, map, and object all matched OpenTofu on `master`.

## Tests

- New `TestL1Collection` (`testdata/cases/l1_collection/main.tf`) covering empty and non-empty arrays, maps, and sets, plus `setsubtract`/`setproduct` results that yield an empty set. On `master` only the three empty-set outputs diverge to `null`; all other collection kinds already match.
- Unit `TestCtyToPropertyValue_Collections/empty set` asserting an empty set converts to an empty array, not null.
- Full `pkg/hcl/...` and the tfcompat suite are green.