### PR TITLE
Support terraform-plugin-framework providers in tfcompat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/go-plugin v1.8.0
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0
+	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-mux v0.23.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -3510,6 +3510,10 @@ github.com/hashicorp/terraform-config-inspect v0.0.0-20191115094559-17f92b0546e8
 github.com/hashicorp/terraform-exec v0.25.0/go.mod h1:dl9IwsCfklDU6I4wq9/StFDp7dNbH/h5AnfS1RmiUl8=
 github.com/hashicorp/terraform-json v0.4.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
+github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
+github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.17.0 h1:0uYQcqqgW3BMyyve07WJgpKorXST3zkpzvrOnf3mpbg=
+github.com/hashicorp/terraform-plugin-framework-validators v0.17.0/go.mod h1:VwdfgE/5Zxm43flraNa0VjcvKQOGVrcO4X8peIri0T0=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=

--- a/tests/testutil/pulexec/bridge.go
+++ b/tests/testutil/pulexec/bridge.go
@@ -23,7 +23,14 @@ import (
 	"io"
 	"testing"
 
+	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfexec"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf"
+	pftfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+	pftfgen "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
@@ -33,6 +40,88 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/require"
 )
+
+// SDKv2Provider builds a Provider from an SDKv2 (helper/schema) provider via
+// the classic bridge.
+func SDKv2Provider(
+	t *testing.T, providerName string, tfp *schema.Provider,
+	customize func(*testing.T, *tfbridge.ProviderInfo),
+) Provider {
+	t.Helper()
+	info := BridgedProvider(t, providerName, tfp, customize)
+	return Provider{Name: providerName, Start: func(ctx context.Context) (pulumirpc.ResourceProviderServer, error) {
+		return providerServerFromInfo(ctx, info)
+	}}
+}
+
+// PFProvider builds a Provider from a terraform-plugin-framework provider via
+// the plugin-framework bridge, recording provider operations to rec at the
+// tfprotov6 boundary — the same boundary tfexec.PFProvider records at on the
+// OpenTofu path. customize plays the same role as in BridgedProvider.
+func PFProvider(
+	t *testing.T, providerName string, p pfprovider.Provider, rec *tfexec.Recorder,
+	customize func(*testing.T, *tfbridge.ProviderInfo),
+) Provider {
+	t.Helper()
+
+	requireValidPFSchema(t, p)
+
+	shimProvider, ok := pftfbridge.ShimProvider(p).(pf.ShimProvider)
+	require.True(t, ok, "pftfbridge.ShimProvider did not return a pf.ShimProvider")
+
+	info := tfbridge.ProviderInfo{
+		P:            recordingShim{ShimProvider: shimProvider, rec: rec},
+		Name:         providerName,
+		Version:      "0.0.1",
+		MetadataInfo: tfbridge.NewProviderMetadata(nil),
+	}
+	info.MustComputeTokens(tokens.SingleModule(providerName, "index", tokens.MakeStandard(providerName)))
+
+	if customize != nil {
+		customize(t, &info)
+	}
+
+	return Provider{Name: providerName, Start: func(ctx context.Context) (pulumirpc.ResourceProviderServer, error) {
+		res, err := pftfgen.GenerateSchema(ctx, pftfgen.GenerateSchemaOptions{
+			ProviderInfo:    info,
+			DiagnosticsSink: discardSink(),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("pf tfgen.GenerateSchema failed: %w", err)
+		}
+		return pftfbridge.NewProviderServer(ctx, nil, info, res.ProviderMetadata)
+	}}
+}
+
+// requireValidPFSchema is the plugin-framework analog of SDKv2's
+// InternalValidate: the framework validates every schema implementation while
+// answering GetProviderSchema, so a clean response means the provider's
+// schemas are well-formed.
+func requireValidPFSchema(t *testing.T, p pfprovider.Provider) {
+	t.Helper()
+	srv := providerserver.NewProtocol6(p)()
+	resp, err := srv.GetProviderSchema(t.Context(), &tfprotov6.GetProviderSchemaRequest{})
+	require.NoError(t, err)
+	for _, d := range resp.Diagnostics {
+		require.NotEqual(t, tfprotov6.DiagnosticSeverityError, d.Severity,
+			"provider schema diagnostic: %s: %s", d.Summary, d.Detail)
+	}
+}
+
+// recordingShim wraps the pf shim so the tfprotov6 server it hands the bridge
+// records operations, mirroring tfexec.WrapServer on the OpenTofu path.
+type recordingShim struct {
+	pf.ShimProvider
+	rec *tfexec.Recorder
+}
+
+func (s recordingShim) Server(ctx context.Context) (tfprotov6.ProviderServer, error) {
+	srv, err := s.ShimProvider.Server(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return tfexec.WrapServer(srv, s.rec), nil
+}
 
 // BridgedProvider wraps a *schema.Provider into a tfbridge.ProviderInfo with
 // auto-generated tokens and no-op CRUD methods where missing. customize, if
@@ -65,12 +154,16 @@ func BridgedProvider(
 	return provider
 }
 
+func discardSink() pulumidiag.Sink {
+	return pulumidiag.DefaultSink(io.Discard, io.Discard, pulumidiag.FormatOptions{
+		Color: colors.Never,
+	})
+}
+
 func providerServerFromInfo(
 	ctx context.Context, providerInfo tfbridge.ProviderInfo,
 ) (pulumirpc.ResourceProviderServer, error) {
-	sink := pulumidiag.DefaultSink(io.Discard, io.Discard, pulumidiag.FormatOptions{
-		Color: colors.Never,
-	})
+	sink := discardSink()
 
 	pkgSchema, err := tfgen.GenerateSchema(providerInfo, sink)
 	if err != nil {

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/optnewstack"
 	"github.com/pulumi/providertest/pulumitest/opttest"
-	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optdestroy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -66,10 +65,11 @@ func serveLanguageHost(t *testing.T) int {
 	return handle.Port
 }
 
-// Provider pairs a provider name with its bridged info.
+// Provider pairs a provider name with a way to start its in-process Pulumi
+// provider server. Use SDKv2Provider or PFProvider to build one.
 type Provider struct {
-	Name string
-	Info tfbridge.ProviderInfo
+	Name  string
+	Start func(ctx context.Context) (pulumirpc.ResourceProviderServer, error)
 }
 
 // Result holds the outputs and resource state from a Pulumi deployment.
@@ -127,11 +127,11 @@ backend:
 		opttest.NewStackOptions(optnewstack.DisableAutoDestroy()),
 	)
 	for _, p := range provs {
-		info := p.Info
+		start := p.Start
 		opts = append(opts, opttest.AttachProvider(
 			p.Name,
 			func(ctx context.Context, pt providers.PulumiTest) (providers.Port, error) {
-				handle, err := startProvider(ctx, info)
+				handle, err := startProvider(ctx, start)
 				if err != nil {
 					return 0, err
 				}
@@ -300,10 +300,12 @@ func (d *Driver) writeStubSDKs(t *testing.T) {
 	}
 }
 
-func startProvider(ctx context.Context, providerInfo tfbridge.ProviderInfo) (*rpcutil.ServeHandle, error) {
-	prov, err := providerServerFromInfo(ctx, providerInfo)
+func startProvider(
+	ctx context.Context, start func(context.Context) (pulumirpc.ResourceProviderServer, error),
+) (*rpcutil.ServeHandle, error) {
+	prov, err := start(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("providerServerFromInfo failed: %w", err)
+		return nil, fmt.Errorf("starting provider server: %w", err)
 	}
 
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{

--- a/tests/testutil/tfcompat/harness.go
+++ b/tests/testutil/tfcompat/harness.go
@@ -41,6 +41,7 @@ import (
 	"sync"
 	"testing"
 
+	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/pulexec"
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfexec"
@@ -51,13 +52,42 @@ import (
 
 // Provider describes an in-memory TF provider that's available to both paths.
 type Provider struct {
-	Name    string
+	Name string
+	// Factory builds an SDKv2 (helper/schema) provider. Exactly one of
+	// Factory and PFFactory must be set.
 	Factory func() *schema.Provider
+	// PFFactory builds a terraform-plugin-framework provider.
+	PFFactory func() pfprovider.Provider
 	// Customize, if non-nil, runs against the bridged ProviderInfo on the
 	// Pulumi path so tests can apply non-default Pulumi-side renames (or any
 	// other ProviderInfo tweak) to exercise the bridge mapping behaviour.
 	// The TF path is unaffected.
 	Customize func(*testing.T, *tfbridge.ProviderInfo)
+}
+
+// buildProviders wires each Case provider into both paths, wrapping it with
+// the per-path recorder. SDKv2 providers record at the helper/schema CRUD
+// boundary (tfexec.Wrap); plugin-framework providers record at the tfprotov6
+// boundary (tfexec.WrapServer). Each path gets its own provider instance.
+func buildProviders(
+	t *testing.T, provs []Provider, recA, recB *tfexec.Recorder,
+) ([]tfexec.Provider, []pulexec.Provider) {
+	t.Helper()
+	tfProvs := make([]tfexec.Provider, len(provs))
+	pulProvs := make([]pulexec.Provider, len(provs))
+	for i, p := range provs {
+		switch {
+		case p.Factory != nil && p.PFFactory == nil:
+			tfProvs[i] = tfexec.SDKv2Provider(t, p.Name, tfexec.Wrap(p.Factory(), recA))
+			pulProvs[i] = pulexec.SDKv2Provider(t, p.Name, tfexec.Wrap(p.Factory(), recB), p.Customize)
+		case p.PFFactory != nil && p.Factory == nil:
+			tfProvs[i] = tfexec.PFProvider(p.Name, p.PFFactory(), recA)
+			pulProvs[i] = pulexec.PFProvider(t, p.Name, p.PFFactory(), recB, p.Customize)
+		default:
+			t.Fatalf("provider %q: exactly one of Factory or PFFactory must be set", p.Name)
+		}
+	}
+	return tfProvs, pulProvs
 }
 
 // Case is the test description passed to RunCase.
@@ -118,15 +148,7 @@ func runCaseStages(t *testing.T, c Case) {
 	t.Helper()
 
 	recA, recB := &tfexec.Recorder{}, &tfexec.Recorder{}
-	tfProvs := make([]tfexec.Provider, len(c.Providers))
-	pulProvs := make([]pulexec.Provider, len(c.Providers))
-	for i, p := range c.Providers {
-		tfProvs[i] = tfexec.Provider{Name: p.Name, Provider: tfexec.Wrap(p.Factory(), recA)}
-		pulProvs[i] = pulexec.Provider{
-			Name: p.Name,
-			Info: pulexec.BridgedProvider(t, p.Name, tfexec.Wrap(p.Factory(), recB), p.Customize),
-		}
-	}
+	tfProvs, pulProvs := buildProviders(t, c.Providers, recA, recB)
 
 	tfDriver := tfexec.NewDriver(t, tfProvs)
 	pulDriver := pulexec.NewDriver(t, pulProvs, c.Config)
@@ -221,16 +243,7 @@ func runCaseFromDir(t *testing.T, caseDir string, c Case) {
 	stages := loadStages(t, caseDir)
 
 	recA, recB := &tfexec.Recorder{}, &tfexec.Recorder{}
-
-	tfProvs := make([]tfexec.Provider, len(c.Providers))
-	pulProvs := make([]pulexec.Provider, len(c.Providers))
-	for i, p := range c.Providers {
-		tfProvs[i] = tfexec.Provider{Name: p.Name, Provider: tfexec.Wrap(p.Factory(), recA)}
-		pulProvs[i] = pulexec.Provider{
-			Name: p.Name,
-			Info: pulexec.BridgedProvider(t, p.Name, tfexec.Wrap(p.Factory(), recB), p.Customize),
-		}
-	}
+	tfProvs, pulProvs := buildProviders(t, c.Providers, recA, recB)
 
 	tfDriver := tfexec.NewDriver(t, tfProvs)
 	pulDriver := pulexec.NewDriver(t, pulProvs, c.Config)

--- a/tests/testutil/tfcompat/providers/pf.go
+++ b/tests/testutil/tfcompat/providers/pf.go
@@ -28,10 +28,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// PFXProvider is the plugin-framework counterpart of SimpleProvider: one
-// resource and one data source, plus a `prefix` provider-config attribute
-// both concatenate into `prefix_result` so tests can observe provider config
-// flowing end-to-end.
+// PFXProvider is a minimal terraform-plugin-framework provider: one resource
+// holding a single string, and one data source returning a constant. It
+// exists so tfcompat covers providers built on the plugin framework rather
+// than terraform-plugin-sdk/v2.
 func PFXProvider() provider.Provider { return &pfxProvider{} }
 
 type pfxProvider struct{}
@@ -43,23 +43,10 @@ func (p *pfxProvider) Metadata(_ context.Context, _ provider.MetadataRequest, re
 }
 
 func (p *pfxProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
-	resp.Schema = pschema.Schema{
-		Attributes: map[string]pschema.Attribute{
-			"prefix": pschema.StringAttribute{Optional: true},
-		},
-	}
+	resp.Schema = pschema.Schema{}
 }
 
-func (p *pfxProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	var cfg struct {
-		Prefix types.String `tfsdk:"prefix"`
-	}
-	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	resp.ResourceData = cfg.Prefix.ValueString()
-	resp.DataSourceData = cfg.Prefix.ValueString()
+func (p *pfxProvider) Configure(context.Context, provider.ConfigureRequest, *provider.ConfigureResponse) {
 }
 
 func (p *pfxProvider) Resources(context.Context) []func() resource.Resource {
@@ -74,18 +61,13 @@ func (p *pfxProvider) DataSources(context.Context) []func() datasource.DataSourc
 	}
 }
 
-type pfxThing struct {
-	prefix string
-}
+type pfxThing struct{}
 
-var _ resource.ResourceWithConfigure = (*pfxThing)(nil)
+var _ resource.Resource = (*pfxThing)(nil)
 
 type pfxThingModel struct {
-	ID           types.String `tfsdk:"id"`
-	Name         types.String `tfsdk:"name"`
-	Note         types.String `tfsdk:"note"`
-	Echo         types.String `tfsdk:"echo"`
-	PrefixResult types.String `tfsdk:"prefix_result"`
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
 }
 
 func (r *pfxThing) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -99,28 +81,9 @@ func (r *pfxThing) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 				Computed:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"name":          rschema.StringAttribute{Required: true},
-			"note":          rschema.StringAttribute{Optional: true},
-			"echo":          rschema.StringAttribute{Computed: true},
-			"prefix_result": rschema.StringAttribute{Computed: true},
+			"name": rschema.StringAttribute{Required: true},
 		},
 	}
-}
-
-func (r *pfxThing) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
-	if prefix, ok := req.ProviderData.(string); ok {
-		r.prefix = prefix
-	}
-}
-
-// fill computes the resource's computed attributes from its arguments.
-func (r *pfxThing) fill(m *pfxThingModel) {
-	echo := m.Name.ValueString()
-	if !m.Note.IsNull() {
-		echo += ":" + m.Note.ValueString()
-	}
-	m.Echo = types.StringValue(echo)
-	m.PrefixResult = types.StringValue(r.prefix + "-" + m.Name.ValueString())
 }
 
 func (r *pfxThing) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -130,7 +93,6 @@ func (r *pfxThing) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 	plan.ID = types.StringValue("pfx-id")
-	r.fill(&plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -142,21 +104,17 @@ func (r *pfxThing) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	r.fill(&plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *pfxThing) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {}
 
-type pfxLookup struct {
-	prefix string
-}
+type pfxLookup struct{}
 
-var _ datasource.DataSourceWithConfigure = (*pfxLookup)(nil)
+var _ datasource.DataSource = (*pfxLookup)(nil)
 
 type pfxLookupModel struct {
-	Query        types.String `tfsdk:"query"`
-	PrefixResult types.String `tfsdk:"prefix_result"`
+	Value types.String `tfsdk:"value"`
 }
 
 func (d *pfxLookup) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -166,24 +124,12 @@ func (d *pfxLookup) Metadata(_ context.Context, req datasource.MetadataRequest, 
 func (d *pfxLookup) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = dschema.Schema{
 		Attributes: map[string]dschema.Attribute{
-			"query":         dschema.StringAttribute{Required: true},
-			"prefix_result": dschema.StringAttribute{Computed: true},
+			"value": dschema.StringAttribute{Computed: true},
 		},
 	}
 }
 
-func (d *pfxLookup) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
-	if prefix, ok := req.ProviderData.(string); ok {
-		d.prefix = prefix
-	}
-}
-
-func (d *pfxLookup) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var cfg pfxLookupModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	cfg.PrefixResult = types.StringValue(d.prefix + "-" + cfg.Query.ValueString())
-	resp.Diagnostics.Append(resp.State.Set(ctx, &cfg)...)
+func (d *pfxLookup) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	state := pfxLookupModel{Value: types.StringValue("pfx-value")}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/tests/testutil/tfcompat/providers/pf.go
+++ b/tests/testutil/tfcompat/providers/pf.go
@@ -1,0 +1,189 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	pschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// PFXProvider is the plugin-framework counterpart of SimpleProvider: one
+// resource and one data source, plus a `prefix` provider-config attribute
+// both concatenate into `prefix_result` so tests can observe provider config
+// flowing end-to-end.
+func PFXProvider() provider.Provider { return &pfxProvider{} }
+
+type pfxProvider struct{}
+
+var _ provider.Provider = (*pfxProvider)(nil)
+
+func (p *pfxProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "pfx"
+}
+
+func (p *pfxProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	resp.Schema = pschema.Schema{
+		Attributes: map[string]pschema.Attribute{
+			"prefix": pschema.StringAttribute{Optional: true},
+		},
+	}
+}
+
+func (p *pfxProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	var cfg struct {
+		Prefix types.String `tfsdk:"prefix"`
+	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.ResourceData = cfg.Prefix.ValueString()
+	resp.DataSourceData = cfg.Prefix.ValueString()
+}
+
+func (p *pfxProvider) Resources(context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		func() resource.Resource { return &pfxThing{} },
+	}
+}
+
+func (p *pfxProvider) DataSources(context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{
+		func() datasource.DataSource { return &pfxLookup{} },
+	}
+}
+
+type pfxThing struct {
+	prefix string
+}
+
+var _ resource.ResourceWithConfigure = (*pfxThing)(nil)
+
+type pfxThingModel struct {
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Note         types.String `tfsdk:"note"`
+	Echo         types.String `tfsdk:"echo"`
+	PrefixResult types.String `tfsdk:"prefix_result"`
+}
+
+func (r *pfxThing) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_thing"
+}
+
+func (r *pfxThing) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"id": rschema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"name":          rschema.StringAttribute{Required: true},
+			"note":          rschema.StringAttribute{Optional: true},
+			"echo":          rschema.StringAttribute{Computed: true},
+			"prefix_result": rschema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (r *pfxThing) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if prefix, ok := req.ProviderData.(string); ok {
+		r.prefix = prefix
+	}
+}
+
+// fill computes the resource's computed attributes from its arguments.
+func (r *pfxThing) fill(m *pfxThingModel) {
+	echo := m.Name.ValueString()
+	if !m.Note.IsNull() {
+		echo += ":" + m.Note.ValueString()
+	}
+	m.Echo = types.StringValue(echo)
+	m.PrefixResult = types.StringValue(r.prefix + "-" + m.Name.ValueString())
+}
+
+func (r *pfxThing) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan pfxThingModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ID = types.StringValue("pfx-id")
+	r.fill(&plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxThing) Read(_ context.Context, _ resource.ReadRequest, _ *resource.ReadResponse) {}
+
+func (r *pfxThing) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan pfxThingModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.fill(&plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxThing) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {}
+
+type pfxLookup struct {
+	prefix string
+}
+
+var _ datasource.DataSourceWithConfigure = (*pfxLookup)(nil)
+
+type pfxLookupModel struct {
+	Query        types.String `tfsdk:"query"`
+	PrefixResult types.String `tfsdk:"prefix_result"`
+}
+
+func (d *pfxLookup) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_lookup"
+}
+
+func (d *pfxLookup) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = dschema.Schema{
+		Attributes: map[string]dschema.Attribute{
+			"query":         dschema.StringAttribute{Required: true},
+			"prefix_result": dschema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *pfxLookup) Configure(_ context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+	if prefix, ok := req.ProviderData.(string); ok {
+		d.prefix = prefix
+	}
+}
+
+func (d *pfxLookup) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var cfg pfxLookupModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	cfg.PrefixResult = types.StringValue(d.prefix + "-" + cfg.Query.ValueString())
+	resp.Diagnostics.Append(resp.State.Set(ctx, &cfg)...)
+}

--- a/tests/testutil/tfexec/driver.go
+++ b/tests/testutil/tfexec/driver.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
@@ -36,10 +38,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Provider pairs a terraform provider name with an SDKv2 provider instance.
+// Provider pairs a terraform provider name with a tfprotov6 server factory.
+// Use SDKv2Provider or PFProvider to build one.
 type Provider struct {
-	Name     string
-	Provider *schema.Provider
+	Name   string
+	Server func() tfprotov6.ProviderServer
+}
+
+// SDKv2Provider adapts an SDKv2 (helper/schema) provider into a Provider by
+// upgrading it to protocol version 6.
+func SDKv2Provider(t *testing.T, name string, p *schema.Provider) Provider {
+	t.Helper()
+	v6server, err := tf5to6server.UpgradeServer(t.Context(),
+		func() tfprotov5.ProviderServer { return p.GRPCProvider() })
+	require.NoError(t, err)
+	return Provider{Name: name, Server: func() tfprotov6.ProviderServer { return v6server }}
+}
+
+// PFProvider adapts a terraform-plugin-framework provider into a Provider,
+// recording its operations to rec at the protocol boundary (see WrapServer).
+func PFProvider(name string, p provider.Provider, rec *Recorder) Provider {
+	server := WrapServer(providerserver.NewProtocol6(p)(), rec)
+	return Provider{Name: name, Server: func() tfprotov6.ProviderServer { return server }}
 }
 
 // Driver hosts TF providers in-process and runs the terraform CLI against them.
@@ -63,17 +83,13 @@ func init() {
 	}
 }
 
-// NewDriver creates a Driver for the given SDKv2 providers. If no providers are given,
-// the driver runs terraform without any reattach configuration.
+// NewDriver creates a Driver for the given providers. If no providers are
+// given, the driver runs terraform without any reattach configuration.
 func NewDriver(t *testing.T, providers []Provider) *Driver {
 	t.Helper()
 
 	reattachConfigs := make(map[string]*plugin.ReattachConfig, len(providers))
 	for _, p := range providers {
-		v6server, err := tf5to6server.UpgradeServer(t.Context(),
-			func() tfprotov5.ProviderServer { return p.Provider.GRPCProvider() })
-		require.NoError(t, err)
-
 		reattachConfigCh := make(chan *plugin.ReattachConfig)
 		closeCh := make(chan struct{})
 
@@ -83,9 +99,9 @@ func NewDriver(t *testing.T, providers []Provider) *Driver {
 			tf6server.WithoutLogStderrOverride(),
 		}
 
-		name := p.Name
+		name, server := p.Name, p.Server
 		go func() {
-			err := tf6server.Serve(name, func() tfprotov6.ProviderServer { return v6server }, serverOpts...)
+			err := tf6server.Serve(name, server, serverOpts...)
 			if err != nil {
 				t.Logf("tf6server.Serve error: %v", err)
 			}

--- a/tests/testutil/tfexec/protorecorder.go
+++ b/tests/testutil/tfexec/protorecorder.go
@@ -1,0 +1,301 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfexec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"sort"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// unknownSentinel stands in for unknown values in recorded ops. Both runtimes
+// must agree on where unknowns appear for their recordings to compare equal.
+const unknownSentinel = "<unknown>"
+
+// WrapServer returns a tfprotov6.ProviderServer that delegates to srv and
+// appends an Op to r for every resource CRUD operation and data-source read.
+// It records at the protocol boundary — wire values are decoded with the
+// provider's own schema — so it works for any provider implementation (e.g.
+// terraform-plugin-framework) and, unlike a per-resource wrapper, preserves
+// optional protocol capabilities such as MoveResourceState.
+//
+// Protocol recordings are stricter than Wrap's helper/schema snapshots: null
+// and unknown values are preserved instead of being flattened to zero values.
+func WrapServer(srv tfprotov6.ProviderServer, r *Recorder) tfprotov6.ProviderServer {
+	return &recordingServer{ProviderServer: srv, rec: r}
+}
+
+type recordingServer struct {
+	tfprotov6.ProviderServer
+	rec *Recorder
+
+	once        sync.Once
+	schemaErr   error
+	resources   map[string]tftypes.Type
+	dataSources map[string]tftypes.Type
+}
+
+// objectTypes returns the object type of every resource and data source,
+// fetched once from the underlying server's GetProviderSchema.
+func (s *recordingServer) objectTypes(ctx context.Context) (resources, dataSources map[string]tftypes.Type, err error) {
+	s.once.Do(func() {
+		resp, err := s.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+		if err != nil {
+			s.schemaErr = err
+			return
+		}
+		s.resources = make(map[string]tftypes.Type, len(resp.ResourceSchemas))
+		for name, sch := range resp.ResourceSchemas {
+			s.resources[name] = sch.ValueType()
+		}
+		s.dataSources = make(map[string]tftypes.Type, len(resp.DataSourceSchemas))
+		for name, sch := range resp.DataSourceSchemas {
+			s.dataSources[name] = sch.ValueType()
+		}
+	})
+	return s.resources, s.dataSources, s.schemaErr
+}
+
+func (s *recordingServer) ApplyResourceChange(
+	ctx context.Context, req *tfprotov6.ApplyResourceChangeRequest,
+) (*tfprotov6.ApplyResourceChangeResponse, error) {
+	resources, _, err := s.objectTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	typ, ok := resources[req.TypeName]
+	if !ok {
+		return nil, fmt.Errorf("recording: no schema for resource %q", req.TypeName)
+	}
+	prior, err := decodeObject(req.PriorState, typ)
+	if err != nil {
+		return nil, fmt.Errorf("recording: decode %s prior state: %w", req.TypeName, err)
+	}
+	planned, err := decodeObject(req.PlannedState, typ)
+	if err != nil {
+		return nil, fmt.Errorf("recording: decode %s planned state: %w", req.TypeName, err)
+	}
+
+	resp, err := s.ProviderServer.ApplyResourceChange(ctx, req)
+	if err != nil {
+		return resp, err
+	}
+
+	newState, err := decodeObject(resp.NewState, typ)
+	if err != nil {
+		return nil, fmt.Errorf("recording: decode %s new state: %w", req.TypeName, err)
+	}
+
+	// The protocol encodes the operation in the null-ness of the states: a
+	// null planned state destroys, a null prior state creates.
+	switch {
+	case planned == nil:
+		s.rec.add(Op{Kind: OpDelete, Type: req.TypeName, Inputs: prior, Outputs: nil})
+	case prior == nil:
+		s.rec.add(Op{Kind: OpCreate, Type: req.TypeName, Inputs: planned, Outputs: newState})
+	default:
+		s.rec.add(Op{Kind: OpUpdate, Type: req.TypeName, Inputs: planned, Outputs: newState})
+	}
+	return resp, nil
+}
+
+func (s *recordingServer) ReadResource(
+	ctx context.Context, req *tfprotov6.ReadResourceRequest,
+) (*tfprotov6.ReadResourceResponse, error) {
+	resources, _, err := s.objectTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	typ, ok := resources[req.TypeName]
+	if !ok {
+		return nil, fmt.Errorf("recording: no schema for resource %q", req.TypeName)
+	}
+	current, err := decodeObject(req.CurrentState, typ)
+	if err != nil {
+		return nil, fmt.Errorf("recording: decode %s current state: %w", req.TypeName, err)
+	}
+
+	resp, err := s.ProviderServer.ReadResource(ctx, req)
+	if err != nil {
+		return resp, err
+	}
+
+	newState, err := decodeObject(resp.NewState, typ)
+	if err != nil {
+		return nil, fmt.Errorf("recording: decode %s new state: %w", req.TypeName, err)
+	}
+	s.rec.add(Op{Kind: OpRead, Type: req.TypeName, Inputs: current, Outputs: newState})
+	return resp, nil
+}
+
+func (s *recordingServer) ReadDataSource(
+	ctx context.Context, req *tfprotov6.ReadDataSourceRequest,
+) (*tfprotov6.ReadDataSourceResponse, error) {
+	_, dataSources, err := s.objectTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	typ, ok := dataSources[req.TypeName]
+	if !ok {
+		return nil, fmt.Errorf("recording: no schema for data source %q", req.TypeName)
+	}
+	config, err := decodeObject(req.Config, typ)
+	if err != nil {
+		return nil, fmt.Errorf("recording: decode %s config: %w", req.TypeName, err)
+	}
+
+	resp, err := s.ProviderServer.ReadDataSource(ctx, req)
+	if err != nil {
+		return resp, err
+	}
+
+	state, err := decodeObject(resp.State, typ)
+	if err != nil {
+		return nil, fmt.Errorf("recording: decode %s state: %w", req.TypeName, err)
+	}
+	s.rec.add(Op{Kind: OpDataSource, Type: req.TypeName, Inputs: config, Outputs: state})
+	return resp, nil
+}
+
+// decodeObject unmarshals a wire value with the given object type and converts
+// it to a JSON-comparable map. A nil or null value decodes to a nil map.
+func decodeObject(dv *tfprotov6.DynamicValue, typ tftypes.Type) (map[string]any, error) {
+	if dv == nil {
+		return nil, nil
+	}
+	val, err := dv.Unmarshal(typ)
+	if err != nil {
+		return nil, err
+	}
+	if val.IsNull() {
+		return nil, nil
+	}
+	var attrs map[string]tftypes.Value
+	if err := val.As(&attrs); err != nil {
+		return nil, err
+	}
+	out := make(map[string]any, len(attrs))
+	for k, av := range attrs {
+		conv, err := valueToAny(av)
+		if err != nil {
+			return nil, fmt.Errorf("attribute %q: %w", k, err)
+		}
+		out[k] = conv
+	}
+	return out, nil
+}
+
+// valueToAny converts a tftypes.Value to plain JSON-comparable Go values:
+// nil for null, unknownSentinel for unknown, and float64/string/bool/[]any/
+// map[string]any otherwise.
+func valueToAny(v tftypes.Value) (any, error) {
+	if v.IsNull() {
+		return nil, nil
+	}
+	if !v.IsKnown() {
+		return unknownSentinel, nil
+	}
+	switch typ := v.Type(); {
+	case typ.Is(tftypes.String):
+		var s string
+		if err := v.As(&s); err != nil {
+			return nil, err
+		}
+		return s, nil
+	case typ.Is(tftypes.Bool):
+		var b bool
+		if err := v.As(&b); err != nil {
+			return nil, err
+		}
+		return b, nil
+	case typ.Is(tftypes.Number):
+		f := new(big.Float)
+		if err := v.As(&f); err != nil {
+			return nil, err
+		}
+		n, _ := f.Float64()
+		return n, nil
+	case typ.Is(tftypes.Set{}):
+		elems, err := elementsToAny(v)
+		if err != nil {
+			return nil, err
+		}
+		return sortByJSON(elems)
+	case typ.Is(tftypes.List{}), typ.Is(tftypes.Tuple{}):
+		return elementsToAny(v)
+	case typ.Is(tftypes.Map{}), typ.Is(tftypes.Object{}):
+		var attrs map[string]tftypes.Value
+		if err := v.As(&attrs); err != nil {
+			return nil, err
+		}
+		out := make(map[string]any, len(attrs))
+		for k, av := range attrs {
+			conv, err := valueToAny(av)
+			if err != nil {
+				return nil, fmt.Errorf("%q: %w", k, err)
+			}
+			out[k] = conv
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported value type %s", typ)
+	}
+}
+
+func elementsToAny(v tftypes.Value) ([]any, error) {
+	var elems []tftypes.Value
+	if err := v.As(&elems); err != nil {
+		return nil, err
+	}
+	out := make([]any, len(elems))
+	for i, e := range elems {
+		conv, err := valueToAny(e)
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+		out[i] = conv
+	}
+	return out, nil
+}
+
+// sortByJSON orders set elements by their JSON encoding. Set element order on
+// the wire is implementation-defined, so recordings from the two paths would
+// otherwise spuriously diverge — the protocol-level analog of canonicalizeSets.
+func sortByJSON(elems []any) ([]any, error) {
+	type keyed struct {
+		key  string
+		elem any
+	}
+	pairs := make([]keyed, len(elems))
+	for i, e := range elems {
+		b, err := json.Marshal(e)
+		if err != nil {
+			return nil, err
+		}
+		pairs[i] = keyed{key: string(b), elem: e}
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].key < pairs[j].key })
+	out := make([]any, len(pairs))
+	for i, p := range pairs {
+		out[i] = p.elem
+	}
+	return out, nil
+}

--- a/tests/testutil/tfexec/protorecorder.go
+++ b/tests/testutil/tfexec/protorecorder.go
@@ -32,8 +32,9 @@ const unknownSentinel = "<unknown-529478307895340>"
 // appends an Op to r for every resource CRUD operation and data-source read.
 // It records at the protocol boundary — wire values are decoded with the
 // provider's own schema — so it works for any provider implementation (e.g.
-// terraform-plugin-framework) and, unlike a per-resource wrapper, preserves
-// optional protocol capabilities such as MoveResourceState.
+// terraform-plugin-framework). Operations with observable behavior but no
+// OpKind (moves, imports, functions, ephemeral resources) error instead of
+// passing through unrecorded.
 //
 // Protocol recordings are stricter than Wrap's helper/schema snapshots: null
 // and unknown values are preserved instead of being flattened to zero values.
@@ -171,6 +172,54 @@ func (s *recordingServer) ReadDataSource(
 	}
 	s.rec.add(Op{Kind: OpDataSource, Type: req.TypeName, Inputs: config, Outputs: state})
 	return resp, nil
+}
+
+// The provider operations below have observable behavior but no OpKind yet.
+// They fail loudly instead of delegating: an operation that slips through
+// both paths unrecorded would compare vacuously equal, hiding a divergence.
+// Plumbing RPCs (schema, validation, plan, configure, upgrade) still pass
+// through via the embedded server.
+
+// errNoOpKind is the error for protocol operations the recorder cannot
+// represent as an Op.
+func errNoOpKind(rpc string) error {
+	return fmt.Errorf("recording: no OpKind for %s; extend the recorder to support it", rpc)
+}
+
+func (s *recordingServer) ImportResourceState(
+	context.Context, *tfprotov6.ImportResourceStateRequest,
+) (*tfprotov6.ImportResourceStateResponse, error) {
+	return nil, errNoOpKind("ImportResourceState")
+}
+
+func (s *recordingServer) MoveResourceState(
+	context.Context, *tfprotov6.MoveResourceStateRequest,
+) (*tfprotov6.MoveResourceStateResponse, error) {
+	return nil, errNoOpKind("MoveResourceState")
+}
+
+func (s *recordingServer) CallFunction(
+	context.Context, *tfprotov6.CallFunctionRequest,
+) (*tfprotov6.CallFunctionResponse, error) {
+	return nil, errNoOpKind("CallFunction")
+}
+
+func (s *recordingServer) OpenEphemeralResource(
+	context.Context, *tfprotov6.OpenEphemeralResourceRequest,
+) (*tfprotov6.OpenEphemeralResourceResponse, error) {
+	return nil, errNoOpKind("OpenEphemeralResource")
+}
+
+func (s *recordingServer) RenewEphemeralResource(
+	context.Context, *tfprotov6.RenewEphemeralResourceRequest,
+) (*tfprotov6.RenewEphemeralResourceResponse, error) {
+	return nil, errNoOpKind("RenewEphemeralResource")
+}
+
+func (s *recordingServer) CloseEphemeralResource(
+	context.Context, *tfprotov6.CloseEphemeralResourceRequest,
+) (*tfprotov6.CloseEphemeralResourceResponse, error) {
+	return nil, errNoOpKind("CloseEphemeralResource")
 }
 
 // decodeObject unmarshals a wire value with the given object type and converts

--- a/tests/testutil/tfexec/protorecorder.go
+++ b/tests/testutil/tfexec/protorecorder.go
@@ -16,10 +16,8 @@ package tfexec
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/big"
-	"sort"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -28,7 +26,7 @@ import (
 
 // unknownSentinel stands in for unknown values in recorded ops. Both runtimes
 // must agree on where unknowns appear for their recordings to compare equal.
-const unknownSentinel = "<unknown>"
+const unknownSentinel = "<unknown-529478307895340>"
 
 // WrapServer returns a tfprotov6.ProviderServer that delegates to srv and
 // appends an Op to r for every resource CRUD operation and data-source read.
@@ -233,13 +231,11 @@ func valueToAny(v tftypes.Value) (any, error) {
 		}
 		n, _ := f.Float64()
 		return n, nil
-	case typ.Is(tftypes.Set{}):
-		elems, err := elementsToAny(v)
-		if err != nil {
-			return nil, err
-		}
-		return sortByJSON(elems)
-	case typ.Is(tftypes.List{}), typ.Is(tftypes.Tuple{}):
+	// Sets keep their wire order. OpenTofu and the bridge could disagree on
+	// set element order (cty hashes vs. Pulumi array order); if a test
+	// provider ever grows a set attribute and recordings diverge on it, set
+	// elements need canonical ordering here.
+	case typ.Is(tftypes.List{}), typ.Is(tftypes.Set{}), typ.Is(tftypes.Tuple{}):
 		return elementsToAny(v)
 	case typ.Is(tftypes.Map{}), typ.Is(tftypes.Object{}):
 		var attrs map[string]tftypes.Value
@@ -272,30 +268,6 @@ func elementsToAny(v tftypes.Value) ([]any, error) {
 			return nil, fmt.Errorf("element %d: %w", i, err)
 		}
 		out[i] = conv
-	}
-	return out, nil
-}
-
-// sortByJSON orders set elements by their JSON encoding. Set element order on
-// the wire is implementation-defined, so recordings from the two paths would
-// otherwise spuriously diverge — the protocol-level analog of canonicalizeSets.
-func sortByJSON(elems []any) ([]any, error) {
-	type keyed struct {
-		key  string
-		elem any
-	}
-	pairs := make([]keyed, len(elems))
-	for i, e := range elems {
-		b, err := json.Marshal(e)
-		if err != nil {
-			return nil, err
-		}
-		pairs[i] = keyed{key: string(b), elem: e}
-	}
-	sort.Slice(pairs, func(i, j int) bool { return pairs[i].key < pairs[j].key })
-	out := make([]any, len(pairs))
-	for i, p := range pairs {
-		out[i] = p.elem
 	}
 	return out, nil
 }

--- a/tests/testutil/tfexec/protorecorder_test.go
+++ b/tests/testutil/tfexec/protorecorder_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfexec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var thingSchema = &tfprotov6.Schema{
+	Block: &tfprotov6.SchemaBlock{
+		Attributes: []*tfprotov6.SchemaAttribute{
+			{Name: "input", Type: tftypes.String, Optional: true},
+			{Name: "result", Type: tftypes.String, Computed: true},
+		},
+	},
+}
+
+// fakeServer is a minimal tfprotov6.ProviderServer with one resource:
+// ApplyResourceChange echoes the planned state with `result` set to the
+// configured value. Only the methods the recorder uses are implemented; the
+// embedded nil interface panics on anything else.
+type fakeServer struct {
+	tfprotov6.ProviderServer
+	result string
+}
+
+func (s *fakeServer) GetProviderSchema(
+	context.Context, *tfprotov6.GetProviderSchemaRequest,
+) (*tfprotov6.GetProviderSchemaResponse, error) {
+	return &tfprotov6.GetProviderSchemaResponse{
+		ResourceSchemas: map[string]*tfprotov6.Schema{"t_resource": thingSchema},
+	}, nil
+}
+
+func (s *fakeServer) ApplyResourceChange(
+	_ context.Context, req *tfprotov6.ApplyResourceChangeRequest,
+) (*tfprotov6.ApplyResourceChangeResponse, error) {
+	typ := thingSchema.ValueType()
+	planned, err := req.PlannedState.Unmarshal(typ)
+	if err != nil {
+		return nil, err
+	}
+	if planned.IsNull() {
+		state, err := tfprotov6.NewDynamicValue(typ, tftypes.NewValue(typ, nil))
+		if err != nil {
+			return nil, err
+		}
+		return &tfprotov6.ApplyResourceChangeResponse{NewState: &state}, nil
+	}
+	var attrs map[string]tftypes.Value
+	if err := planned.As(&attrs); err != nil {
+		return nil, err
+	}
+	attrs["result"] = tftypes.NewValue(tftypes.String, s.result)
+	state, err := tfprotov6.NewDynamicValue(typ, tftypes.NewValue(typ, attrs))
+	if err != nil {
+		return nil, err
+	}
+	return &tfprotov6.ApplyResourceChangeResponse{NewState: &state}, nil
+}
+
+// thingState builds a wire value for t_resource. nil means a null state.
+func thingState(t *testing.T, attrs map[string]tftypes.Value) *tfprotov6.DynamicValue {
+	t.Helper()
+	typ := thingSchema.ValueType()
+	var val tftypes.Value
+	if attrs == nil {
+		val = tftypes.NewValue(typ, nil)
+	} else {
+		val = tftypes.NewValue(typ, attrs)
+	}
+	dv, err := tfprotov6.NewDynamicValue(typ, val)
+	require.NoError(t, err)
+	return &dv
+}
+
+func apply(t *testing.T, srv tfprotov6.ProviderServer, prior, planned *tfprotov6.DynamicValue) {
+	t.Helper()
+	_, err := srv.ApplyResourceChange(t.Context(), &tfprotov6.ApplyResourceChangeRequest{
+		TypeName:     "t_resource",
+		PriorState:   prior,
+		PlannedState: planned,
+	})
+	require.NoError(t, err)
+}
+
+func strVal(s string) tftypes.Value { return tftypes.NewValue(tftypes.String, s) }
+
+// TestWrapServer_ClassifiesOps drives a create (null prior), an update (both
+// states set), and a delete (null planned) through the wrapper and asserts
+// the recorded ops in full: kind classification, decoded inputs, and outputs.
+func TestWrapServer_ClassifiesOps(t *testing.T) {
+	t.Parallel()
+	r := &tfexec.Recorder{}
+	srv := tfexec.WrapServer(&fakeServer{result: "computed"}, r)
+
+	created := map[string]tftypes.Value{"input": strVal("a"), "result": strVal("computed")}
+	apply(t, srv, thingState(t, nil),
+		thingState(t, map[string]tftypes.Value{"input": strVal("a"), "result": tftypes.NewValue(tftypes.String, nil)}))
+	apply(t, srv, thingState(t, created),
+		thingState(t, map[string]tftypes.Value{"input": strVal("b"), "result": strVal("computed")}))
+	apply(t, srv, thingState(t, created), thingState(t, nil))
+
+	assert.Equal(t, []tfexec.Op{
+		{
+			Kind:    tfexec.OpCreate,
+			Type:    "t_resource",
+			Inputs:  map[string]any{"input": "a", "result": nil},
+			Outputs: map[string]any{"input": "a", "result": "computed"},
+		},
+		{
+			Kind:    tfexec.OpUpdate,
+			Type:    "t_resource",
+			Inputs:  map[string]any{"input": "b", "result": "computed"},
+			Outputs: map[string]any{"input": "b", "result": "computed"},
+		},
+		{
+			Kind:    tfexec.OpDelete,
+			Type:    "t_resource",
+			Inputs:  map[string]any{"input": "a", "result": "computed"},
+			Outputs: nil,
+		},
+	}, r.Ops())
+}
+
+// TestWrapServer_EqualWhenSameBehavior verifies that two wrapped servers with
+// identical behavior produce equal recordings.
+func TestWrapServer_EqualWhenSameBehavior(t *testing.T) {
+	t.Parallel()
+	a, b := &tfexec.Recorder{}, &tfexec.Recorder{}
+	srvA := tfexec.WrapServer(&fakeServer{result: "v"}, a)
+	srvB := tfexec.WrapServer(&fakeServer{result: "v"}, b)
+
+	planned := map[string]tftypes.Value{"input": strVal("x"), "result": tftypes.NewValue(tftypes.String, nil)}
+	apply(t, srvA, thingState(t, nil), thingState(t, planned))
+	apply(t, srvB, thingState(t, nil), thingState(t, planned))
+
+	assert.Equal(t, a.Ops(), b.Ops())
+}
+
+// TestWrapServer_DifferentWhenOutputsDiffer confirms a behavioral divergence
+// between the two paths is observed: same planned state, different computed
+// result, unequal recordings.
+func TestWrapServer_DifferentWhenOutputsDiffer(t *testing.T) {
+	t.Parallel()
+	a, b := &tfexec.Recorder{}, &tfexec.Recorder{}
+	srvA := tfexec.WrapServer(&fakeServer{result: "alpha"}, a)
+	srvB := tfexec.WrapServer(&fakeServer{result: "beta"}, b)
+
+	planned := map[string]tftypes.Value{"input": strVal("x"), "result": tftypes.NewValue(tftypes.String, nil)}
+	apply(t, srvA, thingState(t, nil), thingState(t, planned))
+	apply(t, srvB, thingState(t, nil), thingState(t, planned))
+
+	assert.NotEqual(t, a.Ops(), b.Ops())
+}
+
+// TestWrapServer_DifferentWhenUnknownsDiffer confirms the recorder preserves
+// the null/unknown distinction: planned states that differ only in an unknown
+// versus a null computed attribute produce unequal recordings.
+func TestWrapServer_DifferentWhenUnknownsDiffer(t *testing.T) {
+	t.Parallel()
+	a, b := &tfexec.Recorder{}, &tfexec.Recorder{}
+	srvA := tfexec.WrapServer(&fakeServer{result: "v"}, a)
+	srvB := tfexec.WrapServer(&fakeServer{result: "v"}, b)
+
+	apply(t, srvA, thingState(t, nil), thingState(t, map[string]tftypes.Value{
+		"input": strVal("x"), "result": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	}))
+	apply(t, srvB, thingState(t, nil), thingState(t, map[string]tftypes.Value{
+		"input": strVal("x"), "result": tftypes.NewValue(tftypes.String, nil),
+	}))
+
+	assert.NotEqual(t, a.Ops(), b.Ops())
+}

--- a/tests/testutil/tfexec/protorecorder_test.go
+++ b/tests/testutil/tfexec/protorecorder_test.go
@@ -173,6 +173,31 @@ func TestWrapServer_DifferentWhenOutputsDiffer(t *testing.T) {
 	assert.NotEqual(t, a.Ops(), b.Ops())
 }
 
+// TestWrapServer_UnrecordableOpsError confirms operations without an OpKind
+// fail loudly instead of silently passing through unrecorded.
+func TestWrapServer_UnrecordableOpsError(t *testing.T) {
+	t.Parallel()
+	srv := tfexec.WrapServer(&fakeServer{}, &tfexec.Recorder{})
+
+	_, err := srv.MoveResourceState(t.Context(), &tfprotov6.MoveResourceStateRequest{})
+	require.EqualError(t, err, "recording: no OpKind for MoveResourceState; extend the recorder to support it")
+
+	_, err = srv.ImportResourceState(t.Context(), &tfprotov6.ImportResourceStateRequest{})
+	require.EqualError(t, err, "recording: no OpKind for ImportResourceState; extend the recorder to support it")
+
+	_, err = srv.CallFunction(t.Context(), &tfprotov6.CallFunctionRequest{})
+	require.EqualError(t, err, "recording: no OpKind for CallFunction; extend the recorder to support it")
+
+	_, err = srv.OpenEphemeralResource(t.Context(), &tfprotov6.OpenEphemeralResourceRequest{})
+	require.EqualError(t, err, "recording: no OpKind for OpenEphemeralResource; extend the recorder to support it")
+
+	_, err = srv.RenewEphemeralResource(t.Context(), &tfprotov6.RenewEphemeralResourceRequest{})
+	require.EqualError(t, err, "recording: no OpKind for RenewEphemeralResource; extend the recorder to support it")
+
+	_, err = srv.CloseEphemeralResource(t.Context(), &tfprotov6.CloseEphemeralResourceRequest{})
+	require.EqualError(t, err, "recording: no OpKind for CloseEphemeralResource; extend the recorder to support it")
+}
+
 // TestWrapServer_DifferentWhenUnknownsDiffer confirms the recorder preserves
 // the null/unknown distinction: planned states that differ only in an unknown
 // versus a null computed attribute produce unequal recordings.

--- a/tests/tfcompat/l2_plugin_framework_test.go
+++ b/tests/tfcompat/l2_plugin_framework_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2PluginFrameworkProvider exercises a provider built on
+// terraform-plugin-framework (instead of terraform-plugin-sdk/v2) end-to-end:
+// provider config, resource create and update, and a data-source read. The
+// two stages drive a create then an update so the protocol-level recorder
+// compares both operation kinds across the runtimes.
+func TestL2PluginFrameworkProvider(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_plugin_framework", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pfx", PFFactory: providers.PFXProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_plugin_framework_test.go
+++ b/tests/tfcompat/l2_plugin_framework_test.go
@@ -23,9 +23,9 @@ import (
 
 // TestL2PluginFrameworkProvider exercises a provider built on
 // terraform-plugin-framework (instead of terraform-plugin-sdk/v2) end-to-end:
-// provider config, resource create and update, and a data-source read. The
-// two stages drive a create then an update so the protocol-level recorder
-// compares both operation kinds across the runtimes.
+// resource create and update, and a data-source read. The two stages drive a
+// create then an update so the protocol-level recorder compares both
+// operation kinds across the runtimes.
 func TestL2PluginFrameworkProvider(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_plugin_framework", tfcompat.Case{

--- a/tests/tfcompat/testdata/cases/l2_plugin_framework/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_plugin_framework/0/main.tf
@@ -1,23 +1,17 @@
-provider "pfx" {
-  prefix = "pre"
-}
-
 resource "pfx_thing" "t" {
   name = "alpha"
 }
 
-data "pfx_lookup" "l" {
-  query = pfx_thing.t.name
+data "pfx_lookup" "l" {}
+
+output "name" {
+  value = pfx_thing.t.name
 }
 
-output "echo" {
-  value = pfx_thing.t.echo
-}
-
-output "prefix_result" {
-  value = pfx_thing.t.prefix_result
+output "id" {
+  value = pfx_thing.t.id
 }
 
 output "lookup" {
-  value = data.pfx_lookup.l.prefix_result
+  value = data.pfx_lookup.l.value
 }

--- a/tests/tfcompat/testdata/cases/l2_plugin_framework/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_plugin_framework/0/main.tf
@@ -1,0 +1,23 @@
+provider "pfx" {
+  prefix = "pre"
+}
+
+resource "pfx_thing" "t" {
+  name = "alpha"
+}
+
+data "pfx_lookup" "l" {
+  query = pfx_thing.t.name
+}
+
+output "echo" {
+  value = pfx_thing.t.echo
+}
+
+output "prefix_result" {
+  value = pfx_thing.t.prefix_result
+}
+
+output "lookup" {
+  value = data.pfx_lookup.l.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_plugin_framework/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_plugin_framework/1/main.tf
@@ -1,0 +1,24 @@
+provider "pfx" {
+  prefix = "pre"
+}
+
+resource "pfx_thing" "t" {
+  name = "beta"
+  note = "renamed"
+}
+
+data "pfx_lookup" "l" {
+  query = pfx_thing.t.name
+}
+
+output "echo" {
+  value = pfx_thing.t.echo
+}
+
+output "prefix_result" {
+  value = pfx_thing.t.prefix_result
+}
+
+output "lookup" {
+  value = data.pfx_lookup.l.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_plugin_framework/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_plugin_framework/1/main.tf
@@ -1,24 +1,17 @@
-provider "pfx" {
-  prefix = "pre"
-}
-
 resource "pfx_thing" "t" {
   name = "beta"
-  note = "renamed"
 }
 
-data "pfx_lookup" "l" {
-  query = pfx_thing.t.name
+data "pfx_lookup" "l" {}
+
+output "name" {
+  value = pfx_thing.t.name
 }
 
-output "echo" {
-  value = pfx_thing.t.echo
-}
-
-output "prefix_result" {
-  value = pfx_thing.t.prefix_result
+output "id" {
+  value = pfx_thing.t.id
 }
 
 output "lookup" {
-  value = data.pfx_lookup.l.prefix_result
+  value = data.pfx_lookup.l.value
 }


### PR DESCRIPTION
First PR toward https://github.com/pulumi-labs/pulumi-hcl/issues/261: the tfcompat harness can now host test providers built on terraform-plugin-framework alongside the existing terraform-plugin-sdk/v2 ones. A follow-up will add a `MoveResourceState`-implementing resource and the cross-type `moved` coverage the issue asks for.

## How a framework provider is wired in

A `tfcompat.Provider` now takes either `Factory` (SDKv2, unchanged) or `PFFactory` (plugin framework); the harness rejects a provider that sets both or neither.

- **OpenTofu path**: `providerserver.NewProtocol6` served through the existing reattach mechanism (`tfexec.PFProvider`). No tf5→6 upgrade needed — framework providers speak protocol 6 natively.
- **Pulumi path**: bridged with the bridge's `pkg/pf` — `ShimProvider` → `pf/tfgen.GenerateSchema` → `pf/tfbridge.NewProviderServer` — and attached in-process exactly like the SDKv2 bridge (`pulexec.PFProvider`).

## Recording at the protocol boundary

SDKv2 providers keep recording at the helper/schema CRUD boundary (`tfexec.Wrap`). Framework providers record at the tfprotov6 boundary instead (`tfexec.WrapServer`), for two reasons:

1. A per-resource wrapper cannot transparently preserve optional capability interfaces detected by type assertion (`ResourceWithMoveState`, `ResourceWithImportState`, …) — and `MoveResourceState` is the very capability the follow-up needs.
2. It is stricter than the SDKv2 snapshots: nulls and unknowns are preserved rather than flattened to zero values, and the full planned state and new state are compared.

The same middleware wraps both paths — the OpenTofu side wraps the served `tfprotov6.ProviderServer`, the Pulumi side wraps the server the pf shim hands the bridge — so the op comparison stays apples-to-apples.

Recorded sets keep their wire order. No test provider has a set attribute today; if one grows a set and the runtimes disagree on element order, the comparison fails loudly and canonical ordering can be added against that reproducer.

## Strictness parity with the SDKv2 path

The SDKv2 path calls `InternalValidate()` before bridging. The framework has no direct equivalent, but it validates every schema implementation while answering `GetProviderSchema`; the harness requires that response to carry no error diagnostics (`requireValidPFSchema`). The bridge's own `check.Provider` then runs inside `pf/tfgen.GenerateSchema`.

## Test

`TestL2PluginFrameworkProvider` drives the new `pfx` provider (one resource holding a single string, one data source returning a constant) through two stages — create, then update — comparing stack outputs and the recorded create/update/data-source operations across both runtimes.