### PR TITLE
Support changing a resource's type via `moved`

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-261.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-261.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Support changing a resource's type via `moved`
+time: 2026-06-10T10:10:24Z
+custom:
+    Component: runtime
+    PR: "261"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -46,6 +46,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
@@ -1252,7 +1253,7 @@ func (e *Engine) registerResourceInstanceInContext(
 		}
 	}
 
-	opts, err := e.buildResourceOptionsInContext(res, instance, evalCtx, parentURN, node.ModuleInfo, modInst, resourceMapping, resSchema.InputProperties, resSchema.Properties)
+	opts, err := e.buildResourceOptionsInContext(ctx, res, instance, evalCtx, parentURN, node.ModuleInfo, modInst, resourceMapping, resSchema.InputProperties, resSchema.Properties)
 	if err != nil {
 		return err
 	}
@@ -1362,7 +1363,7 @@ func (e *Engine) registerResourceInstanceInContext(
 
 // buildResourceOptionsInContext builds resource options using the provided eval context and parent URN.
 func (e *Engine) buildResourceOptionsInContext(
-	res *ast.Resource, instance *graph.ExpandedResource,
+	ctx context.Context, res *ast.Resource, instance *graph.ExpandedResource,
 	evalCtx *eval.Context, parentURN urn.URN,
 	modInfo *graph.ModuleInfo, modInst *moduleInstance, resourceMapping *bridge.BodyMapping,
 	inputProps, outputProps []*schema.Property,
@@ -1530,7 +1531,7 @@ func (e *Engine) buildResourceOptionsInContext(
 	}
 
 	// Handle moved blocks - resolve aliases from moved blocks that target this resource
-	movedAliases := e.resolveMovedAliases(res, instance.Key, modInfo, modInst)
+	movedAliases := e.resolveMovedAliases(ctx, res, instance.Key, modInfo, modInst)
 	opts.Aliases = append(opts.Aliases, movedAliases...)
 
 	// Handle aliases attribute
@@ -1802,11 +1803,12 @@ func movedKeyToken(v cty.Value) string {
 // A moved block's addresses are relative to the module it is written in, so the
 // resolver walks the resource's own module and every ancestor module. It handles
 // resource renames within a module (including `count`/`for_each` instance-key
-// changes), moves of a resource between the root and a module or between two
-// modules, and resources carried along when an enclosing module call is renamed
-// or re-keyed (the matching component alias is attached in processModuleInit).
+// changes), changes of the resource's type, moves of a resource between the
+// root and a module or between two modules, and resources carried along when an
+// enclosing module call is renamed or re-keyed (the matching component alias is
+// attached in processModuleInit).
 func (e *Engine) resolveMovedAliases(
-	res *ast.Resource, instanceKey string, modInfo *graph.ModuleInfo, modInst *moduleInstance,
+	ctx context.Context, res *ast.Resource, instanceKey string, modInfo *graph.ModuleInfo, modInst *moduleInstance,
 ) []Alias {
 	var aliases []Alias
 
@@ -1866,8 +1868,22 @@ func (e *Engine) resolveMovedAliases(
 			if !ok {
 				continue
 			}
+
+			// A `moved` may also change the resource's type; the alias then
+			// carries the prior type's token so the engine matches the old URN.
+			var priorType string
+			if from.Type != res.Type {
+				prior, err := e.resolveResource(ctx, from.Type)
+				if err != nil {
+					logging.V(5).Infof("moved: cannot resolve prior type %q: %v", from.Type, err)
+					continue
+				}
+				priorType = prior.Token
+			}
+
 			aliases = append(aliases, Alias{Spec: &AliasSpec{
 				Name:      name,
+				Type:      priorType,
 				ParentURN: parentURN,
 				NoParent:  noParent,
 			}})

--- a/tests/testutil/tfcompat/providers/pf.go
+++ b/tests/testutil/tfcompat/providers/pf.go
@@ -28,10 +28,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// PFXProvider is a minimal terraform-plugin-framework provider: one resource
+// PFXProvider is a minimal terraform-plugin-framework provider: two resources
 // holding a single string, and one data source returning a constant. It
 // exists so tfcompat covers providers built on the plugin framework rather
-// than terraform-plugin-sdk/v2.
+// than terraform-plugin-sdk/v2. pfx_widget accepts a `moved` from pfx_thing,
+// which no terraform-plugin-sdk/v2 provider can (its MoveResourceState
+// unconditionally errors).
 func PFXProvider() provider.Provider { return &pfxProvider{} }
 
 type pfxProvider struct{}
@@ -52,6 +54,7 @@ func (p *pfxProvider) Configure(context.Context, provider.ConfigureRequest, *pro
 func (p *pfxProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		func() resource.Resource { return &pfxThing{} },
+		func() resource.Resource { return &pfxWidget{} },
 	}
 }
 
@@ -74,8 +77,10 @@ func (r *pfxThing) Metadata(_ context.Context, req resource.MetadataRequest, res
 	resp.TypeName = req.ProviderTypeName + "_thing"
 }
 
-func (r *pfxThing) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = rschema.Schema{
+// pfxThingSchema is shared by pfx_thing and pfx_widget: the cross-type `moved`
+// test moves state between two resources of identical shape.
+func pfxThingSchema() rschema.Schema {
+	return rschema.Schema{
 		Attributes: map[string]rschema.Attribute{
 			"id": rschema.StringAttribute{
 				Computed:      true,
@@ -84,6 +89,10 @@ func (r *pfxThing) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 			"name": rschema.StringAttribute{Required: true},
 		},
 	}
+}
+
+func (r *pfxThing) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = pfxThingSchema()
 }
 
 func (r *pfxThing) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -108,6 +117,65 @@ func (r *pfxThing) Update(ctx context.Context, req resource.UpdateRequest, resp 
 }
 
 func (r *pfxThing) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {}
+
+// pfxWidget is pfx_thing under another type name. It implements MoveState so a
+// `moved { from = pfx_thing.x, to = pfx_widget.x }` is a state-only move.
+type pfxWidget struct{}
+
+var (
+	_ resource.Resource              = (*pfxWidget)(nil)
+	_ resource.ResourceWithMoveState = (*pfxWidget)(nil)
+)
+
+func (r *pfxWidget) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_widget"
+}
+
+func (r *pfxWidget) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = pfxThingSchema()
+}
+
+func (r *pfxWidget) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan pfxThingModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ID = types.StringValue("pfx-widget-id")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxWidget) Read(_ context.Context, _ resource.ReadRequest, _ *resource.ReadResponse) {}
+
+func (r *pfxWidget) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan pfxThingModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxWidget) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {
+}
+
+func (r *pfxWidget) MoveState(context.Context) []resource.StateMover {
+	sourceSchema := pfxThingSchema()
+	return []resource.StateMover{{
+		SourceSchema: &sourceSchema,
+		StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+			if req.SourceTypeName != "pfx_thing" || req.SourceState == nil {
+				return
+			}
+			var src pfxThingModel
+			resp.Diagnostics.Append(req.SourceState.Get(ctx, &src)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			resp.Diagnostics.Append(resp.TargetState.Set(ctx, &src)...)
+		},
+	}}
+}
 
 type pfxLookup struct{}
 

--- a/tests/testutil/tfexec/protorecorder.go
+++ b/tests/testutil/tfexec/protorecorder.go
@@ -33,8 +33,9 @@ const unknownSentinel = "<unknown-529478307895340>"
 // It records at the protocol boundary — wire values are decoded with the
 // provider's own schema — so it works for any provider implementation (e.g.
 // terraform-plugin-framework). Operations with observable behavior but no
-// OpKind (moves, imports, functions, ephemeral resources) error instead of
-// passing through unrecorded.
+// OpKind (imports, functions, ephemeral resources) error instead of passing
+// through unrecorded; MoveResourceState is the deliberate exception (see its
+// method comment).
 //
 // Protocol recordings are stricter than Wrap's helper/schema snapshots: null
 // and unknown values are preserved instead of being flattened to zero values.
@@ -174,6 +175,18 @@ func (s *recordingServer) ReadDataSource(
 	return resp, nil
 }
 
+// MoveResourceState delegates without recording. Pulumi performs a cross-type
+// `moved` inside the engine — the old state is re-addressed via an alias and
+// the provider is never consulted — so OpenTofu's move call has no counterpart
+// operation to compare against. The moved state is still compared: it feeds
+// every later operation on the resource, including the final destroy, which
+// records it as the Delete op's inputs.
+func (s *recordingServer) MoveResourceState(
+	ctx context.Context, req *tfprotov6.MoveResourceStateRequest,
+) (*tfprotov6.MoveResourceStateResponse, error) {
+	return s.ProviderServer.MoveResourceState(ctx, req)
+}
+
 // The provider operations below have observable behavior but no OpKind yet.
 // They fail loudly instead of delegating: an operation that slips through
 // both paths unrecorded would compare vacuously equal, hiding a divergence.
@@ -190,12 +203,6 @@ func (s *recordingServer) ImportResourceState(
 	context.Context, *tfprotov6.ImportResourceStateRequest,
 ) (*tfprotov6.ImportResourceStateResponse, error) {
 	return nil, errNoOpKind("ImportResourceState")
-}
-
-func (s *recordingServer) MoveResourceState(
-	context.Context, *tfprotov6.MoveResourceStateRequest,
-) (*tfprotov6.MoveResourceStateResponse, error) {
-	return nil, errNoOpKind("MoveResourceState")
 }
 
 func (s *recordingServer) CallFunction(

--- a/tests/testutil/tfexec/protorecorder_test.go
+++ b/tests/testutil/tfexec/protorecorder_test.go
@@ -78,6 +78,12 @@ func (s *fakeServer) ApplyResourceChange(
 	return &tfprotov6.ApplyResourceChangeResponse{NewState: &state}, nil
 }
 
+func (s *fakeServer) MoveResourceState(
+	context.Context, *tfprotov6.MoveResourceStateRequest,
+) (*tfprotov6.MoveResourceStateResponse, error) {
+	return &tfprotov6.MoveResourceStateResponse{}, nil
+}
+
 // thingState builds a wire value for t_resource. nil means a null state.
 func thingState(t *testing.T, attrs map[string]tftypes.Value) *tfprotov6.DynamicValue {
 	t.Helper()
@@ -179,10 +185,7 @@ func TestWrapServer_UnrecordableOpsError(t *testing.T) {
 	t.Parallel()
 	srv := tfexec.WrapServer(&fakeServer{}, &tfexec.Recorder{})
 
-	_, err := srv.MoveResourceState(t.Context(), &tfprotov6.MoveResourceStateRequest{})
-	require.EqualError(t, err, "recording: no OpKind for MoveResourceState; extend the recorder to support it")
-
-	_, err = srv.ImportResourceState(t.Context(), &tfprotov6.ImportResourceStateRequest{})
+	_, err := srv.ImportResourceState(t.Context(), &tfprotov6.ImportResourceStateRequest{})
 	require.EqualError(t, err, "recording: no OpKind for ImportResourceState; extend the recorder to support it")
 
 	_, err = srv.CallFunction(t.Context(), &tfprotov6.CallFunctionRequest{})
@@ -196,6 +199,20 @@ func TestWrapServer_UnrecordableOpsError(t *testing.T) {
 
 	_, err = srv.CloseEphemeralResource(t.Context(), &tfprotov6.CloseEphemeralResourceRequest{})
 	require.EqualError(t, err, "recording: no OpKind for CloseEphemeralResource; extend the recorder to support it")
+}
+
+// TestWrapServer_MoveDelegatesUnrecorded confirms MoveResourceState reaches the
+// underlying server and produces no Op: a cross-type `moved` has no counterpart
+// provider operation on the Pulumi path to compare against.
+func TestWrapServer_MoveDelegatesUnrecorded(t *testing.T) {
+	t.Parallel()
+	r := &tfexec.Recorder{}
+	srv := tfexec.WrapServer(&fakeServer{}, r)
+
+	resp, err := srv.MoveResourceState(t.Context(), &tfprotov6.MoveResourceStateRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Empty(t, r.Ops())
 }
 
 // TestWrapServer_DifferentWhenUnknownsDiffer confirms the recorder preserves

--- a/tests/tfcompat/l2_moved_test.go
+++ b/tests/tfcompat/l2_moved_test.go
@@ -72,4 +72,16 @@ func TestL2Moved(t *testing.T) {
 			})
 		})
 	}
+
+	// Changing the resource's type. This needs the plugin-framework provider:
+	// the target type must implement MoveResourceState, which every
+	// terraform-plugin-sdk/v2 provider rejects unconditionally.
+	t.Run("change_type", func(t *testing.T) {
+		t.Parallel()
+		tfcompat.RunCase(t, "l2_moved_change_type", tfcompat.Case{
+			Providers: []tfcompat.Provider{
+				{Name: "pfx", PFFactory: providers.PFXProvider},
+			},
+		})
+	})
 }

--- a/tests/tfcompat/testdata/cases/l2_moved_change_type/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_change_type/0/main.tf
@@ -1,0 +1,11 @@
+resource "pfx_thing" "t" {
+  name = "alpha"
+}
+
+output "name" {
+  value = pfx_thing.t.name
+}
+
+output "id" {
+  value = pfx_thing.t.id
+}

--- a/tests/tfcompat/testdata/cases/l2_moved_change_type/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_change_type/1/main.tf
@@ -1,0 +1,16 @@
+resource "pfx_widget" "t" {
+  name = "alpha"
+}
+
+moved {
+  from = pfx_thing.t
+  to   = pfx_widget.t
+}
+
+output "name" {
+  value = pfx_widget.t.name
+}
+
+output "id" {
+  value = pfx_widget.t.id
+}


### PR DESCRIPTION
Closes https://github.com/pulumi-labs/pulumi-hcl/issues/261.

A `moved` block whose `from` and `to` use different resource types is a state-only move in OpenTofu: the target type's provider transforms the source state via `MoveResourceState`. pulumi-hcl's `resolveMovedAliases` already matched cross-type blocks, but the alias it emitted carried only the prior name — the engine assumed the type was unchanged and replaced the resource instead of moving it.

## Changes

- **`pkg/hcl/run`**: when a matched `moved` block's `from` type differs from the resource's type, `resolveMovedAliases` resolves the prior type's Pulumi token and sets it as the alias's `Type`.
- **tfcompat recorder**: `MoveResourceState` now delegates without recording (it previously failed loudly as an op with no `OpKind`). Pulumi performs a cross-type move inside the engine — the old state is re-addressed via an alias and the provider is never consulted — so OpenTofu's move call has no counterpart operation to compare against. A state-transforming move that pulumi-hcl fails to replicate is still caught: the moved state feeds every later operation on the resource, including the final destroy, which records it as the Delete op's inputs, and the stack outputs comparison.
- **pfx test provider**: gains `pfx_widget`, identical in shape to `pfx_thing`, implementing `ResourceWithMoveState` for moves from `pfx_thing`. This requires the plugin-framework provider from https://github.com/pulumi-labs/pulumi-hcl/pull/262 — every terraform-plugin-sdk/v2 provider rejects `MoveResourceState` unconditionally.
- **`TestL2Moved/change_type`**: stage 0 creates `pfx_thing.t`; stage 1 declares `pfx_widget.t` plus the `moved` block. Both runtimes must agree on provider operations (no create/delete on the move) and on outputs (`id` stays `pfx-id`).

## Verification

The fix is load-bearing: with the alias `Type` change reverted, the test fails — pulumi replaces the resource and reports `id = "pfx-widget-id"` while tofu's move preserves `"pfx-id"`:

```
--- Expected
+++ Actual
@@ -1,3 +1,3 @@
 (map[string]string) (len=2) {
- (string) (len=2) "id": (string) (len=6) "pfx-id",
+ (string) (len=2) "id": (string) (len=13) "pfx-widget-id",
  (string) (len=4) "name": (string) (len=5) "alpha"
```

Full `TestL2Moved` suite, `TestL2PluginFrameworkProvider`, the recorder unit tests, build, and lint all pass locally.