### PR TITLE
Propagate a module output's `sensitive` mark to its caller

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-259.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-259.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Propagate a module output's `sensitive` mark to its caller
+time: 2026-06-09T13:25:59.000000+00:00
+custom:
+    Component: runtime
+    PR: "259"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2847,6 +2847,11 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating module output %s: %s", outputName, diags.Error())
 		}
+		// A `sensitive = true` output carries the mark into the calling module,
+		// so a reference to it stays sensitive.
+		if output.Sensitive {
+			val = val.Mark(eval.SensitiveMark)
+		}
 		inst.mu.Lock()
 		inst.Outputs[outputName] = val
 		inst.mu.Unlock()

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -1067,6 +1067,55 @@ output "item_count" {
 	})
 }
 
+func TestEngine_ModuleSensitiveOutput(t *testing.T) {
+	t.Parallel()
+
+	const childMain = `
+variable "in" {
+  type    = string
+  default = "hunter2"
+}
+
+output "token" {
+  value     = var.in
+  sensitive = true
+}
+`
+	const rootMain = `
+module "child" {
+  source = "./modules/child"
+}
+
+output "is_sensitive" {
+  value = issensitive(module.child.token)
+}
+`
+	tmpDir := t.TempDir()
+	moduleDir := tmpDir + "/modules/child"
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(moduleDir+"/main.tf", []byte(childMain), 0o644))
+	require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(rootMain), 0o644))
+
+	p := parser.NewParser()
+	config, diags := p.ParseDirectory(tmpDir)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         tmpDir,
+		RootDir:         tmpDir,
+		SchemaLoader:    schemaloader.New(t, schema.PackageSpec{Name: "empty"}),
+	})
+	require.NoError(t, engine.Run(t.Context()))
+
+	output, ok := mock.StackOutputs.GetOk("is_sensitive")
+	require.True(t, ok, "expected is_sensitive output")
+	assert.True(t, output.AsBool(), "a sensitive module output must be sensitive in the caller")
+}
+
 func TestEngine_VariableValidationPass(t *testing.T) {
 	t.Parallel()
 

--- a/tests/tfcompat/l2_module_sensitive_output_test.go
+++ b/tests/tfcompat/l2_module_sensitive_output_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2ModuleSensitiveOutput asserts that a child-module output declared
+// `sensitive = true` carries its sensitive mark into the calling module. The
+// root reads it through `issensitive`, which OpenTofu reports as true; pulumi-hcl
+// does not apply the declared mark and reports false.
+func TestL2ModuleSensitiveOutput(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_sensitive_output", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_module_sensitive_output/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_sensitive_output/main.tf
@@ -1,0 +1,17 @@
+module "secret" {
+  source = "./modules/secret"
+}
+
+# A module output declared `sensitive = true` must carry the sensitive mark into
+# the calling module. `issensitive` exposes the mark as a plain bool, so the
+# behavior is observable in outputs without leaking the value (and without
+# forcing this root output to itself be sensitive).
+output "is_sensitive" {
+  value = issensitive(module.secret.token)
+}
+
+# The mark must also propagate through an expression that derives from the
+# sensitive module output.
+output "derived_is_sensitive" {
+  value = issensitive("tok-${module.secret.token}")
+}

--- a/tests/tfcompat/testdata/cases/l2_module_sensitive_output/modules/secret/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_sensitive_output/modules/secret/main.tf
@@ -1,0 +1,9 @@
+variable "in" {
+  type    = string
+  default = "hunter2"
+}
+
+output "token" {
+  value     = var.in
+  sensitive = true
+}


### PR DESCRIPTION
A child module output declared `sensitive = true` must carry the sensitive mark into the calling module, so a reference to it stays sensitive:

```hcl
# modules/secret/main.tf
output "token" { value = var.in, sensitive = true }

# root
output "is_sensitive" { value = issensitive(module.secret.token) }
# OpenTofu: true   pulumi-hcl (before): false
```

`processModuleOutput` evaluated the output expression and published the value to the calling module's context, but never applied the output block's `sensitive` declaration — so a reference to `module.secret.token` was non-sensitive. The root-output path already marks a stack output secret when `sensitive = true`, but module outputs flow on as cty values to other expressions and need the mark applied to the value itself. The result is a value the author declared sensitive being treated as plain in the caller (and anything derived from it).

## Fix

In `processModuleOutput` (`pkg/hcl/run/run.go`), mark the evaluated value with the sensitive mark when the output declares `sensitive = true`, per module instance (covers single, `count`, and `for_each` modules).

## Sweep

The companion paths are already correct: an input `variable` with `sensitive = true` is marked in `processVariable`, and a root `output` with `sensitive = true` is marked at stack registration. Marks propagate through derived expressions automatically once the value carries them (verified by the `derived_is_sensitive` output). One related behavior is intentionally **out of scope**: OpenTofu *errors* when a non-sensitive root output references a sensitive value ("Output refers to sensitive values"), whereas pulumi-hcl marks it secret without erroring — that is pulumi-hcl being more lenient, not the migration-breaking direction.

## Tests

- `TestL2ModuleSensitiveOutput` (`testdata/cases/l2_module_sensitive_output/`) — a child module with a `sensitive = true` output; the root observes the mark via `issensitive` directly and through a derived interpolation. Both were `false` on `master`, `true` here.
- `TestEngine_ModuleSensitiveOutput` (unit) — asserts the caller's `issensitive(module.child.token)` output is `true`.
- Full `pkg/hcl/...` and the tfcompat suite are green.